### PR TITLE
Load user info (display name + avatar) for the local user.

### DIFF
--- a/lib/user.cpp
+++ b/lib/user.cpp
@@ -49,6 +49,16 @@ User::User(QString userId, Connection* connection)
     : QObject(connection), d(new Private(move(userId)))
 {
     setObjectName(id());
+    if (connection->userId() == id()) {
+        // Load profile information for local user.
+        auto *profileJob = connection->callApi<GetUserProfileJob>(id());
+        connect(profileJob, &BaseJob::result, this, [this, profileJob] {
+            d->defaultName = profileJob->displayname();
+            d->defaultAvatar = Avatar(QUrl(profileJob->avatarUrl()));
+            emit defaultNameChanged();
+            emit defaultAvatarChanged();
+        });
+    }
 }
 
 Connection* User::connection() const

--- a/quotest/quotest.cpp
+++ b/quotest/quotest.cpp
@@ -513,12 +513,7 @@ TEST_IMPL(changeName)
 TEST_IMPL(showLocalUsername)
 {
     auto* const localUser = connection()->user();
-    if (localUser->name().contains("@")) {
-        // it is using the id fallback :(
-        FAIL_TEST();
-    }
-    FINISH_TEST(true);
-    return false;
+    FINISH_TEST(localUser->name().contains("@"));
 }
 
 TEST_IMPL(sendAndRedact)

--- a/quotest/quotest.cpp
+++ b/quotest/quotest.cpp
@@ -101,6 +101,7 @@ private slots:
     TEST_DECL(setTopic)
     TEST_DECL(changeName)
     TEST_DECL(sendAndRedact)
+    TEST_DECL(showLocalUsername)
     TEST_DECL(addAndRemoveTag)
     TEST_DECL(markDirectChat)
     TEST_DECL(visitResources)
@@ -505,6 +506,17 @@ TEST_IMPL(changeName)
                  [this, thisTest, localUser, newName] {
                      FINISH_TEST(localUser->name() == newName);
                  });
+    return false;
+}
+
+
+TEST_IMPL(showLocalUsername)
+{
+    auto* const localUser = connection()->user();
+    if (localUser->name().contains("@")) {
+        // it is using the id fallback :(
+        FAIL_TEST();
+    }
     return false;
 }
 

--- a/quotest/quotest.cpp
+++ b/quotest/quotest.cpp
@@ -513,7 +513,7 @@ TEST_IMPL(changeName)
 TEST_IMPL(showLocalUsername)
 {
     auto* const localUser = connection()->user();
-    FINISH_TEST(localUser->name().contains("@"));
+    FINISH_TEST(!localUser->name().contains("@"));
 }
 
 TEST_IMPL(sendAndRedact)

--- a/quotest/quotest.cpp
+++ b/quotest/quotest.cpp
@@ -517,6 +517,7 @@ TEST_IMPL(showLocalUsername)
         // it is using the id fallback :(
         FAIL_TEST();
     }
+    FINISH_TEST(true);
     return false;
 }
 


### PR DESCRIPTION
This is needed for a few cases like the account list in NeoChat or the
account switcher. In this cases we don't have a room binded to the user
and can't fetch the real display name and avatar.