### PR TITLE
Ignore some errors on leaving rooms, add new error enum. Fixes #307

### DIFF
--- a/lib/jobs/basejob.cpp
+++ b/lib/jobs/basejob.cpp
@@ -325,6 +325,9 @@ void BaseJob::gotReply()
                 d->status.code = UserConsentRequiredError;
                 d->errorUrl = json.value("consent_uri"_ls).toString();
             }
+            else if (errCode == "M_UNKNOWN") {
+                d->status.code = UnknownError;
+            }
             else if (errCode == "M_UNSUPPORTED_ROOM_VERSION" ||
                      errCode == "M_INCOMPATIBLE_ROOM_VERSION")
             {

--- a/lib/jobs/basejob.h
+++ b/lib/jobs/basejob.h
@@ -67,6 +67,7 @@ namespace QMatrixClient
                 , UnsupportedRoomVersionError
                 , NetworkAuthRequiredError
                 , UserConsentRequiredError
+                , UnknownError // Unknown room or other item (M_UNKNOWN)
                 , UserDefinedError = 200
             };
 


### PR DESCRIPTION
Tested with Spectral as client and the problematic rooms are forgot properly after this fix.