### PR TITLE
Upload one-time keys when their count is low

### DIFF
--- a/lib/connection.cpp
+++ b/lib/connection.cpp
@@ -621,17 +621,15 @@ void Connection::onSyncSuccess(SyncData&& data, bool fromCache)
     d->consumePresenceData(data.takePresenceData());
     d->consumeToDeviceEvents(data.takeToDeviceEvents());
 #ifdef Quotient_E2EE_ENABLED
-    // handling device_one_time_keys_count
-    //if (!d->encryptionManager)
-    //{
-    //    qCDebug(E2EE) << "Encryption manager is not there yet, updating "
-    //                     "one-time key counts will be skipped";
-    //    return;
-    //}
-    //if (const auto deviceOneTimeKeysCount = data.deviceOneTimeKeysCount();
-    //        !deviceOneTimeKeysCount.isEmpty())
-    //    d->encryptionManager->updateOneTimeKeyCounts(this,
-    //                                                 deviceOneTimeKeysCount);
+    if(data.deviceOneTimeKeysCount()["signed_curve25519"] < 0.4 * d->olmAccount->maxNumberOfOneTimeKeys()) {
+        d->olmAccount->generateOneTimeKeys(d->olmAccount->maxNumberOfOneTimeKeys() - data.deviceOneTimeKeysCount()["signed_curve25519"]);
+        auto keys = d->olmAccount->oneTimeKeys();
+        auto job = d->olmAccount->createUploadKeyRequest(keys);
+        run(job, ForegroundRequest);
+        connect(job, &BaseJob::success, this, [=](){
+            d->olmAccount->markKeysAsPublished();
+        });
+    }
 #endif // Quotient_E2EE_ENABLED
 }
 

--- a/lib/crypto/qolmaccount.cpp
+++ b/lib/crypto/qolmaccount.cpp
@@ -276,6 +276,11 @@ std::variant<std::unique_ptr<QOlmSession>, QOlmError> QOlmAccount::createOutboun
     return QOlmSession::createOutboundSession(this, theirIdentityKey, theirOneTimeKey);
 }
 
+void QOlmAccount::markKeysAsPublished()
+{
+    olm_account_mark_keys_as_published(m_account);
+}
+
 bool Quotient::verifyIdentitySignature(const DeviceKeys &deviceKeys,
                              const QString &deviceId,
                              const QString &userId)

--- a/lib/crypto/qolmaccount.h
+++ b/lib/crypto/qolmaccount.h
@@ -93,6 +93,8 @@ public:
     /// identity and one time key.
     std::variant<std::unique_ptr<QOlmSession>, QOlmError> createOutboundSession(const QByteArray &theirIdentityKey, const QByteArray &theirOneTimeKey);
 
+    void markKeysAsPublished();
+
     // HACK do not use directly
     QOlmAccount(OlmAccount *account);
     OlmAccount *data();


### PR DESCRIPTION
For now it only checks and uploads signed curve keys.
Apparently unsigned one-time keys are also a thing in theory, but not really used