### PR TITLE
Better unread statistics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,8 @@ jobs:
       env:
         TEST_USER: ${{ secrets.TEST_USER }}
         TEST_PWD: ${{ secrets.TEST_PWD }}
+        QT_LOGGING_RULES: 'quotient.main.debug=true;quotient.jobs.debug=true'
+        QT_MESSAGE_PATTERN: '%{time h:mm:ss.zzz}|%{category}|%{if-debug}D%{endif}%{if-info}I%{endif}%{if-warning}W%{endif}%{if-critical}C%{endif}%{if-fatal}F%{endif}|%{message}'
       run: |
         [[ -z "$TEST_USER" ]] || $VALGRIND build/quotest/quotest "$TEST_USER" "$TEST_PWD" quotest-gha '#quotest:matrix.org' "$QUOTEST_ORIGIN"
       timeout-minutes: 5 # quotest is supposed to finish within 3 minutes, actually

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,7 @@ list(APPEND lib_SRCS
     lib/avatar.cpp
     lib/uri.cpp
     lib/uriresolver.cpp
+    lib/eventstats.cpp
     lib/syncdata.cpp
     lib/settings.cpp
     lib/networksettings.cpp

--- a/lib/eventstats.cpp
+++ b/lib/eventstats.cpp
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: 2021 Quotient contributors
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "eventstats.h"
+
+using namespace Quotient;
+
+EventStats EventStats::fromRange(const Room* room, const Room::rev_iter_t& from,
+                                 const Room::rev_iter_t& to,
+                                 const EventStats& init)
+{
+    Q_ASSERT(to <= room->historyEdge());
+    Q_ASSERT(from >= Room::rev_iter_t(room->syncEdge()));
+    Q_ASSERT(from <= to);
+    QElapsedTimer et;
+    et.start();
+    const auto result =
+        accumulate(from, to, init,
+                   [room](EventStats acc, const TimelineItem& ti) {
+                       acc.notableCount += room->isEventNotable(ti);
+                       acc.highlightCount += room->notificationFor(ti).type
+                                             == Notification::Highlight;
+                       return acc;
+                   });
+    if (et.nsecsElapsed() > profilerMinNsecs() / 10)
+        qCDebug(PROFILER).nospace()
+            << "Event statistics collection over index range [" << from->index()
+            << "," << (to - 1)->index() << "] took " << et;
+    return result;
+}
+
+EventStats EventStats::fromMarker(const Room* room,
+                                  const EventStats::marker_t& marker)
+{
+    const auto s = fromRange(room, marker_t(room->syncEdge()), marker,
+                             { 0, 0, marker == room->historyEdge() });
+    Q_ASSERT(s.isValidFor(room, marker));
+    return s;
+}
+
+EventStats EventStats::fromCachedCounters(Omittable<int> notableCount,
+                                          Omittable<int> highlightCount)
+{
+    const auto hCount = std::max(0, highlightCount.value_or(0));
+    if (!notableCount.has_value())
+        return { 0, hCount, true };
+    auto nCount = notableCount.value_or(0);
+    return { std::max(0, nCount), hCount, nCount != -1 };
+}
+
+bool EventStats::updateOnMarkerMove(const Room* room, const marker_t& oldMarker,
+                                    const marker_t& newMarker)
+{
+    if (newMarker == oldMarker)
+        return false;
+
+    // Double-check consistency between the old marker and the old stats
+    Q_ASSERT(isValidFor(room, oldMarker));
+    Q_ASSERT(oldMarker > newMarker);
+
+    // A bit of optimisation: only calculate the difference if the marker moved
+    // less than half the remaining timeline ahead; otherwise, recalculation
+    // over the remaining timeline will very likely be faster.
+    if (oldMarker != room->historyEdge()
+        && oldMarker - newMarker < newMarker - marker_t(room->syncEdge())) {
+        const auto removedStats = fromRange(room, newMarker, oldMarker);
+        Q_ASSERT(notableCount >= removedStats.notableCount
+                 && highlightCount >= removedStats.highlightCount);
+        notableCount -= removedStats.notableCount;
+        highlightCount -= removedStats.highlightCount;
+        return removedStats.notableCount > 0 || removedStats.highlightCount > 0;
+    }
+
+    const auto newStats = EventStats::fromMarker(room, newMarker);
+    if (!isEstimate && newStats == *this)
+        return false;
+    *this = newStats;
+    return true;
+}
+
+bool EventStats::isValidFor(const Room* room, const marker_t& marker) const
+{
+    const auto markerAtHistoryEdge = marker == room->historyEdge();
+    // Either markerAtHistoryEdge and isEstimate are in the same state, or it's
+    // a special case of no notable events and the marker at history edge
+    // (then isEstimate can assume any value).
+    return markerAtHistoryEdge == isEstimate
+           || (markerAtHistoryEdge && notableCount == 0);
+}
+
+QDebug Quotient::operator<<(QDebug dbg, const EventStats& es)
+{
+    QDebugStateSaver _(dbg);
+    dbg.nospace() << es.notableCount << '/' << es.highlightCount;
+    if (es.isEstimate)
+        dbg << " (estimated)";
+    return dbg;
+}

--- a/lib/eventstats.h
+++ b/lib/eventstats.h
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: 2021 Quotient contributors
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include "room.h"
+
+namespace Quotient {
+
+//! \brief Counters of unread events and highlights with a precision flag
+//!
+//! This structure contains a static snapshot with values of unread counters
+//! returned by Room::partiallyReadStats and Room::unreadStats (properties
+//! or methods).
+//!
+//! \note It's just a simple grouping of counters and is not automatically
+//! updated from the room as subsequent syncs arrive.
+//! \sa Room::unreadStats, Room::partiallyReadStats, Room::isEventNotable
+struct EventStats {
+    Q_GADGET
+    Q_PROPERTY(qsizetype notableCount MEMBER notableCount CONSTANT)
+    Q_PROPERTY(qsizetype highlightCount MEMBER highlightCount CONSTANT)
+    Q_PROPERTY(bool isEstimate MEMBER isEstimate CONSTANT)
+public:
+    //! The number of "notable" events in an events range
+    //! \sa Room::isEventNotable
+    qsizetype notableCount = 0;
+    qsizetype highlightCount = 0;
+    //! \brief Whether the counter values above are exact
+    //!
+    //! This is false when the end marker (m.read receipt or m.fully_read) used
+    //! to collect the stats points to an event loaded locally and the counters
+    //! can therefore be calculated exactly using the locally available segment
+    //! of the timeline; true when the marker points to an event outside of
+    //! the local timeline (in which case the estimation is made basing on
+    //! the data supplied by the homeserver as well as counters saved from
+    //! the previous run of the client).
+    bool isEstimate = true;
+
+    bool operator==(const EventStats& rhs) const& = default;
+
+    //! \brief Check whether the event statistics are empty
+    //!
+    //! Empty statistics have notable and highlight counters of zero and
+    //! isEstimate set to false.
+    Q_INVOKABLE bool empty() const
+    {
+        return notableCount == 0 && !isEstimate && highlightCount == 0;
+    }
+
+    using marker_t = Room::rev_iter_t;
+
+    //! \brief Build event statistics on a range of events
+    //!
+    //! This is a factory that returns an EventStats instance with counts of
+    //! notable and highlighted events between \p from and \p to reverse
+    //! timeline iterators; the \p init parameter allows to override
+    //! the initial statistics object and start from other values.
+    static EventStats fromRange(const Room* room, const marker_t& from,
+                                const marker_t& to,
+                                const EventStats& init = { 0, 0, false });
+
+    //! \brief Build event statistics on a range from sync edge to marker
+    //!
+    //! This is mainly a shortcut for \code
+    //! <tt>fromRange(room, marker_t(room->syncEdge()), marker)</tt>
+    //! \endcode except that it also sets isEstimate to true if (and only if)
+    //! <tt>to == room->historyEdge()</tt>.
+    static EventStats fromMarker(const Room* room, const marker_t& marker);
+
+    //! \brief Loads a statistics object from the cached counters
+    //!
+    //! Sets isEstimate to `true` unless both notableCount and highlightCount
+    //! are equal to -1.
+    static EventStats fromCachedCounters(Omittable<int> notableCount,
+                                         Omittable<int> highlightCount = none);
+
+    //! \brief Update statistics when a read marker moves down the timeline
+    //!
+    //! Removes events between oldMarker and newMarker from statistics
+    //! calculation if \p oldMarker points to an existing event in the timeline,
+    //! or recalculates the statistics entirely if \p oldMarker points
+    //! to <tt>room->historyEdge()</tt>. Always results in exact statistics
+    //! (<tt>isEstimate == false</tt>.
+    //! \param oldMarker Must point correspond to the _current_ statistics
+    //!        isEstimate state, i.e. it should point to
+    //!        <tt>room->historyEdge()</tt> if <tt>isEstimate == true</tt>, or
+    //!        to a valid position within the timeline otherwise
+    //! \param newMarker Must point to a valid position in the timeline (not to
+    //!        <tt>room->historyEdge()</tt> that is equal to or closer to
+    //!        the sync edge than \p oldMarker
+    //! \return true if either notableCount or highlightCount changed, or if
+    //!         the statistics was completely recalculated; false otherwise
+    bool updateOnMarkerMove(const Room* room, const marker_t& oldMarker,
+                            const marker_t& newMarker);
+
+    //! \brief Validate the statistics object against the given marker
+    //!
+    //! Checks whether the statistics object data are valid for a given marker.
+    //! No stats recalculation takes place, only isEstimate and zero-ness
+    //! of notableCount are checked.
+    bool isValidFor(const Room* room, const marker_t& marker) const;
+};
+
+QDebug operator<<(QDebug dbg, const EventStats& es);
+
+}

--- a/lib/eventstats.h
+++ b/lib/eventstats.h
@@ -37,7 +37,14 @@ public:
     //! the previous run of the client).
     bool isEstimate = true;
 
-    bool operator==(const EventStats& rhs) const& = default;
+    // TODO: replace with = default once C++20 becomes a requirement on clients
+    bool operator==(const EventStats& rhs) const
+    {
+        return notableCount == rhs.notableCount
+               && highlightCount == rhs.highlightCount
+               && isEstimate == rhs.isEstimate;
+    }
+    bool operator!=(const EventStats& rhs) const { return !operator==(rhs); }
 
     //! \brief Check whether the event statistics are empty
     //!

--- a/lib/room.cpp
+++ b/lib/room.cpp
@@ -736,7 +736,7 @@ Room::Changes Room::Private::updateStats(const rev_iter_t& from,
             qCDebug(MESSAGES).nospace()
                     << "Recalculated partially read event statistics in "
                     << q->objectName() << ": " << partiallyReadStats;
-            return Change::PartiallyReadStats | Change::UnreadStats;
+            return changes | Change::PartiallyReadStats;
         }
     }
 
