### PR TITLE
switch most deprecation comments to attributes

### DIFF
--- a/lib/connection.h
+++ b/lib/connection.h
@@ -548,7 +548,7 @@ public Q_SLOTS:
     /// Find out if capabilites are still loading from the server
     bool loadingCapabilities() const;
 
-    [[deprecate("Use stopSync() instead")]]
+    [[deprecated("Use stopSync() instead")]]
     void disconnectFromServer() { stopSync(); }
     void logout();
 
@@ -689,7 +689,7 @@ Q_SIGNALS:
     void capabilitiesLoaded();
 
     void connected();
-    [[deprecated("Use connected() instead")
+    [[deprecated("Use connected() instead")]]
     void reconnected();
     void loggedOut();
     /** Login data or state have changed

--- a/lib/connection.h
+++ b/lib/connection.h
@@ -525,7 +525,7 @@ public Q_SLOTS:
      */
     void assumeIdentity(const QString& mxId, const QString& accessToken,
                         const QString& deviceId);
-    /*! \deprecated Use loginWithPassword instead */
+    [[deprecated("Use loginWithPassword instead")]]
     void connectToServer(const QString& userId, const QString& password,
                          const QString& initialDeviceName,
                          const QString& deviceId = {})
@@ -536,6 +536,7 @@ public Q_SLOTS:
      * Use assumeIdentity() if you have an access token or
      * loginWithToken() if you have a login token.
      */
+    [[deprecated("Use assumeIdentity() (access token) or loginWithToken() (login token)")]]
     void connectWithToken(const QString& userId, const QString& accessToken,
                           const QString& deviceId)
     {
@@ -547,7 +548,7 @@ public Q_SLOTS:
     /// Find out if capabilites are still loading from the server
     bool loadingCapabilities() const;
 
-    /** @deprecated Use stopSync() instead */
+    [[deprecate("Use stopSync() instead")]]
     void disconnectFromServer() { stopSync(); }
     void logout();
 
@@ -665,8 +666,7 @@ public Q_SLOTS:
 
     // Old API that will be abolished any time soon. DO NOT USE.
 
-    /** @deprecated Use callApi<PostReceiptJob>() or Room::postReceipt() instead
-     */
+    [[deprecated("Use callApi<PostReceiptJob>() or Room::postReceipt() instead")]]
     virtual PostReceiptJob* postReceipt(Room* room, RoomEvent* event);
 
 Q_SIGNALS:
@@ -675,11 +675,12 @@ Q_SIGNALS:
      * This was a signal resulting from a successful resolveServer().
      * Since Connection now provides setHomeserver(), the HS URL
      * may change even without resolveServer() invocation. Use
-     * loginFLowsChanged() instead of resolved(). You can also use
+     * loginFlowsChanged() instead of resolved(). You can also use
      * loginWith*() and assumeIdentity() without the HS URL set in
      * advance (i.e. without calling resolveServer), as they trigger
      * server name resolution from MXID if the server URL is not valid.
      */
+    [[deprecated("Read comment above. TL;DR: use loginFlowsChanged")]]
     void resolved();
     void resolveError(QString error);
 
@@ -688,7 +689,8 @@ Q_SIGNALS:
     void capabilitiesLoaded();
 
     void connected();
-    void reconnected(); //< \deprecated Use connected() instead
+    [[deprecated("Use connected() instead")
+    void reconnected();
     void loggedOut();
     /** Login data or state have changed
      *

--- a/lib/room.cpp
+++ b/lib/room.cpp
@@ -803,7 +803,7 @@ bool Room::isValidIndex(TimelineItem::index_t timelineIndex) const
 
 Room::rev_iter_t Room::findInTimeline(TimelineItem::index_t index) const
 {
-    return timelineEdge()
+    return historyEdge()
            - (isValidIndex(index) ? index - minTimelineIndex() + 1 : 0);
 }
 
@@ -2701,7 +2701,7 @@ Room::Changes Room::processEphemeralEvent(EventPtr&& event)
                                        << p.receipts.size() << "users";
             }
             const auto newMarker = findInTimeline(p.evtId);
-            if (newMarker != timelineEdge()) {
+            if (newMarker != historyEdge()) {
                 for (const Receipt& r : p.receipts) {
                     if (r.userId == connection()->userId())
                         continue; // FIXME, #185
@@ -2721,7 +2721,7 @@ Room::Changes Room::processEphemeralEvent(EventPtr&& event)
                         continue; // FIXME, #185
                     auto u = user(r.userId);
                     if (memberJoinState(u) == JoinState::Join
-                        && readMarker(u) == timelineEdge())
+                        && readMarker(u) == historyEdge())
                         changes |= d->setLastReadEvent(u, p.evtId);
                 }
             }
@@ -2749,7 +2749,7 @@ Room::Changes Room::processAccountDataEvent(EventPtr&& event)
         qCDebug(STATE) << "Server-side read marker at" << readEventId;
         d->serverReadMarker = readEventId;
         const auto newMarker = findInTimeline(readEventId);
-        changes |= newMarker != timelineEdge()
+        changes |= newMarker != historyEdge()
                        ? d->markMessagesAsRead(newMarker)
                        : d->setLastReadEvent(localUser(), readEventId);
     }

--- a/lib/room.h
+++ b/lib/room.h
@@ -377,7 +377,7 @@ public:
      * events (non-redacted message events from users other than local)
      * are counted.
      *
-     * In a case when readMarker() == timelineEdge() (the local read
+     * In a case when readMarker() == historyEdge() (the local read
      * marker is beyond the local timeline) only the bottom limit of
      * the unread messages number can be estimated (and even that may
      * be slightly off due to, e.g., redactions of events not loaded

--- a/lib/room.h
+++ b/lib/room.h
@@ -30,6 +30,8 @@
 #include <utility>
 
 namespace Quotient {
+Q_NAMESPACE
+
 class Event;
 class Avatar;
 class SyncRoomData;
@@ -260,12 +262,12 @@ public:
     /*!
      * \brief Get a disambiguated name for the given user in the room context
      */
-    [[deprecated("Use safeMemberName() instead")
+    [[deprecated("Use safeMemberName() instead")]]
     Q_INVOKABLE QString roomMembername(const Quotient::User* u) const;
     /*!
      * \brief Get a disambiguated name for a user with this id in the room context
      */
-    [[deprecated("Use safeMemberName() instead")
+    [[deprecated("Use safeMemberName() instead")]]
     Q_INVOKABLE QString roomMembername(const QString& userId) const;
 
     /*!
@@ -312,7 +314,7 @@ public:
      * arrived event; same as messageEvents().cend()
      */
     Timeline::const_iterator syncEdge() const;
-    [[deprecated("Use historyEdge instead")
+    [[deprecated("Use historyEdge instead")]]
     rev_iter_t timelineEdge() const;
     Q_INVOKABLE Quotient::TimelineItem::index_t minTimelineIndex() const;
     Q_INVOKABLE Quotient::TimelineItem::index_t maxTimelineIndex() const;

--- a/lib/room.h
+++ b/lib/room.h
@@ -259,15 +259,13 @@ public:
 
     /*!
      * \brief Get a disambiguated name for the given user in the room context
-     *
-     * \deprecated use safeMemberName() instead
      */
+    [[deprecated("Use safeMemberName() instead")
     Q_INVOKABLE QString roomMembername(const Quotient::User* u) const;
     /*!
      * \brief Get a disambiguated name for a user with this id in the room context
-     *
-     * \deprecated use safeMemberName() instead
      */
+    [[deprecated("Use safeMemberName() instead")
     Q_INVOKABLE QString roomMembername(const QString& userId) const;
 
     /*!
@@ -314,7 +312,7 @@ public:
      * arrived event; same as messageEvents().cend()
      */
     Timeline::const_iterator syncEdge() const;
-    /// \deprecated Use historyEdge instead
+    [[deprecated("Use historyEdge instead")
     rev_iter_t timelineEdge() const;
     Q_INVOKABLE Quotient::TimelineItem::index_t minTimelineIndex() const;
     Q_INVOKABLE Quotient::TimelineItem::index_t maxTimelineIndex() const;

--- a/lib/settings.h
+++ b/lib/settings.h
@@ -147,10 +147,9 @@ public:
     QUrl homeserver() const;
     void setHomeserver(const QUrl& url);
 
-    /** \deprecated \sa setToken */
+    [[deprecated("Use setToken")]]
     QString accessToken() const;
-    /** \deprecated Storing accessToken in QSettings is unsafe,
-     * see quotient-im/Quaternion#181 */
+    [[deprecated("Storing accessToken in QSettings is unsafe, see quotient-im/Quaternion#181")]]
     void setAccessToken(const QString& accessToken);
     Q_INVOKABLE void clearAccessToken();
 

--- a/quotest/quotest.cpp
+++ b/quotest/quotest.cpp
@@ -556,7 +556,7 @@ bool TestSuite::checkRedactionOutcome(const QByteArray& thisTest,
     // redacted at the next sync, or the nearest sync completes with
     // the unredacted event but the next one brings redaction.
     auto it = targetRoom->findInTimeline(evtIdToRedact);
-    if (it == targetRoom->timelineEdge())
+    if (it == targetRoom->historyEdge())
         return false; // Waiting for the next sync
 
     if ((*it)->isRedacted()) {


### PR DESCRIPTION
enables compiler warnings which will help old code get updated.
not sure how to go about the very long explanation, i think the tldr is okay.