### PR TITLE
Fix build on big-endian systems

### DIFF
--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -104,7 +104,7 @@ qreal Quotient::stringToHueF(const QString& s)
     Q_ASSERT(!s.isEmpty());
     QByteArray hash = QCryptographicHash::hash(s.toUtf8(),
                                                QCryptographicHash::Sha1);
-    QDataStream dataStream(qToLittleEndian(hash).left(2));
+    QDataStream dataStream(hash.left(2));
     dataStream.setByteOrder(QDataStream::LittleEndian);
     quint16 hashValue;
     dataStream >> hashValue;


### PR DESCRIPTION
This fixes the build error described in #374:
 
On little-endian systems, this call to qToLittleEndian(hash) disappears
completely.

On big-endian systems, it turns into qbswap(hash), and causes a build
error.  qbswap() isn't defined for QByteArrays, because QByteArray
isn't an array containing multi-byte elements. Since each element
is a single byte, machine endianness isn't a factor.  (If we really
wanted to swap the bytes, we'd need to reverse every 4 bytes of
the array.)

This just drops the call to QToLittleEndian completely. The lines
after it converts part of the hash to a QDataStream, which DOES have
to worry about endianness, but that code is also specifically calling
QDataStream::setByteOrder to specify little-endian.