### PR TITLE
Fix a bunch of key management bugs

### DIFF
--- a/lib/connection.cpp
+++ b/lib/connection.cpp
@@ -659,10 +659,12 @@ void Connection::onSyncSuccess(SyncData&& data, bool fromCache)
     d->consumeAccountData(data.takeAccountData());
     d->consumePresenceData(data.takePresenceData());
     d->consumeToDeviceEvents(data.takeToDeviceEvents());
+#ifdef Quotient_E2EE_ENABLED
     if(d->encryptionUpdateRequired) {
         d->loadOutdatedUserDevices();
         d->encryptionUpdateRequired = false;
     }
+#endif
 }
 
 void Connection::Private::consumeRoomData(SyncDataList&& roomDataList,

--- a/lib/connection.cpp
+++ b/lib/connection.cpp
@@ -484,11 +484,6 @@ void Connection::Private::completeSetup(const QString& mxId)
     emit q->stateChanged();
     emit q->connected();
     q->reloadCapabilities();
-#ifdef Quotient_E2EE_ENABLED
-    connectSingleShot(q, &Connection::syncDone, q, [=](){
-        loadDevicesList();
-    });
-#endif
 }
 
 void Connection::Private::checkAndConnect(const QString& userId,
@@ -637,11 +632,6 @@ QJsonObject toJson(const DirectChatsMap& directChats)
 
 void Connection::onSyncSuccess(SyncData&& data, bool fromCache)
 {
-    d->data->setLastEvent(data.nextBatch());
-    d->consumeRoomData(data.takeRoomData(), fromCache);
-    d->consumeAccountData(data.takeAccountData());
-    d->consumePresenceData(data.takePresenceData());
-    d->consumeToDeviceEvents(data.takeToDeviceEvents());
 #ifdef Quotient_E2EE_ENABLED
     if(data.deviceOneTimeKeysCount()["signed_curve25519"] < 0.4 * d->olmAccount->maxNumberOfOneTimeKeys() && !d->isUploadingKeys) {
         d->isUploadingKeys = true;
@@ -656,8 +646,19 @@ void Connection::onSyncSuccess(SyncData&& data, bool fromCache)
             d->isUploadingKeys = false;
         });
     }
-#endif // Quotient_E2EE_ENABLED
+    static bool first = true;
+    if(first) {
+        d->loadDevicesList();
+        first = false;
+    }
+
     d->consumeDevicesList(data.takeDevicesList());
+#endif // Quotient_E2EE_ENABLED
+    d->data->setLastEvent(data.nextBatch());
+    d->consumeRoomData(data.takeRoomData(), fromCache);
+    d->consumeAccountData(data.takeAccountData());
+    d->consumePresenceData(data.takePresenceData());
+    d->consumeToDeviceEvents(data.takeToDeviceEvents());
 }
 
 void Connection::Private::consumeRoomData(SyncDataList&& roomDataList,
@@ -814,9 +815,11 @@ void Connection::Private::consumeToDeviceEvents(Events&& toDeviceEvents)
 void Connection::Private::consumeDevicesList(DevicesList&& devicesList)
 {
 #ifdef Quotient_E2EE_ENABLED
+    bool hasNewOutdatedUser = false;
     for(const auto &changed : devicesList.changed) {
         if(trackedUsers.contains(changed)) {
             outdatedUsers += changed;
+            hasNewOutdatedUser = true;
         }
     }
     for(const auto &left : devicesList.left) {
@@ -824,7 +827,7 @@ void Connection::Private::consumeDevicesList(DevicesList&& devicesList)
         outdatedUsers -= left;
         deviceKeys.remove(left);
     }
-    if(!outdatedUsers.isEmpty()) {
+    if(hasNewOutdatedUser) {
         loadOutdatedUserDevices();
     }
 #endif
@@ -1892,13 +1895,15 @@ void Connection::Private::loadOutdatedUserDevices()
 
 void Connection::encryptionUpdate(Room *room)
 {
+    bool hasNewOutdatedUser = false;
     for(const auto &user : room->users()) {
         if(!d->trackedUsers.contains(user->id())) {
             d->trackedUsers += user->id();
             d->outdatedUsers += user->id();
+            hasNewOutdatedUser = true;
         }
     }
-    if(!d->outdatedUsers.isEmpty()) {
+    if(hasNewOutdatedUser) {
         d->loadOutdatedUserDevices();
     }
 }
@@ -1927,13 +1932,13 @@ void Connection::Private::saveDevicesList()
               { QStringLiteral("minor"), SyncData::cacheVersion().second } } }
     };
     {
-        QJsonObject trackedUsersJson;
-        QJsonObject outdatedUsersJson;
+        QJsonArray trackedUsersJson;
+        QJsonArray outdatedUsersJson;
         for (const auto &user : trackedUsers) {
-            trackedUsersJson.insert(user, QJsonValue::Null);
+            trackedUsersJson += user;
         }
         for (const auto &user : outdatedUsers) {
-            outdatedUsersJson.insert(user, QJsonValue::Null);
+            outdatedUsersJson += user;
         }
         rootObj.insert(QStringLiteral("tracked_users"), trackedUsersJson);
         rootObj.insert(QStringLiteral("outdated_users"), outdatedUsersJson);
@@ -1990,10 +1995,14 @@ void Connection::Private::loadDevicesList()
     auto oldToken = json["sync_token"].toString();
     auto changesJob = q->callApi<GetKeysChangesJob>(oldToken, q->nextBatchToken());
     connect(changesJob, &BaseJob::success, q, [=](){
+        bool hasNewOutdatedUser = false;
         for(const auto &user : changesJob->changed()) {
             outdatedUsers += user;
+            hasNewOutdatedUser = true;
         }
-        loadOutdatedUserDevices();
+        if(hasNewOutdatedUser) {
+            loadOutdatedUserDevices();
+        }
     });
 }
 #endif


### PR DESCRIPTION
Fixes problems:
- DevicesList cache being stored incorrectly and thus failing to load the list of users
- Redundant discovery of relevant users
- Starting irrelevant new query jobs, aborting the old ones and DOS'ing the homeserver