### PR TITLE
MSC1849 compatible edited messages

### DIFF
--- a/lib/room.cpp
+++ b/lib/room.cpp
@@ -2086,8 +2086,7 @@ RoomEventPtr makeReplaced(const RoomEvent& target,
                           const RoomMessageEvent& replacement)
 {
     auto originalJson = target.originalJsonObject();
-    originalJson[ContentKeyL] = replacement.originalJsonObject().
-            take(ContentKeyL).toObject().take("m.new_content"_ls).toObject();
+    originalJson[ContentKeyL] = replacement.contentJson().value("m.new_content"_ls);
 
     auto unsignedData = originalJson.take(UnsignedKeyL).toObject();
     auto relations = unsignedData.take("m.relations"_ls).toObject();

--- a/lib/room.cpp
+++ b/lib/room.cpp
@@ -2086,7 +2086,8 @@ RoomEventPtr makeReplaced(const RoomEvent& target,
                           const RoomMessageEvent& replacement)
 {
     auto originalJson = target.originalJsonObject();
-    originalJson[ContentKeyL] = replacement.contentJson();
+    originalJson[ContentKeyL] = replacement.originalJsonObject().
+            take(ContentKeyL).toObject().take("m.new_content"_ls).toObject();
 
     auto unsignedData = originalJson.take(UnsignedKeyL).toObject();
     auto relations = unsignedData.take("m.relations"_ls).toObject();


### PR DESCRIPTION
Server side aggregation replaces `content` with `new_content` in
edited messages. The same must be done at client side on
incremental updates to keep timeline consistent.