### PR TITLE
Simplify event factories

### DIFF
--- a/lib/events/eventloader.h
+++ b/lib/events/eventloader.h
@@ -6,16 +6,6 @@
 #include "stateevent.h"
 
 namespace Quotient {
-namespace _impl {
-    template <typename BaseEventT>
-    static inline auto loadEvent(const QJsonObject& json,
-                                 const QString& matrixType)
-    {
-        if (auto e = EventFactory<BaseEventT>::make(json, matrixType))
-            return e;
-        return makeEvent<BaseEventT>(unknownEventTypeId(), json);
-    }
-} // namespace _impl
 
 /*! Create an event with proper type from a JSON object
  *
@@ -26,7 +16,7 @@ namespace _impl {
 template <typename BaseEventT>
 inline event_ptr_tt<BaseEventT> loadEvent(const QJsonObject& fullJson)
 {
-    return _impl::loadEvent<BaseEventT>(fullJson, fullJson[TypeKeyL].toString());
+    return doLoadEvent<BaseEventT>(fullJson, fullJson[TypeKeyL].toString());
 }
 
 /*! Create an event from a type string and content JSON
@@ -39,8 +29,8 @@ template <typename BaseEventT>
 inline event_ptr_tt<BaseEventT> loadEvent(const QString& matrixType,
                                           const QJsonObject& content)
 {
-    return _impl::loadEvent<BaseEventT>(basicEventJson(matrixType, content),
-                                        matrixType);
+    return doLoadEvent<BaseEventT>(basicEventJson(matrixType, content),
+                                   matrixType);
 }
 
 /*! Create a state event from a type string, content JSON and state key
@@ -53,7 +43,7 @@ inline StateEventPtr loadStateEvent(const QString& matrixType,
                                     const QJsonObject& content,
                                     const QString& stateKey = {})
 {
-    return _impl::loadEvent<StateEventBase>(
+    return doLoadEvent<StateEventBase>(
         basicStateEventJson(matrixType, content, stateKey), matrixType);
 }
 

--- a/lib/events/roomevent.cpp
+++ b/lib/events/roomevent.cpp
@@ -9,9 +9,6 @@
 
 using namespace Quotient;
 
-[[maybe_unused]] static auto roomEventTypeInitialised =
-    Event::factory_t::chainFactory<RoomEvent>();
-
 RoomEvent::RoomEvent(Type type, event_mtype_t matrixType,
                      const QJsonObject& contentJson)
     : Event(type, matrixType, contentJson)

--- a/lib/events/roomevent.h
+++ b/lib/events/roomevent.h
@@ -13,7 +13,7 @@ class RedactionEvent;
 /** This class corresponds to m.room.* events */
 class RoomEvent : public Event {
 public:
-    using factory_t = EventFactory<RoomEvent>;
+    static inline _impl::EventFactory<RoomEvent> factory { "RoomEvent" };
 
     // RedactionEvent is an incomplete type here so we cannot inline
     // constructors and destructors and we cannot use 'using'.

--- a/lib/events/roommemberevent.h
+++ b/lib/events/roommemberevent.h
@@ -49,16 +49,15 @@ public:
                      std::forward<ArgTs>(contentArgs)...)
     {}
 
-    /// A special constructor to create unknown RoomMemberEvents
-    /**
-     * This is needed in order to use RoomMemberEvent as a "base event
-     * class" in cases like GetMembersByRoomJob when RoomMemberEvents
-     * (rather than RoomEvents or StateEvents) are resolved from JSON.
-     * For such cases loadEvent<> requires an underlying class to be
-     * constructible with unknownTypeId() instead of its genuine id.
-     * Don't use it directly.
-     * \sa GetMembersByRoomJob, loadEvent, unknownTypeId
-     */
+    //! \brief A special constructor to create unknown RoomMemberEvents
+    //!
+    //! This is needed in order to use RoomMemberEvent as a "base event class"
+    //! in cases like GetMembersByRoomJob when RoomMemberEvents (rather than
+    //! RoomEvents or StateEvents) are resolved from JSON. For such cases
+    //! loadEvent\<> requires an underlying class to have a specialisation of
+    //! EventFactory\<> and be constructible with unknownTypeId() instead of
+    //! its genuine id. Don't use directly.
+    //! \sa EventFactory, loadEvent, GetMembersByRoomJob
     RoomMemberEvent(Type type, const QJsonObject& fullJson)
         : StateEvent(type, fullJson)
     {}
@@ -89,14 +88,13 @@ public:
 };
 
 template <>
-class EventFactory<RoomMemberEvent> {
-public:
-    static event_ptr_tt<RoomMemberEvent> make(const QJsonObject& json,
-                                              const QString&)
-    {
+inline event_ptr_tt<RoomMemberEvent>
+doLoadEvent<RoomMemberEvent>(const QJsonObject& json, const QString& matrixType)
+{
+    if (matrixType == QLatin1String(RoomMemberEvent::matrixTypeId()))
         return makeEvent<RoomMemberEvent>(json);
-    }
-};
+    return makeEvent<RoomMemberEvent>(unknownEventTypeId(), json);
+}
 
 REGISTER_EVENT_TYPE(RoomMemberEvent)
 } // namespace Quotient

--- a/lib/events/stateevent.cpp
+++ b/lib/events/stateevent.cpp
@@ -5,6 +5,14 @@
 
 using namespace Quotient;
 
+StateEventBase::StateEventBase(Type type, const QJsonObject& json)
+    : RoomEvent(json.contains(StateKeyKeyL) ? type : unknownEventTypeId(), json)
+{
+    if (Event::type() == unknownEventTypeId() && !json.contains(StateKeyKeyL))
+        qWarning(EVENTS) << "Attempt to create a state event with no stateKey -"
+                            "forcing the event type to unknown to avoid damage";
+}
+
 StateEventBase::StateEventBase(Event::Type type, event_mtype_t matrixType,
                                const QString& stateKey,
                                const QJsonObject& contentJson)

--- a/lib/events/stateevent.cpp
+++ b/lib/events/stateevent.cpp
@@ -5,21 +5,6 @@
 
 using namespace Quotient;
 
-// Aside from the normal factory to instantiate StateEventBase inheritors
-// StateEventBase itself can be instantiated if there's a state_key JSON key
-// but the event type is unknown.
-[[maybe_unused]] static auto stateEventTypeInitialised =
-    RoomEvent::factory_t::addMethod(
-        [](const QJsonObject& json, const QString& matrixType) -> StateEventPtr {
-            if (!json.contains(StateKeyKeyL))
-                return nullptr;
-
-            if (auto e = StateEventBase::factory_t::make(json, matrixType))
-                return e;
-
-            return makeEvent<StateEventBase>(unknownEventTypeId(), json);
-        });
-
 StateEventBase::StateEventBase(Event::Type type, event_mtype_t matrixType,
                                const QString& stateKey,
                                const QJsonObject& contentJson)

--- a/lib/events/stateevent.h
+++ b/lib/events/stateevent.h
@@ -21,8 +21,7 @@ class StateEventBase : public RoomEvent {
 public:
     static inline _impl::EventFactory<StateEventBase> factory { "StateEvent" };
 
-    StateEventBase(Type type, const QJsonObject& json) : RoomEvent(type, json)
-    {}
+    StateEventBase(Type type, const QJsonObject& json);
     StateEventBase(Type type, event_mtype_t matrixType,
                    const QString& stateKey = {},
                    const QJsonObject& contentJson = {});


### PR DESCRIPTION
This is the first path of streamlining and simplifying the code in `event.h`. The centerpiece here is 231c4d7 (see also its commit message for details).