### PR TITLE
E2EE: implement receiving of the messages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,8 @@ set(API_VERSION "0.6")
 project(Quotient VERSION "${API_VERSION}.0" LANGUAGES CXX)
 
 option(${PROJECT_NAME}_INSTALL_TESTS "install quotest (former qmc-example) application" ON)
+# https://github.com/quotient-im/libQuotient/issues/369
+option(${PROJECT_NAME}_ENABLE_E2EE "end-to-end encryption (E2EE) support" OFF)
 
 include(CheckCXXCompilerFlag)
 if (NOT WIN32)
@@ -55,22 +57,26 @@ endif()
 find_package(Qt5 5.9 REQUIRED Network Gui Multimedia Test)
 get_filename_component(Qt5_Prefix "${Qt5_DIR}/../../../.." ABSOLUTE)
 
-if ((NOT DEFINED USE_INTREE_LIBQOLM OR USE_INTREE_LIBQOLM)
-        AND EXISTS ${PROJECT_SOURCE_DIR}/3rdparty/libQtOlm/lib/utils.h)
-    add_subdirectory(3rdparty/libQtOlm EXCLUDE_FROM_ALL)
-    include_directories(3rdparty/libQtOlm)
-    if (NOT DEFINED USE_INTREE_LIBQOLM)
-        set (USE_INTREE_LIBQOLM 1)
+if (${PROJECT_NAME}_ENABLE_E2EE)
+    if ((NOT DEFINED USE_INTREE_LIBQOLM OR USE_INTREE_LIBQOLM)
+            AND EXISTS ${PROJECT_SOURCE_DIR}/3rdparty/libQtOlm/lib/utils.h)
+        add_subdirectory(3rdparty/libQtOlm EXCLUDE_FROM_ALL)
+        include_directories(3rdparty/libQtOlm)
+        if (NOT DEFINED USE_INTREE_LIBQOLM)
+            set (USE_INTREE_LIBQOLM 1)
+        endif ()
     endif ()
-endif ()
-if (NOT USE_INTREE_LIBQOLM)
-    find_package(QtOlm 0.1.0 REQUIRED)
-    if (NOT QtOlm_FOUND)
-        message( WARNING "libQtOlm not found; configuration will most likely fail.")
-        message( WARNING "Make sure you have installed libQtOlm development files")
-        message( WARNING "as a package or checked out the library sources in lib/.")
-        message( WARNING "See also BUILDING.md")
+    if (NOT USE_INTREE_LIBQOLM)
+        find_package(QtOlm 0.1.0 REQUIRED)
+        if (NOT QtOlm_FOUND)
+            message( WARNING "libQtOlm not found; configuration will most likely fail.")
+            message( WARNING "Make sure you have installed libQtOlm development files")
+            message( WARNING "as a package or checked out the library sources in lib/.")
+            message( WARNING "See also BUILDING.md")
+        endif ()
     endif ()
+else ()
+    message( WARNING "End-to-end encryption (E2EE) support is turned off.")
 endif ()
 
 if (GTAD_PATH)
@@ -108,18 +114,20 @@ if (ABS_API_DEF_PATH AND ABS_GTAD_PATH)
     endif ()
 endif ()
 find_package(Git)
-if (USE_INTREE_LIBQOLM)
-    message( STATUS "Using in-tree libQtOlm")
-    if (GIT_FOUND)
-        execute_process(COMMAND
-            "${GIT_EXECUTABLE}" rev-parse -q HEAD
-            WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/3rdparty/libQtOlm
-            OUTPUT_VARIABLE QTOLM_GIT_SHA1
-            OUTPUT_STRIP_TRAILING_WHITESPACE)
-        message( STATUS "  Library git SHA1: ${QTOLM_GIT_SHA1}")
-    endif (GIT_FOUND)
-else ()
-    message( STATUS "Using libQtOlm ${QtOlm_VERSION} at ${QtOlm_DIR}")
+if (${PROJECT_NAME}_ENABLE_E2EE)
+    if (USE_INTREE_LIBQOLM)
+        message( STATUS "Using in-tree libQtOlm")
+        if (GIT_FOUND)
+            execute_process(COMMAND
+                "${GIT_EXECUTABLE}" rev-parse -q HEAD
+                WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/3rdparty/libQtOlm
+                OUTPUT_VARIABLE QTOLM_GIT_SHA1
+                OUTPUT_STRIP_TRAILING_WHITESPACE)
+            message( STATUS "  Library git SHA1: ${QTOLM_GIT_SHA1}")
+        endif (GIT_FOUND)
+    else ()
+        message( STATUS "Using libQtOlm ${QtOlm_VERSION} at ${QtOlm_DIR}")
+    endif ()
 endif ()
 message( STATUS "=============================================================================" )
 message( STATUS )
