### PR TITLE
Add method to get all state events in a room

### DIFF
--- a/lib/room.cpp
+++ b/lib/room.cpp
@@ -224,9 +224,15 @@ public:
         return evt;
     }
 
-    const QHash<StateEventKey, const StateEventBase*> stateEvents() const
+    QVector<const StateEventBase*> stateEventsOfType(const QString& evtType) const
     {
-        return currentState;
+        QVector<const StateEventBase*> vals = QVector<const StateEventBase*>();
+        for (const auto* val : currentState) {
+            if (val->matrixType() == evtType) {
+                vals.append(val);
+            }
+        }
+        return vals;
     }
 
     template <typename EventT>
@@ -1298,9 +1304,15 @@ const StateEventBase* Room::getCurrentState(const QString& evtType,
     return d->getCurrentState({ evtType, stateKey });
 }
 
-const QHash<StateEventKey, const StateEventBase*> Room::stateEvents() const
+const QVector<const StateEventBase*>
+Room::stateEventsOfType(const QString& evtType) const
 {
-    return d->stateEvents();
+    return d->stateEventsOfType(evtType);
+}
+
+const QHash<StateEventKey, const StateEventBase*>& Room::currentState() const
+{
+    return d->currentState;
 }
 
 RoomEventPtr Room::decryptMessage(const EncryptedEvent& encryptedEvent)

--- a/lib/room.cpp
+++ b/lib/room.cpp
@@ -224,6 +224,11 @@ public:
         return evt;
     }
 
+    const QHash<StateEventKey, const StateEventBase*> stateEvents() const
+    {
+        return currentState;
+    }
+
     template <typename EventT>
     const EventT* getCurrentState(const QString& stateKey = {}) const
     {
@@ -1291,6 +1296,11 @@ const StateEventBase* Room::getCurrentState(const QString& evtType,
                                             const QString& stateKey) const
 {
     return d->getCurrentState({ evtType, stateKey });
+}
+
+const QHash<StateEventKey, const StateEventBase*> Room::stateEvents() const
+{
+    return d->stateEvents();
 }
 
 RoomEventPtr Room::decryptMessage(const EncryptedEvent& encryptedEvent)

--- a/lib/room.h
+++ b/lib/room.h
@@ -508,6 +508,12 @@ public:
     Q_INVOKABLE const Quotient::StateEventBase*
     getCurrentState(const QString& evtType, const QString& stateKey = {}) const;
 
+    /// Get all state events in the room.
+    /*! This method returns all known state events that have occured in
+     * the room, as a mapping from the event type and state key to value.
+     */
+    Q_INVOKABLE const QHash<StateEventKey, const StateEventBase*> stateEvents() const;
+
     /// Get a state event with the given event type and state key
     /*! This is a typesafe overload that accepts a C++ event type instead of
      * its Matrix name.

--- a/lib/room.h
+++ b/lib/room.h
@@ -512,7 +512,14 @@ public:
     /*! This method returns all known state events that have occured in
      * the room, as a mapping from the event type and state key to value.
      */
-    Q_INVOKABLE const QHash<StateEventKey, const StateEventBase*> stateEvents() const;
+    const QHash<StateEventKey, const StateEventBase*>& currentState() const;
+
+    /// Get all state events in the room of a certain type.
+    /*! This method returns all known state events that have occured in
+     * the room of the given type.
+     */
+    Q_INVOKABLE const QVector<const StateEventBase*>
+    stateEventsOfType(const QString& evtType) const;
 
     /// Get a state event with the given event type and state key
     /*! This is a typesafe overload that accepts a C++ event type instead of


### PR DESCRIPTION
It is useful to be able to get all of the state events that have occurred in a room, instead of needing to use `Room::getCurrentState`, which filters based on the event type and state key.

This is useful for implementing Spaces support, where all events of type `m.space.child` are needed, and we don't know their state keys in advance.