### PR TITLE
Fix E2EE master build

### DIFF
--- a/tests/quotest.cpp
+++ b/tests/quotest.cpp
@@ -46,7 +46,7 @@ private:
 };
 
 using TestToken = QByteArray; // return value of QMetaMethod::name
-Q_DECLARE_METATYPE(TestToken);
+Q_DECLARE_METATYPE(TestToken)
 // For now, the token itself is the test name but that may change.
 const char* testName(const TestToken& token) { return token.constData(); }
 


### PR DESCRIPTION
This fixes two build errors and a warning:

- encryptionManager::upload* expects a Connection, not the Private
- sessionDecryptMessage returns a RoomEventPtr. The code dropped in commit ec4110c63443e29c78fdf0f72af08f5395ec48f7 created the RoomKeyEvent from the RoomEvent::fullJson.
- fix warning about Q_DECLARE_METATYPE(TestToken) semicolon

I ran the clang-format-7 from my Debian Buster on the file, which produced a much larger diff then expected, so I just included the hunks from the code I actually changed.