### PR TITLE
Fix rich edits (transmit)

### DIFF
--- a/lib/events/roommessageevent.cpp
+++ b/lib/events/roommessageevent.cpp
@@ -329,8 +329,8 @@ void TextContent::fillJson(QJsonObject* json) const
         if (relatesTo->type == RelatesTo::ReplacementTypeId()) {
             QJsonObject newContentJson;
             if (mimeType.inherits("text/html")) {
-                json->insert(FormatKey, HtmlContentTypeId);
-                json->insert(FormattedBodyKey, body);
+                newContentJson.insert(FormatKey, HtmlContentTypeId);
+                newContentJson.insert(FormattedBodyKey, body);
             }
             json->insert(QStringLiteral("m.new_content"), newContentJson);
         }


### PR DESCRIPTION
The new formatted_body was not included into new content on edit
due to badly constructed json.