### PR TITLE
Fix DELETE jobs with json data

### DIFF
--- a/lib/jobs/basejob.cpp
+++ b/lib/jobs/basejob.cpp
@@ -324,7 +324,7 @@ void BaseJob::Private::sendRequest()
         reply.reset(connection->nam()->put(req, requestData.source()));
         break;
     case HttpVerb::Delete:
-        reply.reset(connection->nam()->deleteResource(req));
+        reply.reset(connection->nam()->sendCustomRequest(req, "DELETE", requestData.source()));
         break;
     }
 }


### PR DESCRIPTION
DeleteDeviceJob requires authentication, but the JSON data is not added for DELETE requests.
Since QNetworkAccessManager::deleteResource does not support body data, we need to send a custom request.