### PR TITLE
Fix rich replies json format (transmit)

### DIFF
--- a/lib/events/roommessageevent.cpp
+++ b/lib/events/roommessageevent.cpp
@@ -325,7 +325,10 @@ void TextContent::fillJson(QJsonObject* json) const
     }
     if (relatesTo) {
         json->insert(QStringLiteral("m.relates_to"),
-                     QJsonObject { { "rel_type", relatesTo->type }, { EventIdKey, relatesTo->eventId } });
+                     relatesTo->type == RelatesTo::ReplyTypeId() ?
+                         QJsonObject { { relatesTo->type, QJsonObject{ { EventIdKey, relatesTo->eventId } } } } :
+                         QJsonObject { { "rel_type", relatesTo->type }, { EventIdKey, relatesTo->eventId } }
+        );
         if (relatesTo->type == RelatesTo::ReplacementTypeId()) {
             QJsonObject newContentJson;
             if (mimeType.inherits("text/html")) {


### PR DESCRIPTION
With this patch it looks like:

```
"m.relates_to": {
  "m.in_reply_to": {
    "event_id": "$another:event.com"
  }
}
```

instead of:

```
"m.relates_to": {
  "event_id": "$another:event.com",
  "rel_type": "m.in_reply_to"
},
```

So it fits the specification by now.

https://matrix.org/docs/spec/client_server/r0.6.1#rich-replies