### PR TITLE
Qt 6 support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,16 +9,6 @@ environment:
   - QTDIR: C:\Qt\5.13\msvc2017_64 # Fresh Qt, 64-bit
     VCVARS: "vcvars64.bat"
     PLATFORM:
-  - QTDIR: C:\Qt\5.9\msvc2017_64 # Oldest supported Qt, 64-bit, E2EE
-    VCVARS: "vcvars64.bat"
-    QMAKE_E2EE_ARGS: '"DEFINES += Quotient_E2EE_ENABLED USE_INTREE_LIBQOLM" "INCLUDEPATH += olm/include" "LIBS += -Lbuild/olm"'
-    CMAKE_E2EE_ARGS: '-DQuotient_ENABLE_E2EE=ON -DOlm_DIR=build/olm'
-    PLATFORM:
-  - QTDIR: C:\Qt\5.13\msvc2017_64 # Fresh Qt, 64-bit, E2EE
-    VCVARS: "vcvars64.bat"
-    QMAKE_E2EE_ARGS: '"DEFINES += Quotient_E2EE_ENABLED USE_INTREE_LIBQOLM" "INCLUDEPATH += olm/include" "LIBS += -Lbuild/olm"'
-    CMAKE_E2EE_ARGS: '-DQuotient_ENABLE_E2EE=ON -DOlm_DIR=build/olm'
-    PLATFORM:
 
 init:
 - call "%QTDIR%\bin\qtenv2.bat"
@@ -28,12 +18,9 @@ init:
 
 before_build:
 - git submodule update --init --recursive
-- git clone https://gitlab.matrix.org/matrix-org/olm.git
-- cmake %CMAKE_ARGS% -Holm -Bbuild/olm
-- cmake --build build/olm
 
 build_script:
-- cmake %CMAKE_ARGS% %CMAKE_E2EE_ARGS% -H. -Bbuild
+- cmake %CMAKE_ARGS% -H. -Bbuild
 - cmake --build build
 
 #after_build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v2.11.1
       with:
-        version: '5.9.9'
+        version: '5.12.10'
         cached: ${{ steps.cache-qt.outputs.cache-hit }}
 
     - name: Install Ninja (macOS)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         os: [ubuntu-18.04, macos-10.15]
         compiler: [ GCC, Clang ]
+        qt-version: [ '5.12.10' ]
         # Not using binary values here, to make the job captions more readable
         e2ee: [ '', 'E2EE' ]
         update-api: [ '', 'update-api' ]
@@ -37,12 +38,12 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ runner.workspace }}/Qt
-        key: ${{ runner.os }}-QtCache
+        key: ${{ runner.os }}-Qt${{ matrix.qt-version }}-cache
 
     - name: Install Qt
       uses: jurplel/install-qt-action@v2.11.1
       with:
