### PR TITLE
Make it compile with QT_NO_KEYWORDS

### DIFF
--- a/lib/connection.h
+++ b/lib/connection.h
@@ -497,7 +497,7 @@ public:
         setUserFactory(defaultUserFactory<T>());
     }
 
-public slots:
+public Q_SLOTS:
     /** Set the homeserver base URL */
     void setHomeserver(const QUrl& baseUrl);
 
@@ -656,7 +656,7 @@ public slots:
      */
     virtual PostReceiptJob* postReceipt(Room* room, RoomEvent* event);
 
-signals:
+Q_SIGNALS:
     /**
      * @deprecated
      * This was a signal resulting from a successful resolveServer().
@@ -853,7 +853,7 @@ protected:
      */
     void onSyncSuccess(SyncData&& data, bool fromCache = false);
 
-protected slots:
+protected Q_SLOTS:
     void syncLoopIteration();
 
 private:

--- a/lib/jobs/basejob.h
+++ b/lib/jobs/basejob.h
@@ -251,7 +251,7 @@ public:
         return dbg << j->objectName();
     }
 
-public slots:
+public Q_SLOTS:
     void initiate(ConnectionData* connData, bool inBackground);
 
     /**
@@ -263,7 +263,7 @@ public slots:
      */
     void abandon();
 
-signals:
+Q_SIGNALS:
     /** The job is about to send a network request */
     void aboutToSendRequest();
 
@@ -433,7 +433,7 @@ protected:
     // Job objects should only be deleted via QObject::deleteLater
     ~BaseJob() override;
 
-protected slots:
+protected Q_SLOTS:
     void timeout();
 
     /*! \brief Check the pending or received reply for upfront issues
@@ -456,7 +456,7 @@ protected slots:
      */
     virtual Status checkReply(const QNetworkReply *reply) const;
 
-private slots:
+private Q_SLOTS:
     void sendRequest();
     void gotReply();
 

--- a/lib/room.h
+++ b/lib/room.h
@@ -547,7 +547,7 @@ public:
         return setState(EvT(std::forward<ArgTs>(args)...));
     }
 
-public slots:
+public Q_SLOTS:
     /** Check whether the room should be upgraded */
     void checkVersion();
 
@@ -611,7 +611,7 @@ public slots:
     void answerCall(const QString& callId, const QString& sdp);
     void hangupCall(const QString& callId);
 
-signals:
+Q_SIGNALS:
     /// Initial set of state events has been loaded
     /**
      * The initial set is what comes from the initial sync for the room.

--- a/lib/uriresolver.h
+++ b/lib/uriresolver.h
@@ -141,7 +141,7 @@ public:
         return UriResolverBase::visitResource(account, uri);
     }
 
-signals:
+Q_SIGNALS:
     /// An action on a user has been requested
     void userAction(Quotient::User* user, QString action);
 

--- a/lib/user.h
+++ b/lib/user.h
@@ -122,7 +122,7 @@ public:
     QString avatarMediaId(const Room* room = nullptr) const;
     QUrl avatarUrl(const Room* room = nullptr) const;
 
-public slots:
+public Q_SLOTS:
     /// Set a new name in the global user profile
     void rename(const QString& newName);
     /// Set a new name for the user in one room
@@ -143,7 +143,7 @@ public slots:
     /// Check whether the user is in ignore list
     bool isIgnored() const;
 
-signals:
+Q_SIGNALS:
     void defaultNameChanged();
     void defaultAvatarChanged();
 


### PR DESCRIPTION
This is generally nicer for libraries since it reduces the chance of collision with other libraries.