### PR TITLE
Update the cache for sure if unread counters were changed

### DIFF
--- a/lib/room.cpp
+++ b/lib/room.cpp
@@ -1387,15 +1387,18 @@ void Room::updateData(SyncRoomData&& data, bool fromCache)
     if (data.unreadCount != -2 && data.unreadCount != d->unreadMessages) {
         qCDebug(MAIN) << "Setting unread_count to" << data.unreadCount;
         d->unreadMessages = data.unreadCount;
+        roomChanges |= Change::UnreadNotifsChange;
         emit unreadMessagesChanged(this);
     }
 
     if (data.highlightCount != d->highlightCount) {
         d->highlightCount = data.highlightCount;
+        roomChanges |= Change::UnreadNotifsChange;
         emit highlightCountChanged();
     }
     if (data.notificationCount != d->notificationCount) {
         d->notificationCount = data.notificationCount;
+        roomChanges |= Change::UnreadNotifsChange;
         emit notificationCountChanged();
     }
     if (roomChanges != Change::NoChange) {


### PR DESCRIPTION
In Quaternion, I was able to reproduce a process where
`d->notificationCount` and `d->highlightCount` were changed in
`Room::updateData()` meanwhile `roomChanges` indicated `NoChange`
thus the cache became permanently inconsistent with running state.

Without deep understanding of `roomChanges` logic, I've applied
this straightforward change which made this phenomenon
unreproducible.