### PR TITLE
Distinguish between read receipts and the fully read marker

### DIFF
--- a/lib/room.h
+++ b/lib/room.h
@@ -364,7 +364,7 @@ public:
     rev_iter_t readMarker(const User* user) const;
     rev_iter_t readMarker() const;
     QString readMarkerEventId() const;
-    QList<User*> usersAtEventId(const QString& eventId);
+    QSet<User*> usersAtEventId(const QString& eventId);
     /**
      * \brief Mark the event with uptoEventId as read
      *

--- a/lib/syncdata.cpp
+++ b/lib/syncdata.cpp
@@ -103,7 +103,7 @@ SyncData::SyncData(const QString& cacheFileName)
 {
     QFileInfo cacheFileInfo { cacheFileName };
     auto json = loadJson(cacheFileName);
-    auto requiredVersion = std::get<0>(cacheVersion());
+    auto requiredVersion = MajorCacheVersion;
     auto actualVersion =
         json.value("cache_version"_ls).toObject().value("major"_ls).toInt();
     if (actualVersion == requiredVersion)
@@ -127,6 +127,11 @@ Events&& SyncData::takePresenceData() { return std::move(presenceData); }
 Events&& SyncData::takeAccountData() { return std::move(accountData); }
 
 Events&& SyncData::takeToDeviceEvents() { return std::move(toDeviceEvents); }
+
+std::pair<int, int> SyncData::cacheVersion()
+{
+    return { MajorCacheVersion, 1 };
+}
 
 QJsonObject SyncData::loadJson(const QString& fileName)
 {

--- a/lib/syncdata.h
+++ b/lib/syncdata.h
@@ -87,7 +87,8 @@ public:
 
     QStringList unresolvedRooms() const { return unresolvedRoomIds; }
 
-    static std::pair<int, int> cacheVersion() { return { 11, 0 }; }
+    static constexpr int MajorCacheVersion = 11;
+    static std::pair<int, int> cacheVersion();
     static QString fileNameForRoom(QString roomId);
 
 private:


### PR DESCRIPTION
This brings in the changes already introduced in 0.6.x in response to #464, while also introducing a clearer `Room` API as #464 lays out:
- [x] `lastReadReceipt()` preempts `readMarker(User*)`, also returns the timestamp along with the event id; there's no shortcut to get a marker (the reverse iterator) as before - clients will have to wrap a `lastReadReceipt()` call into a `findInTimeline()` call if that's really needed.
- [x] `lastFullyReadEventId()` is the new name for `readMarkerEventId()`; the corresponding `Q_PROPERTY` is renamed as well.
- [x] `fullyReadMarker()` replaces `readMarker()`; `readMarkerMoved()` is `fullReadMarkerMoved()` now.
- [x] `readMarkerForUserMoved()` is going to go; `lastReadEventChanged()` (that existed prior) is emitted when read receipts arrive (for the local user as well though; client code will have to take account of that difference if it's important).
- [ ] `postReadReceipt(QString eventId)` to wrap what effectively is `callApi<PostReceiptJob>(roomId, eventId)`. In 0.6.x, this was done from `setLastDisplayedEvent()` in some poor-man heuristics - it's much better if clients decide when it's appropriate and which event it should be called on.
- [ ] `freshEventCount()` to match what's `unreadCount()` does but with a read receipt.
  - [ ] Expose in the API `isEventNotable()` that is internally used to count the number exposed by `unreadCount()`.

Closes #464.