### PR TITLE
MSC1954: Remove prev_content from the essential keys list

### DIFF
--- a/lib/room.cpp
+++ b/lib/room.cpp
@@ -1937,7 +1937,6 @@ RoomEventPtr makeRedacted(const RoomEvent& target,
     // clang-format off
     static const QStringList keepKeys { EventIdKey, TypeKey,
         QStringLiteral("room_id"), QStringLiteral("sender"), StateKeyKey,
-        QStringLiteral("prev_content"), ContentKey,
         QStringLiteral("hashes"), QStringLiteral("signatures"),
         QStringLiteral("depth"), QStringLiteral("prev_events"),
         QStringLiteral("prev_state"), QStringLiteral("auth_events"),


### PR DESCRIPTION
Fixes #318

(2nd attempt :) thank you for the corrections!