### PR TITLE
E2EE: add new account and identity keys generation logic

### DIFF
--- a/lib/connection.cpp
+++ b/lib/connection.cpp
@@ -254,6 +254,9 @@ void Connection::doConnectToServer(const QString& user, const QString& password,
 
             AccountSettings accountSettings(loginJob->userId());
             d->encryptionManager.reset(new EncryptionManager(accountSettings.encryptionAccountPickle()));
+            if (accountSettings.encryptionAccountPickle().isEmpty()) {
+                accountSettings.setEncryptionAccountPickle(d->encryptionManager->olmAccountPickle());
+            }
 
             d->encryptionManager->uploadIdentityKeys(this);
             d->encryptionManager->uploadOneTimeKeys(this);

--- a/lib/encryptionmanager.cpp
+++ b/lib/encryptionmanager.cpp
@@ -112,19 +112,29 @@ void EncryptionManager::uploadIdentityKeys(Connection* connection)
                         d->olmAccount->ed25519IdentityKey()
             }
         },
-        /*
-         * Signatures for the device key object.
-         * A map from user ID, to a map from <algorithm>:<device_id> to the signature.
-         * The signature is calculated using the process called Signing JSON.
-         */
+        /* signatures should be provided after the unsigned deviceKeys generation */
+        {}
+    };
+
+    QJsonObject deviceKeysJsonObject = toJson(deviceKeys);
+    /* additionally removing signatures key,
+     * since we could not initialize deviceKeys
+     * without an empty signatures value:
+     */
+    deviceKeysJsonObject.remove(QStringLiteral("signatures"));
+    /*
+     * Signatures for the device key object.
+     * A map from user ID, to a map from <algorithm>:<device_id> to the signature.
+     * The signature is calculated using the process called Signing JSON.
+     */
+    deviceKeys.signatures =
+    {
         {
+            connection->userId(),
             {
-                connection->userId(),
                 {
-                    {
-                        ed25519Name + QStringLiteral(":") + connection->deviceId(),
-                                d->olmAccount->sign(toJson(deviceKeys))
-                    }
+                    ed25519Name + QStringLiteral(":") + connection->deviceId(),
+                            d->olmAccount->sign(deviceKeysJsonObject)
                 }
             }
         }

--- a/lib/encryptionmanager.h
+++ b/lib/encryptionmanager.h
@@ -15,12 +15,13 @@ namespace QMatrixClient
         public:
             // TODO: store constats separately?
             // TODO: 0.5 oneTimeKeyThreshold instead of 0.1?
-            explicit EncryptionManager(const QByteArray& encryptionAccountPickle, float signedKeysProportion = 1, float oneTimeKeyThreshold = float(0.1),
+            explicit EncryptionManager(const QByteArray& encryptionAccountPickle = QByteArray(), float signedKeysProportion = 1, float oneTimeKeyThreshold = float(0.1),
                                        QObject* parent = nullptr);
             ~EncryptionManager();
 
             void uploadIdentityKeys(Connection* connection);
             void uploadOneTimeKeys(Connection* connection, bool forceUpdate = false);
+            QByteArray olmAccountPickle();
 
         private:
             class Private;


### PR DESCRIPTION
Add a missed option to generate new Olm account at the clean new device and save the result to a pickle for future usage. Also switched to `QScopedPointer` for `olmAccount` :thinking: 