### PR TITLE
Keep the reply when replacing an event

### DIFF
--- a/lib/room.cpp
+++ b/lib/room.cpp
@@ -2251,8 +2251,13 @@ bool Room::Private::processRedaction(const RedactionEvent& redaction)
 RoomEventPtr makeReplaced(const RoomEvent& target,
                           const RoomMessageEvent& replacement)
 {
+    const auto &targetReply = target.contentJson()["m.relates_to"].toObject();
+    auto newContent = replacement.contentJson().value("m.new_content"_ls).toObject();
+    if (!targetReply.empty()) {
+        newContent["m.relates_to"] = targetReply;
+    }
     auto originalJson = target.originalJsonObject();
-    originalJson[ContentKeyL] = replacement.contentJson().value("m.new_content"_ls);
+    originalJson[ContentKeyL] = newContent;
 
     auto unsignedData = originalJson.take(UnsignedKeyL).toObject();
     auto relations = unsignedData.take("m.relations"_ls).toObject();


### PR DESCRIPTION
This makes edited messages not loose the `m.relates_to` key, meaning that they will still be recognized as replies.
Honestly I have no idea if this is the best way to do this, since I'm still entirely confused by edits and replies and the combination of edits and replies