### PR TITLE
Make it possible to load the user metadata

### DIFF
--- a/lib/user.cpp
+++ b/lib/user.cpp
@@ -51,13 +51,7 @@ User::User(QString userId, Connection* connection)
     setObjectName(id());
     if (connection->userId() == id()) {
         // Load profile information for local user.
-        auto *profileJob = connection->callApi<GetUserProfileJob>(id());
-        connect(profileJob, &BaseJob::result, this, [this, profileJob] {
-            d->defaultName = profileJob->displayname();
-            d->defaultAvatar = Avatar(QUrl(profileJob->avatarUrl()));
-            emit defaultNameChanged();
-            emit defaultAvatarChanged();
-        });
+        load();
     }
 }
 
@@ -68,6 +62,17 @@ Connection* User::connection() const
 }
 
 User::~User() = default;
+
+void User::load()
+{
+    auto *profileJob = connection()->callApi<GetUserProfileJob>(id());
+    connect(profileJob, &BaseJob::result, this, [this, profileJob] {
+        d->defaultName = profileJob->displayname();
+        d->defaultAvatar = Avatar(QUrl(profileJob->avatarUrl()));
+        emit defaultNameChanged();
+        emit defaultAvatarChanged();
+    });
+}
 
 QString User::id() const { return d->id; }
 

--- a/lib/user.h
+++ b/lib/user.h
@@ -130,6 +130,10 @@ public Q_SLOTS:
     void unmarkIgnore();
     /// Check whether the user is in ignore list
     bool isIgnored() const;
+    /// Force loading displayName and avartar url. This is required in
+    /// some cases where the you need to use an user independent of the
+    /// room.
+    void load();
 
 Q_SIGNALS:
     void defaultNameChanged();


### PR DESCRIPTION
In the normal case there is always a room that is associated with an
user. So it is in most of the cases, possible to load the metadata
(display name and avatar url) with the help of the room.

In some cases, it is not possible. For example, when opening an user
matrix link pointing to an user and not to a room. In this case, we need
to load the metadata independly of the room, since the user is not
linked to a room.