@@ -224,6 +232,9 @@ endif()
 set(tests_SRCS tests/quotest.cpp)
 
 add_library(${PROJECT_NAME} ${lib_SRCS} ${api_SRCS})
+if (${PROJECT_NAME}_ENABLE_E2EE)
+    target_compile_definitions(${PROJECT_NAME} PUBLIC ${PROJECT_NAME}_E2EE_ENABLED)
+endif()
 set_target_properties(${PROJECT_NAME} PROPERTIES
     VERSION "${PROJECT_VERSION}"
     SOVERSION ${API_VERSION}
@@ -238,7 +249,10 @@ target_include_directories(${PROJECT_NAME} PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/lib>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
-target_link_libraries(${PROJECT_NAME} QtOlm Qt5::Core Qt5::Network Qt5::Gui Qt5::Multimedia)
+if (${PROJECT_NAME}_ENABLE_E2EE)
+    target_link_libraries(${PROJECT_NAME} QtOlm)
+endif()
+target_link_libraries(${PROJECT_NAME} Qt5::Core Qt5::Network Qt5::Gui Qt5::Multimedia)
 
 set(TEST_BINARY quotest)
 add_executable(${TEST_BINARY} ${tests_SRCS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,7 @@ set(lib_SRCS
     lib/events/directchatevent.cpp
     lib/events/encryptionevent.cpp
     lib/events/encryptedevent.cpp
+    lib/events/roomkeyevent.cpp
     lib/jobs/requestdata.cpp
     lib/jobs/basejob.cpp
     lib/jobs/syncjob.cpp

--- a/lib/connection.cpp
+++ b/lib/connection.cpp
@@ -243,15 +243,6 @@ void Connection::doConnectToServer(const QString& user, const QString& password,
     connect(loginJob, &BaseJob::success, this, [this, loginJob] {
         d->connectWithToken(loginJob->userId(), loginJob->accessToken(),
                             loginJob->deviceId());
-
-        AccountSettings accountSettings(loginJob->userId());
-        d->encryptionManager.reset(
-            new EncryptionManager(accountSettings.encryptionAccountPickle()));
-        if (accountSettings.encryptionAccountPickle().isEmpty()) {
-            accountSettings.setEncryptionAccountPickle(
-                d->encryptionManager->olmAccountPickle());
-        }
-
         d->encryptionManager->uploadIdentityKeys(this);
         d->encryptionManager->uploadOneTimeKeys(this);
     });
@@ -309,6 +300,13 @@ void Connection::Private::connectWithToken(const QString& userId,
     q->setObjectName(userId % '/' % deviceId);
     qCDebug(MAIN) << "Using server" << data->baseUrl().toDisplayString()
                   << "by user" << userId << "from device" << deviceId;
+    AccountSettings accountSettings(userId);
+    encryptionManager.reset(
+        new EncryptionManager(accountSettings.encryptionAccountPickle()));
+    if (accountSettings.encryptionAccountPickle().isEmpty()) {
+        accountSettings.setEncryptionAccountPickle(
+            encryptionManager->olmAccountPickle());
+    }
     emit q->stateChanged();
     emit q->connected();
     q->reloadCapabilities();

--- a/lib/connection.h
+++ b/lib/connection.h
@@ -304,7 +304,9 @@ public:
     QString userId() const;
     QString deviceId() const;
     QByteArray accessToken() const;
+#ifdef Quotient_E2EE_ENABLED
     QtOlm::Account* olmAccount() const;
+#endif // Quotient_E2EE_ENABLED
     Q_INVOKABLE Quotient::SyncJob* syncJob() const;
     Q_INVOKABLE int millisToReconnect() const;
 

--- a/lib/encryptionmanager.cpp
+++ b/lib/encryptionmanager.cpp
@@ -9,6 +9,10 @@
 #include <QtCore/QStringBuilder>
 
 #include <account.h> // QtOlm
+#include <session.h> // QtOlm
+#include <message.h> // QtOlm
+#include <errors.h> // QtOlm
+#include <utils.h> // QtOlm
 #include <functional>
 #include <memory>
 
@@ -20,7 +24,8 @@ class EncryptionManager::Private {
 public:
     explicit Private(const QByteArray& encryptionAccountPickle,
                      float signedKeysProportion, float oneTimeKeyThreshold)
-        : signedKeysProportion(move(signedKeysProportion))
+        : q(nullptr)
+        , signedKeysProportion(move(signedKeysProportion))
         , oneTimeKeyThreshold(move(oneTimeKeyThreshold))
     {
         Q_ASSERT((0 <= signedKeysProportion) && (signedKeysProportion <= 1));
@@ -44,18 +49,23 @@ public:
          * until the limit is reached and it starts discarding keys, starting by
          * the oldest.
          */
-        targetKeysNumber = olmAccount->maxOneTimeKeys(); // 2 // see note below
+        targetKeysNumber = olmAccount->maxOneTimeKeys() / 2;
         targetOneTimeKeyCounts = {
             { SignedCurve25519Key,
               qRound(signedKeysProportion * targetKeysNumber) },
             { Curve25519Key,
               qRound((1 - signedKeysProportion) * targetKeysNumber) }
         };
+        updateKeysToUpload();
     }
     ~Private() = default;
 
+    EncryptionManager* q;
+
     UploadKeysJob* uploadIdentityKeysJob = nullptr;
+    UploadKeysJob* uploadOneTimeKeysInitJob = nullptr;
     UploadKeysJob* uploadOneTimeKeysJob = nullptr;
+    QueryKeysJob* queryKeysJob = nullptr;
 
     QScopedPointer<Account> olmAccount;
 
@@ -74,6 +84,95 @@ public:
     }
     QHash<QString, int> oneTimeKeysToUploadCounts;
     QHash<QString, int> targetOneTimeKeyCounts;
+
+    // A map from senderKey to InboundSession
+    QMap<QString, InboundSession*> sessions; // TODO: cache
+    void updateDeviceKeys(
+        const QHash<QString, QHash<QString, QueryKeysJob::DeviceInformation>>&
+            deviceKeys)
+    {
+        for (auto userId : deviceKeys.keys()) {
+            for (auto deviceId : deviceKeys.value(userId).keys()) {
+                QueryKeysJob::DeviceInformation info =
+                    deviceKeys.value(userId).value(deviceId);
+                // TODO: ed25519Verify, etc
+            }
+        }
+    }
+    QString sessionDecrypt(Message* message, const QString& senderKey)
+    {
+        QString decrypted;
+        QList<InboundSession*> senderSessions = sessions.values(senderKey);
+        // Try to decrypt message body using one of the known sessions for that
+        // device
+        bool sessionsPassed = false;
+        for (auto senderSession : senderSessions) {
+            if (senderSession == senderSessions.last()) {
+                sessionsPassed = true;
+            }
+            try {
+                decrypted = senderSession->decrypt(message);
+                qCDebug(E2EE)
+                    << "Success decrypting Olm event using existing session"
+                    << senderSession->id();
+                break;
+            } catch (OlmError* e) {
+                if (message->messageType() == 0) {
+                    PreKeyMessage preKeyMessage =
+                        PreKeyMessage(message->cipherText());
+                    if (senderSession->matches(&preKeyMessage, senderKey)) {
+                        // We had a matching session for a pre-key message, but
+                        // it didn't work. This means something is wrong, so we
+                        // fail now.
+                        qCDebug(E2EE)
+                            << "Error decrypting pre-key message with existing "
+                               "Olm session"
+                            << senderSession->id() << "reason:" << e->what();
+                        return QString();
+                    }
+                }
+                // Simply keep trying otherwise
+            }
+        }
+        if (sessionsPassed || senderSessions.empty()) {
+            if (message->messageType() > 0) {
+                // Not a pre-key message, we should have had a matching session
+                if (!sessions.empty()) {
+                    qCDebug(E2EE) << "Error decrypting with existing sessions";
+                    return QString();
+                }
+                qCDebug(E2EE) << "No existing sessions";
+                return QString();
+            }
+            // We have a pre-key message without any matching session, in this
+            // case we should try to create one.
+            InboundSession* newSession;
+            qCDebug(E2EE) << "try to establish new InboundSession with" << senderKey;
+            PreKeyMessage preKeyMessage = PreKeyMessage(message->cipherText());
+            try {
+                newSession = new InboundSession(olmAccount.data(),
+                                                &preKeyMessage,
+                                                senderKey.toLatin1(), q);
+            } catch (OlmError* e) {
+                qCDebug(E2EE) << "Error decrypting pre-key message when trying "
+                                 "to establish a new session:"
+                              << e->what();
+                return QString();
+            }
+            qCDebug(E2EE) << "Created new Olm session" << newSession->id();
+            try {
+                decrypted = newSession->decrypt(message);
+            } catch (OlmError* e) {
+                qCDebug(E2EE)
+                    << "Error decrypting pre-key message with new session"
+                    << e->what();
+                return QString();
+            }
+            olmAccount->removeOneTimeKeys(newSession);
+            sessions.insert(senderKey, newSession);
+        }
+        return decrypted;
+    }
 };
 
 EncryptionManager::EncryptionManager(const QByteArray& encryptionAccountPickle,
@@ -83,7 +182,9 @@ EncryptionManager::EncryptionManager(const QByteArray& encryptionAccountPickle,
     , d(std::make_unique<Private>(std::move(encryptionAccountPickle),
                                   std::move(signedKeysProportion),
                                   std::move(oneTimeKeyThreshold)))
-{}
+{
+    d->q = this;
+}
 
 EncryptionManager::~EncryptionManager() = default;
 
@@ -132,20 +233,19 @@ void EncryptionManager::uploadIdentityKeys(Connection* connection)
               d->olmAccount->sign(deviceKeysJsonObject) } } }
     };
 
+    d->uploadIdentityKeysJob = connection->callApi<UploadKeysJob>(deviceKeys);
     connect(d->uploadIdentityKeysJob, &BaseJob::success, this, [this] {
         d->setOneTimeKeyCounts(d->uploadIdentityKeysJob->oneTimeKeyCounts());
-        qDebug() << QString("Uploaded identity keys.");
     });
-    d->uploadIdentityKeysJob = connection->callApi<UploadKeysJob>(deviceKeys);
 }
 
 void EncryptionManager::uploadOneTimeKeys(Connection* connection,
                                           bool forceUpdate)
 {
     if (forceUpdate || d->oneTimeKeyCounts.isEmpty()) {
-        auto job = connection->callApi<UploadKeysJob>();
-        connect(job, &BaseJob::success, this, [job, this] {
-            d->setOneTimeKeyCounts(job->oneTimeKeyCounts());
+        d->uploadOneTimeKeysInitJob = connection->callApi<UploadKeysJob>();
+        connect(d->uploadOneTimeKeysInitJob, &BaseJob::success, this, [this] {
+            d->setOneTimeKeyCounts(d->uploadIdentityKeysJob->oneTimeKeyCounts());
         });
     }
 
@@ -170,9 +270,17 @@ void EncryptionManager::uploadOneTimeKeys(Connection* connection,
         if (oneTimeKeysCounter < signedKeysToUploadCount) {
             QJsonObject message { { QStringLiteral("key"),
                                     it.value().toString() } };
-            key = d->olmAccount->sign(message);
-            keyType = SignedCurve25519Key;
 
+            QByteArray signedMessage = d->olmAccount->sign(message);
+            QJsonObject signatures {
+                { connection->userId(),
+                  QJsonObject { { Ed25519Key + QStringLiteral(":")
+                                      + connection->deviceId(),
+                                  QString::fromUtf8(signedMessage) } } }
+            };
+            message.insert(QStringLiteral("signatures"), signatures);
+            key = message;
+            keyType = SignedCurve25519Key;
         } else {
             key = it.value();
             keyType = Curve25519Key;
@@ -180,13 +288,50 @@ void EncryptionManager::uploadOneTimeKeys(Connection* connection,
         ++oneTimeKeysCounter;
         oneTimeKeys.insert(QString("%1:%2").arg(keyType).arg(keyId), key);
     }
-
-    d->uploadOneTimeKeysJob = connection->callApi<UploadKeysJob>(none,
-                                                                 oneTimeKeys);
+    d->uploadOneTimeKeysJob =
+        connection->callApi<UploadKeysJob>(none, oneTimeKeys);
+    connect(d->uploadOneTimeKeysJob, &BaseJob::success, this, [this] {
+        d->setOneTimeKeyCounts(d->uploadOneTimeKeysJob->oneTimeKeyCounts());
+    });
     d->olmAccount->markKeysAsPublished();
-    qDebug() << QString("Uploaded new one-time keys: %1 signed, %2 unsigned.")
+    qCDebug(E2EE) << QString("Uploaded new one-time keys: %1 signed, %2 unsigned.")
                     .arg(signedKeysToUploadCount)
-                    .arg(unsignedKeysToUploadCount);
+                .arg(unsignedKeysToUploadCount);
+}
+
+void EncryptionManager::updateOneTimeKeyCounts(
+    Connection* connection, const QHash<QString, int>& deviceOneTimeKeysCount)
+{
+    d->oneTimeKeyCounts = deviceOneTimeKeysCount;
+    if (d->oneTimeKeyShouldUpload()) {
+        qCDebug(E2EE) << "Uploading new one-time keys.";
+        uploadOneTimeKeys(connection);
+    }
+}
+
+void Quotient::EncryptionManager::updateDeviceKeys(
+    Connection* connection, const QHash<QString, QStringList>& deviceKeys)
+{
+    d->queryKeysJob = connection->callApi<QueryKeysJob>(deviceKeys);
+    connect(d->queryKeysJob, &BaseJob::success, this,
+            [this] { d->updateDeviceKeys(d->queryKeysJob->deviceKeys()); });
+}
+
+QString EncryptionManager::sessionDecryptMessage(
+    const QJsonObject& personalCipherObject, const QByteArray& senderKey)
+{
+    QString decrypted;
+    int type = personalCipherObject.value(TypeKeyL).toInt(-1);
+    QByteArray body = personalCipherObject.value(BodyKeyL).toString().toLatin1();
+    if (type == 0) {
+        PreKeyMessage preKeyMessage { body };
+        decrypted = d->sessionDecrypt(reinterpret_cast<Message*>(&preKeyMessage),
+                                      senderKey);
+    } else if (type == 1) {
+        Message message { body };
+        decrypted = d->sessionDecrypt(&message, senderKey);
+    }
+    return decrypted;
 }
 
 QByteArray EncryptionManager::olmAccountPickle()

--- a/lib/encryptionmanager.cpp
+++ b/lib/encryptionmanager.cpp
@@ -1,3 +1,4 @@
+#ifdef Quotient_E2EE_ENABLED
 #include "encryptionmanager.h"
 
 #include "connection.h"
@@ -366,3 +367,4 @@ bool EncryptionManager::Private::oneTimeKeyShouldUpload()
     }
     return false;
 }
+#endif // Quotient_E2EE_ENABLED

--- a/lib/encryptionmanager.h
+++ b/lib/encryptionmanager.h
@@ -1,3 +1,4 @@
+#ifdef Quotient_E2EE_ENABLED
 #pragma once
 
 #include <QtCore/QObject>
@@ -43,3 +44,4 @@ private:
 };
 
 } // namespace Quotient
+#endif // Quotient_E2EE_ENABLED

--- a/lib/encryptionmanager.h
+++ b/lib/encryptionmanager.h
@@ -26,6 +26,13 @@ public:
 
     void uploadIdentityKeys(Connection* connection);
     void uploadOneTimeKeys(Connection* connection, bool forceUpdate = false);
+    void
+    updateOneTimeKeyCounts(Connection* connection,
+                           const QHash<QString, int>& deviceOneTimeKeysCount);
+    void updateDeviceKeys(Connection* connection,
+                          const QHash<QString, QStringList>& deviceKeys);
+    QString sessionDecryptMessage(const QJsonObject& personalCipherObject,
+                                  const QByteArray& senderKey);
     QByteArray olmAccountPickle();
 
     QtOlm::Account* account() const;

--- a/lib/events/encryptedevent.cpp
+++ b/lib/events/encryptedevent.cpp
@@ -28,5 +28,5 @@ EncryptedEvent::EncryptedEvent(QByteArray ciphertext, const QString& senderKey,
 EncryptedEvent::EncryptedEvent(const QJsonObject& obj)
     : RoomEvent(typeId(), obj)
 {
-    qCDebug(EVENTS) << "Encrypted event" << id();
+    qCDebug(E2EE) << "Encrypted event from" << senderId();
 }

--- a/lib/events/roomkeyevent.cpp
+++ b/lib/events/roomkeyevent.cpp
@@ -1,0 +1,11 @@
+#include "roomkeyevent.h"
+
+using namespace Quotient;
+
+RoomKeyEvent::RoomKeyEvent(const QJsonObject &obj) : Event(typeId(), obj)
+{
+    _algorithm = contentJson()["algorithm"_ls].toString();
+    _roomId = contentJson()["room_id"_ls].toString();
+    _sessionId = contentJson()["session_id"_ls].toString();
+    _sessionKey = contentJson()["session_key"_ls].toString();
+}

--- a/lib/events/roomkeyevent.h
+++ b/lib/events/roomkeyevent.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "event.h"
+
+namespace Quotient {
+class RoomKeyEvent : public Event
+{
+public:
+    DEFINE_EVENT_TYPEID("m.room_key", RoomKeyEvent)
+
+    RoomKeyEvent(const QJsonObject& obj);
+
+    const QString algorithm() const { return _algorithm; }
+    const QString roomId() const { return _roomId; }
+    const QString sessionId() const { return _sessionId; }
+    const QString sessionKey() const { return _sessionKey; }
+
+private:
+    QString _algorithm;
+    QString _roomId;
+    QString _sessionId;
+    QString _sessionKey;
+};
+REGISTER_EVENT_TYPE(RoomKeyEvent)
+} // namespace Quotient

--- a/lib/room.cpp
+++ b/lib/room.cpp
@@ -1233,6 +1233,11 @@ QString Room::decryptMessage(QByteArray cipher, const QString& senderKey,
     return decrypted;
 }
 
+void Room::handleRoomKeyEvent(RoomKeyEvent *roomKeyEvent, QString senderKey)
+{
+    // TODO
+}
+
 int Room::joinedCount() const
 {
     return d->summary.joinedMemberCount.value_or(d->membersMap.size());

--- a/lib/room.h
+++ b/lib/room.h
@@ -209,13 +209,7 @@ public:
     int memberCount() const;
     int timelineSize() const;
     bool usesEncryption() const;
-    RoomEventPtr decryptMessage(EncryptedEvent* encryptedEvent);
-    QString decryptMessage(QJsonObject personalCipherObject,
-                           QByteArray senderKey);
-    QString sessionKey(const QString& senderKey, const QString& deviceId,
-                       const QString& sessionId) const;
-    QString decryptMessage(QByteArray cipher, const QString& senderKey,
-                           const QString& deviceId, const QString& sessionId);
+    RoomEventPtr decryptMessage(const EncryptedEvent& encryptedEvent);
     void handleRoomKeyEvent(RoomKeyEvent* roomKeyEvent, QString senderKey);
     int joinedCount() const;
     int invitedCount() const;

--- a/lib/room.h
+++ b/lib/room.h
@@ -26,6 +26,7 @@
 
 #include "events/accountdataevents.h"
 #include "events/encryptedevent.h"
+#include "events/roomkeyevent.h"
 #include "events/roommessageevent.h"
 #include "events/roomcreateevent.h"
 #include "events/roomtombstoneevent.h"
@@ -215,6 +216,7 @@ public:
                        const QString& sessionId) const;
     QString decryptMessage(QByteArray cipher, const QString& senderKey,
                            const QString& deviceId, const QString& sessionId);
+    void handleRoomKeyEvent(RoomKeyEvent* roomKeyEvent, QString senderKey);
     int joinedCount() const;
     int invitedCount() const;
     int totalMemberCount() const;

--- a/lib/syncdata.cpp
+++ b/lib/syncdata.cpp
@@ -178,6 +178,13 @@ void SyncData::parseJson(const QJsonObject& json, const QString& baseDir)
     accountData = load<Events>(json, "account_data"_ls);
     toDeviceEvents = load<Events>(json, "to_device"_ls);
 
+    auto deviceOneTimeKeysCountVariantHash =
+        json.value("device_one_time_keys_count"_ls).toObject().toVariantHash();
+    for (auto key : deviceOneTimeKeysCountVariantHash.keys()) {
+        deviceOneTimeKeysCount_.insert(
+            key, deviceOneTimeKeysCountVariantHash.value(key).toInt());
+    }
+
     auto rooms = json.value("rooms"_ls).toObject();
     JoinStates::Int ii = 1; // ii is used to make a JoinState value
     auto totalRooms = 0;

--- a/lib/syncdata.h
+++ b/lib/syncdata.h
@@ -92,6 +92,10 @@ public:
     Events&& takePresenceData();
     Events&& takeAccountData();
     Events&& takeToDeviceEvents();
+    const QHash<QString, int>& deviceOneTimeKeysCount() const
+    {
+        return deviceOneTimeKeysCount_;
+    }
     SyncDataList&& takeRoomData();
 
     QString nextBatch() const { return nextBatch_; }
@@ -108,6 +112,7 @@ private:
     Events toDeviceEvents;
     SyncDataList roomData;
     QStringList unresolvedRoomIds;
+    QHash<QString, int> deviceOneTimeKeysCount_;
 
     static QJsonObject loadJson(const QString& fileName);
 };

--- a/libquotient.pri
+++ b/libquotient.pri
@@ -8,7 +8,14 @@ win32-msvc* {
     QMAKE_CXXFLAGS_WARN_ON += -Wno-unused-parameter
 }
 
-include(3rdparty/libQtOlm/libQtOlm.pri)
+contains(DEFINES, Quotient_E2EE_ENABLED=.) {
+    contains(DEFINES, USE_INTREE_LIBQOLM=.) {
+        include(3rdparty/libQtOlm/libQtOlm.pri)
+    } else {
+        CONFIG += link_pkgconfig
+        PKGCONFIG += QtOlm
+    }
+}
 
 SRCPATH = $$PWD/lib
 INCLUDEPATH += $$SRCPATH
@@ -45,6 +52,7 @@ HEADERS += \
     $$SRCPATH/events/directchatevent.h \
     $$SRCPATH/events/encryptionevent.h \
     $$SRCPATH/events/encryptedevent.h \
+    $$SRCPATH/events/roomkeyevent.h \
     $$SRCPATH/events/redactionevent.h \
     $$SRCPATH/events/eventloader.h \
     $$SRCPATH/events/roompowerlevelsevent.h \
@@ -93,6 +101,7 @@ SOURCES += \
     $$SRCPATH/events/directchatevent.cpp \
     $$SRCPATH/events/encryptionevent.cpp \
     $$SRCPATH/events/encryptedevent.cpp \
+    $$SRCPATH/events/roomkeyevent.cpp \
     $$SRCPATH/events/roompowerlevelsevent.cpp \
     $$SRCPATH/jobs/requestdata.cpp \
     $$SRCPATH/jobs/basejob.cpp \


### PR DESCRIPTION
With the current state, it is possible to receive the (megolm) messages at the room.
Created sessions are not saving to persistent storage though (the crypto storage for the sessions is not implemented yet), so to check it's working I'm logging in as new device with clean new cache and olm account every time.
Olm decryption is also implemented to initialize the megolm session to share messages.
Tested with Quaternion. Apropriate draft commit to display encrypted messages: https://github.com/quotient-im/Quaternion/commit/9f9868ace6d72c1ec53fbe9f69737247e5fdacca