-        version: '5.12.10'
+        version: ${{ matrix.qt-version }}
         cached: ${{ steps.cache-qt.outputs.cache-hit }}
 
     - name: Install Ninja (macOS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ endif()
 if (NOT Qt5Core_FOUND OR BUILD_WITH_Qt6)
     find_package(Qt6 6.2 REQUIRED Core Network Gui Test) # TODO: Multimedia
     set(Qt Qt6)
+    qt6_wrap_cpp(lib_SRCS lib/quotient_common.h)
 else()
     find_package(Qt5 5.12 REQUIRED Core Network Gui Multimedia Test)
     set(Qt Qt5)
@@ -124,7 +125,7 @@ if (${PROJECT_NAME}_ENABLE_E2EE)
 endif ()
 
 # Set up source files
-set(lib_SRCS
+list(APPEND lib_SRCS
     lib/networkaccessmanager.cpp
     lib/connectiondata.cpp
     lib/connection.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,9 +72,21 @@ message(STATUS "  Header files will be installed to ${CMAKE_INSTALL_PREFIX}/${${
 # Instruct CMake to run moc automatically when needed.
 set(CMAKE_AUTOMOC ON)
 
-find_package(Qt5 5.9 REQUIRED Core Network Gui Multimedia Test)
-get_filename_component(Qt5_Prefix "${Qt5_DIR}/../../../.." ABSOLUTE)
-message(STATUS "Using Qt ${Qt5_VERSION} at ${Qt5_Prefix}")
+option(BUILD_WITH_QT6 "Build Quotient with Qt 6" OFF)
+
+if (NOT BUILD_WITH_QT6)
+    # Use Qt5 by default
+    find_package(Qt5 5.12 QUIET COMPONENTS Core)
+endif()
+if (NOT Qt5Core_FOUND OR BUILD_WITH_Qt6)
+    find_package(Qt6 6.2 REQUIRED Core Network Gui Test) # TODO: Multimedia
+    set(Qt Qt6)
+else()
+    find_package(Qt5 5.12 REQUIRED Core Network Gui Multimedia Test)
+    set(Qt Qt5)
+endif()
+get_filename_component($Qt_Prefix "${${Qt}_DIR}/../../../.." ABSOLUTE)
+message(STATUS "Using Qt ${${Qt}_VERSION} at ${Qt_Prefix}")
 
 if (${PROJECT_NAME}_ENABLE_E2EE)
     if ((NOT DEFINED USE_INTREE_LIBQOLM OR USE_INTREE_LIBQOLM)
@@ -279,7 +291,10 @@ if (${PROJECT_NAME}_ENABLE_E2EE)
     target_link_libraries(${PROJECT_NAME} QtOlm)
     set(FIND_DEPS "find_dependency(QtOlm)") # For QuotientConfig.cmake.in
 endif()
-target_link_libraries(${PROJECT_NAME} Qt5::Core Qt5::Network Qt5::Gui Qt5::Multimedia)
+target_link_libraries(${PROJECT_NAME} ${Qt}::Core ${Qt}::Network ${Qt}::Gui)
+if (Qt STREQUAL Qt5) # Qt 6 hasn't got Multimedia component as yet
+    target_link_libraries(${PROJECT_NAME} ${Qt}::Multimedia)
+endif()
 
 configure_file(${PROJECT_NAME}.pc.in ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc @ONLY NEWLINE_STYLE UNIX)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,13 +72,9 @@ message(STATUS "  Header files will be installed to ${CMAKE_INSTALL_PREFIX}/${${
 # Instruct CMake to run moc automatically when needed.
 set(CMAKE_AUTOMOC ON)
 
-option(BUILD_WITH_QT6 "Build Quotient with Qt 6" OFF)
+option(BUILD_WITH_QT6 "Build Quotient with Qt 6 (EXPERIMENTAL)" OFF)
 
-if (NOT BUILD_WITH_QT6)
-    # Use Qt5 by default
-    find_package(Qt5 5.12 QUIET COMPONENTS Core)
-endif()
-if (NOT Qt5Core_FOUND OR BUILD_WITH_Qt6)
+if (BUILD_WITH_QT6)
     find_package(Qt6 6.2 REQUIRED Core Network Gui Test) # TODO: Multimedia
     set(Qt Qt6)
     qt6_wrap_cpp(lib_SRCS lib/quotient_common.h)

--- a/autotests/CMakeLists.txt
+++ b/autotests/CMakeLists.txt
@@ -7,7 +7,7 @@ include(CMakeParseArguments)
 function(QUOTIENT_ADD_TEST)
     cmake_parse_arguments(ARG "" "NAME" "" ${ARGN})
     add_executable(${ARG_NAME} ${ARG_NAME}.cpp)
-    target_link_libraries(${ARG_NAME} Qt5::Core Qt5::Test Quotient)
+    target_link_libraries(${ARG_NAME} ${Qt}::Core ${Qt}::Test Quotient)
     add_test(NAME ${ARG_NAME} COMMAND ${ARG_NAME})
 endfunction()
 

--- a/lib/connection.cpp
+++ b/lib/connection.cpp
@@ -14,6 +14,9 @@
 #include "settings.h"
 #include "user.h"
 
+// NB: since Qt 6, moc_connection.cpp needs Room and User fully defined
+#include "moc_connection.cpp"
+
 #include "csapi/account-data.h"
 #include "csapi/capabilities.h"
 #include "csapi/joining.h"

--- a/lib/connection.cpp
+++ b/lib/connection.cpp
@@ -58,7 +58,7 @@ using namespace Quotient;
 
 // This is very much Qt-specific; STL iterators don't have key() and value()
 template <typename HashT, typename Pred>
-HashT erase_if(HashT& hashMap, Pred pred)
+HashT remove_if(HashT& hashMap, Pred pred)
 {
     HashT removals;
     for (auto it = hashMap.begin(); it != hashMap.end();) {
@@ -668,16 +668,16 @@ void Connection::Private::consumeAccountData(Events&& accountDataEvents)
                 // https://github.com/quotient-im/libQuotient/wiki/Handling-direct-chat-events
                 const auto& usersToDCs = dce.usersToDirectChats();
                 DirectChatsMap remoteRemovals =
-                    erase_if(directChats, [&usersToDCs, this](auto it) {
+                    remove_if(directChats, [&usersToDCs, this](auto it) {
                         return !(
                             usersToDCs.contains(it.key()->id(), it.value())
                             || dcLocalAdditions.contains(it.key(), it.value()));
                     });
-                erase_if(directChatUsers, [&remoteRemovals](auto it) {
+                remove_if(directChatUsers, [&remoteRemovals](auto it) {
                     return remoteRemovals.contains(it.value(), it.key());
                 });
                 // Remove from dcLocalRemovals what the server already has.
-                erase_if(dcLocalRemovals, [&remoteRemovals](auto it) {
+                remove_if(dcLocalRemovals, [&remoteRemovals](auto it) {
                     return remoteRemovals.contains(it.key(), it.value());
                 });
                 if (MAIN().isDebugEnabled())
@@ -705,7 +705,7 @@ void Connection::Private::consumeAccountData(Events&& accountDataEvents)
                             << "Couldn't get a user object for" << it.key();
                 }
                 // Remove from dcLocalAdditions what the server already has.
-                erase_if(dcLocalAdditions, [&remoteAdditions](auto it) {
+                remove_if(dcLocalAdditions, [&remoteAdditions](auto it) {
                     return remoteAdditions.contains(it.key(), it.value());
                 });
                 if (!remoteAdditions.isEmpty() || !remoteRemovals.isEmpty())
@@ -1388,7 +1388,7 @@ void Connection::removeFromDirectChats(const QString& roomId, User* user)
         removals.insert(user, roomId);
         d->dcLocalRemovals.insert(user, roomId);
     } else {
-        removals = erase_if(d->directChats,
+        removals = remove_if(d->directChats,
                             [&roomId](auto it) { return it.value() == roomId; });
         d->directChatUsers.remove(roomId);
         d->dcLocalRemovals += removals;

--- a/lib/converters.h
+++ b/lib/converters.h
@@ -221,14 +221,16 @@ template <typename T>
 struct JsonConverter<std::vector<T>>
     : public JsonArrayConverter<std::vector<T>> {};
 
+#if QT_VERSION_MAJOR < 6 // QVector is an alias of QList in Qt6 but not in Qt 5
 template <typename T>
 struct JsonConverter<QVector<T>> : public JsonArrayConverter<QVector<T>> {};
+#endif
 
 template <typename T>
 struct JsonConverter<QList<T>> : public JsonArrayConverter<QList<T>> {};
 
 template <>
-struct JsonConverter<QStringList> : public JsonConverter<QList<QString>> {
+struct JsonConverter<QStringList> : public JsonArrayConverter<QStringList> {
     static auto dump(const QStringList& sl)
     {
         return QJsonArray::fromStringList(sl);

--- a/lib/events/encryptionevent.h
+++ b/lib/events/encryptionevent.h
@@ -40,6 +40,7 @@ public:
                                                           // default value
         : StateEvent(typeId(), obj)
     {}
+    EncryptionEvent(EncryptionEvent&&) = delete;
     template <typename... ArgTs>
     EncryptionEvent(ArgTs&&... contentArgs)
         : StateEvent(typeId(), matrixTypeId(), QString(),

--- a/lib/events/roommessageevent.cpp
+++ b/lib/events/roommessageevent.cpp
@@ -10,7 +10,9 @@
 #include <QtCore/QFileInfo>
 #include <QtCore/QMimeDatabase>
 #include <QtGui/QImageReader>
-#include <QtMultimedia/QMediaResource>
+#if QT_VERSION_MAJOR < 6
+#    include <QtMultimedia/QMediaResource>
+#endif
 
 using namespace Quotient;
 using namespace EventContent;
@@ -149,7 +151,11 @@ TypedBase* contentFromFile(const QFileInfo& file, bool asGenericFile)
         // done by starting to play the file. Left for a future implementation.
         if (mimeTypeName.startsWith("video/"))
             return new VideoContent(localUrl, file.size(), mimeType,
+#if QT_VERSION_MAJOR < 6
                                     QMediaResource(localUrl).resolution(),
+#else
+                                    {},
+#endif
                                     file.fileName());
 
         if (mimeTypeName.startsWith("audio/"))

--- a/lib/jobs/basejob.cpp
+++ b/lib/jobs/basejob.cpp
@@ -288,7 +288,8 @@ void BaseJob::Private::sendRequest()
         req.setRawHeader("Authorization",
                          QByteArray("Bearer ") + connection->accessToken());
     req.setAttribute(QNetworkRequest::BackgroundRequestAttribute, inBackground);
-    req.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
+    req.setAttribute(QNetworkRequest::RedirectPolicyAttribute,
+                     QNetworkRequest::NoLessSafeRedirectPolicy);
     req.setMaximumRedirectsAllowed(10);
     req.setAttribute(QNetworkRequest::HttpPipeliningAllowedAttribute, true);
     req.setAttribute(

--- a/lib/jobs/requestdata.cpp
+++ b/lib/jobs/requestdata.cpp
@@ -3,6 +3,7 @@
 
 #include "requestdata.h"
 
+#include <QtCore/QIODevice>
 #include <QtCore/QBuffer>
 #include <QtCore/QByteArray>
 #include <QtCore/QJsonArray>
@@ -30,5 +31,9 @@ RequestData::RequestData(const QByteArray& a) : _source(fromData(a)) {}
 RequestData::RequestData(const QJsonObject& jo) : _source(fromJson(jo)) {}
 
 RequestData::RequestData(const QJsonArray& ja) : _source(fromJson(ja)) {}
+
+RequestData::RequestData(QIODevice* source)
+    : _source(std::unique_ptr<QIODevice>(source))
+{}
 
 RequestData::~RequestData() = default;

--- a/lib/jobs/requestdata.h
+++ b/lib/jobs/requestdata.h
@@ -24,8 +24,7 @@ public:
     RequestData(const QByteArray& a = {});
     RequestData(const QJsonObject& jo);
     RequestData(const QJsonArray& ja);
-    RequestData(QIODevice* source) : _source(std::unique_ptr<QIODevice>(source))
-    {}
+    RequestData(QIODevice* source);
     RequestData(RequestData&&) = default;
     RequestData& operator=(RequestData&&) = default;
     ~RequestData();

--- a/lib/room.cpp
+++ b/lib/room.cpp
@@ -2962,12 +2962,16 @@ bool MemberSorter::operator()(User* u1, User* u2) const
     return operator()(u1, room->disambiguatedMemberName(u2->id()));
 }
 
-bool MemberSorter::operator()(User* u1, const QString& u2name) const
+bool MemberSorter::operator()(User* u1, QStringView u2name) const
 {
     auto n1 = room->disambiguatedMemberName(u1->id());
     if (n1.startsWith('@'))
         n1.remove(0, 1);
-    auto n2 = u2name.midRef(u2name.startsWith('@') ? 1 : 0);
+    const auto n2 = u2name.mid(u2name.startsWith('@') ? 1 : 0)
+#if QT_VERSION_MAJOR < 6
+        .toString() // Qt 5 doesn't have QStringView::localeAwareCompare
+#endif
+        ;
 
     return n1.localeAwareCompare(n2) < 0;
 }

--- a/lib/room.cpp
+++ b/lib/room.cpp
@@ -16,6 +16,9 @@
 #include "syncdata.h"
 #include "user.h"
 
+// NB: since Qt 6, moc_room.cpp needs User fully defined
+#include "moc_room.cpp"
+
 #include "csapi/account-data.h"
 #include "csapi/banning.h"
 #include "csapi/inviting.h"

--- a/lib/room.h
+++ b/lib/room.h
@@ -754,7 +754,7 @@ public:
     explicit MemberSorter(const Room* r) : room(r) {}
 
     bool operator()(User* u1, User* u2) const;
-    bool operator()(User* u1, const QString& u2name) const;
+    bool operator()(User* u1, QStringView u2name) const;
 
     template <typename ContT, typename ValT>
     typename ContT::size_type lowerBoundIndex(const ContT& c, const ValT& v) const

--- a/lib/settings.cpp
+++ b/lib/settings.cpp
@@ -21,7 +21,9 @@ void Settings::setLegacyNames(const QString& organizationName,
 
 Settings::Settings(QObject* parent) : QSettings(parent)
 {
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
     setIniCodec("UTF-8");
+#endif
 }
 
 void Settings::setValue(const QString& key, const QVariant& value)

--- a/lib/uri.cpp
+++ b/lib/uri.cpp
@@ -70,7 +70,7 @@ static QString pathSegment(const QUrl& url, int which)
         encodedPath(url).section('/', which, which).toUtf8());
 }
 
-static auto decodeFragmentPart(const QStringRef& part)
+static auto decodeFragmentPart(QStringView part)
 {
     return QUrl::fromPercentEncoding(part.toLatin1()).toUtf8();
 }
@@ -98,7 +98,7 @@ Uri::Uri(QUrl url) : QUrl(std::move(url))
     if (scheme() == "matrix") {
         // Check sanity as per https://github.com/matrix-org/matrix-doc/pull/2312
         const auto& urlPath = encodedPath(*this);
-        const auto& splitPath = urlPath.splitRef('/');
+        const auto& splitPath = urlPath.split('/');
         switch (splitPath.size()) {
         case 2:
             break;
@@ -128,9 +128,9 @@ Uri::Uri(QUrl url) : QUrl(std::move(url))
         // so force QUrl to decode everything.
         auto f = fragment(QUrl::EncodeUnicode);
         if (auto&& m = MatrixToUrlRE.match(f); m.hasMatch())
-            *this = Uri { decodeFragmentPart(m.capturedRef("main")),
-                          decodeFragmentPart(m.capturedRef("sec")),
-                          decodeFragmentPart(m.capturedRef("query")) };
+            *this = Uri { decodeFragmentPart(m.capturedView(u"main")),
+                          decodeFragmentPart(m.capturedView(u"sec")),
+                          decodeFragmentPart(m.capturedView(u"query")) };
     }
 }
 

--- a/lib/uri.cpp
+++ b/lib/uri.cpp
@@ -186,14 +186,18 @@ QString Uri::primaryId() const
     if (primaryType_ == Empty || primaryType_ == Invalid)
         return {};
 
-    const auto& idStem = pathSegment(*this, 1);
-    return idStem.isEmpty() ? idStem : primaryType_ + idStem;
+    auto idStem = pathSegment(*this, 1);
+    if (!idStem.isEmpty())
+        idStem.push_front(char(primaryType_));
+    return idStem;
 }
 
 QString Uri::secondaryId() const
 {
-    const auto& idStem = pathSegment(*this, 3);
-    return idStem.isEmpty() ? idStem : secondaryType() + idStem;
+    auto idStem = pathSegment(*this, 3);
+    if (!idStem.isEmpty())
+        idStem.push_front(char(secondaryType()));
+    return idStem;
 }
 
 static const auto ActionKey = QStringLiteral("action");

--- a/quotest/CMakeLists.txt
+++ b/quotest/CMakeLists.txt
@@ -5,7 +5,7 @@
 set(quotest_SRCS quotest.cpp)
 
 add_executable(quotest ${quotest_SRCS})
-target_link_libraries(quotest PRIVATE Qt5::Core Qt5::Test ${PROJECT_NAME})
+target_link_libraries(quotest PRIVATE ${Qt}::Core ${Qt}::Test ${PROJECT_NAME})
 
 option(${PROJECT_NAME}_INSTALL_TESTS "install quotest (former qmc-example) application" ON)
 add_feature_info(InstallQuotest ${PROJECT_NAME}_INSTALL_TESTS


### PR DESCRIPTION
This PR enables building either with Qt 5 (by default) or with Qt 6 (used when Qt 5 is not found, or when `BUILD_WITH_QT6` option is explicitly passed to CMake). For Qt 6, Qt 6.2 or later is required although the current 6.2 snapshot still doesn't have Qt Multimedia and therefore the relevant code in `roommessageevent.cpp` (the only place where the library uses Qt Multimedia) is disabled for Qt 6. CI will check Qt 6 for now as it makes little sence for the moment; once Qt 6.2 is released (presumably later this summer), it hopefully will be possible to provide Quotient support on par between Qt 5 and Qt 6.

Qt 6 support revealed a few shortcuts and even a bug in `EncryptionEvent`, which is why this code is worth merging into master instead of staying in a branch until Qt 6.2 is ready.

Closes #478.