@@ -748,7 +748,7 @@ Room::Changes Room::Private::updateStats(const rev_iter_t& from,
 
     const auto newStats = EventStats::fromRange(q, from, to);
     Q_ASSERT(!newStats.isEstimate);
-    if (newStats.notableCount == 0 || newStats.highlightCount == 0)
+    if (newStats.empty())
         return changes;
 
     const auto doAddStats = [this, &changes, newStats](EventStats& s,

--- a/lib/room.cpp
+++ b/lib/room.cpp
@@ -1814,7 +1814,11 @@ void Room::Private::postprocessChanges(Changes changes, bool saveState)
     if (changes & Change::Highlights)
         emit q->highlightCountChanged();
 
-    qCDebug(MAIN) << terse << changes << "in" << q->objectName();
+    qCDebug(MAIN) << terse << changes << "= hex" <<
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+        Qt::
+#endif
+            hex << uint(changes) << "in" << q->objectName();
     emit q->changed(changes);
     if (saveState)
         connection->saveRoomState(q);

--- a/lib/room.h
+++ b/lib/room.h
@@ -492,7 +492,7 @@ public:
     //! the current m.fully_read marker or is not loaded, to prevent
     //! accidentally trying to move the marker back in the timeline.
     //! \sa markAllMessagesAsRead, fullyReadMarker
-    Q_INVOKABLE void markMessagesAsRead(QString uptoEventId);
+    Q_INVOKABLE void markMessagesAsRead(const QString& uptoEventId);
 
     //! \brief Determine whether an event should be counted as unread
     //!

--- a/lib/room.h
+++ b/lib/room.h
@@ -149,10 +149,10 @@ class Room : public QObject {
     Q_PROPERTY(bool hasUnreadMessages READ hasUnreadMessages NOTIFY
                    unreadMessagesChanged STORED false)
     Q_PROPERTY(int unreadCount READ unreadCount NOTIFY unreadMessagesChanged)
-    Q_PROPERTY(int highlightCount READ highlightCount NOTIFY
-                   highlightCountChanged RESET resetHighlightCount)
-    Q_PROPERTY(int notificationCount READ notificationCount NOTIFY
-                   notificationCountChanged RESET resetNotificationCount)
+    Q_PROPERTY(qsizetype highlightCount READ highlightCount
+                   NOTIFY highlightCountChanged)
+    Q_PROPERTY(qsizetype notificationCount READ notificationCount
+                   NOTIFY notificationCountChanged)
     Q_PROPERTY(bool allHistoryLoaded READ allHistoryLoaded NOTIFY addedMessages
                    STORED false)
     Q_PROPERTY(QStringList tagNames READ tagNames NOTIFY tagsChanged)
@@ -538,9 +538,21 @@ public:
      */
     int unreadCount() const;
 
-    Q_INVOKABLE int notificationCount() const;
+    //! \brief Get the number of notifications since the last read receipt
+    //!
+    //! \sa lastLocalReadReceipt
+    qsizetype notificationCount() const;
+
+    //! \deprecated Use setReadReceipt() to drive changes in notification count
     Q_INVOKABLE void resetNotificationCount();
-    Q_INVOKABLE int highlightCount() const;
+
+    //! \brief Get the number of highlights since the last read receipt
+    //!
+    //! As of 0.7, this is defined by the homeserver as Quotient doesn't process
+    //! push rules.
+    qsizetype highlightCount() const;
+
+    //! \deprecated Use setReadReceipt() to drive changes in highlightCount
     Q_INVOKABLE void resetHighlightCount();
 
     /** Check whether the room has account data of the given type

--- a/lib/room.h
+++ b/lib/room.h
@@ -176,28 +176,45 @@ public:
     using rev_iter_t = Timeline::const_reverse_iterator;
     using timeline_iter_t = Timeline::const_iterator;
 
+    //! \brief Room changes that can be tracked using Room::changed() signal
+    //!
+    //! This enumeration lists kinds of changes that can be tracked with
+    //! a "cumulative" changed() signal instead of using individual signals for
+    //! each change. Specific enumerators mention these individual signals.
+    //! \sa changed
     enum class Change : uint {
-        None = 0x0,
-        Name = 0x1,
-        Aliases = 0x2,
+        None = 0x0, //< No changes occurred in the room
+        Name = 0x1, //< \sa namesChanged, displaynameChanged
+        Aliases = 0x2, //< \sa namesChanged, displaynameChanged
         CanonicalAlias = Aliases,
-        Topic = 0x4,
-        PartiallyReadStats = 0x8,
+        Topic = 0x4, //< \sa topicChanged
+        PartiallyReadStats = 0x8, //< \sa partiallyReadStatsChanged
         DECL_DEPRECATED_ENUMERATOR(UnreadNotifs, PartiallyReadStats),
-        Avatar = 0x10,
-        JoinState = 0x20,
-        Tags = 0x40,
+        Avatar = 0x10, //< \sa avatarChanged
+        JoinState = 0x20, //< \sa joinStateChanged
+        Tags = 0x40, //< \sa tagsChanged
+        //! \sa userAdded, userRemoved, memberRenamed, memberListChanged,
+        //!     displaynameChanged
         Members = 0x80,
-        UnreadStats = 0x100,
+        UnreadStats = 0x100, //< \sa unreadStatsChanged
         AccountData Q_DECL_ENUMERATOR_DEPRECATED_X(
             "Change::AccountData will be merged into Change::Other in 0.8") =
             0x200,
-        Summary = 0x400,
+        Summary = 0x400, //< \sa summaryChanged, displaynameChanged
         ReadMarker Q_DECL_ENUMERATOR_DEPRECATED_X(
             "Change::ReadMarker will be merged into Change::Other in 0.8") =
             0x800,
-        Highlights = 0x1000,
+        Highlights = 0x1000, //< \sa highlightCountChanged
+        //! A catch-all value that covers changes not listed above (such as
+        //! encryption turned on or the room having been upgraded), as well as
+        //! changes in the room state that the library is not aware of (e.g.,
+        //! custom state events) and m.read/m.fully_read position changes.
+        //! \sa encryptionChanged, upgraded, accountDataChanged
         Other = 0x8000,
+        //! This is intended to test a Change/Changes value for non-emptiness;
+        //! testFlag(Change::Any) or adding <tt>& Change::Any</tt> has
+        //! the same meaning as !testFlag(Change::None) or adding
+        //! <tt>!= Change::None</tt>.
         Any = 0xFFFF
     };
     QUO_DECLARE_FLAGS(Changes, Change)
@@ -931,12 +948,14 @@ Q_SIGNALS:
                           Quotient::JoinState newState);
     void typingChanged();
 
-    void highlightCountChanged();
-    void notificationCountChanged();
+    void highlightCountChanged(); //< \sa highlightCount
+    void notificationCountChanged(); //< \sa notificationCount
 
     void displayedChanged(bool displayed);
     void firstDisplayedEventChanged();
     void lastDisplayedEventChanged();
+    //! The event that m.read receipt points to has changed
+    //! \sa lastReadReceipt
     void lastReadEventChanged(Quotient::User* user);
     void fullyReadMarkerMoved(QString fromEventId, QString toEventId);
     //! \deprecated since 0.7 - use fullyReadMarkerMoved

--- a/lib/syncdata.h
+++ b/lib/syncdata.h
@@ -8,6 +8,12 @@
 #include "events/stateevent.h"
 
 namespace Quotient {
+
+constexpr auto UnreadNotificationsKey = "unread_notifications"_ls;
+constexpr auto PartiallyReadCountKey = "x-quotient.since_fully_read_count"_ls;
+constexpr auto NewUnreadCountKey = "org.matrix.msc2654.unread_count"_ls;
+constexpr auto HighlightCountKey = "highlight_count"_ls;
+
 /// Room summary, as defined in MSC688
 /**
  * Every member of this structure is an Omittable; as per the MSC, only
@@ -29,7 +35,6 @@ struct RoomSummary {
 };
 QDebug operator<<(QDebug dbg, const RoomSummary& rs);
 
-
 template <>
 struct JsonObjectConverter<RoomSummary> {
     static void dumpTo(QJsonObject& jo, const RoomSummary& rs);
@@ -48,16 +53,14 @@ public:
 
     bool timelineLimited;
     QString timelinePrevBatch;
+    Omittable<int> partiallyReadCount;
     Omittable<int> unreadCount;
     Omittable<int> highlightCount;
-    Omittable<int> notificationCount;
 
-    SyncRoomData(const QString& roomId, JoinState joinState_,
-                 const QJsonObject& room_);
+    SyncRoomData(QString roomId, JoinState joinState,
+                 const QJsonObject& roomJson);
     SyncRoomData(SyncRoomData&&) = default;
     SyncRoomData& operator=(SyncRoomData&&) = default;
-
-    static const QString UnreadCountKey;
 };
 
 // QVector cannot work with non-copyable objects, std::vector can.


### PR DESCRIPTION
This makes it possible to count unread events and lays down the framework to do the same for highlights - both since `m.read` (along the lines of [MSC2654](https://github.com/matrix-org/matrix-doc/pull/2654)) and since `m.fully_read`. `Room::isEventNotable()` and `Room::checkForNotifications()` are virtual, allowing to extend and even override the behaviour. `Room::partiallyReadStats()` and `Room::unreadStats()` return values of a newly introduced `EventStats` class that is supposed to be suitable for consumption in QML.

A nice side effect of this work is making `Room::changed()` signal more systematic, with the intention to provide client room list models with a single point to connect to in order to refresh on room changes. Previously one had to connect to the whole array of signals, ultimately to only `emit dataChanged()` to refresh a line item.

Closes #204. Closes #516.