### PR TITLE
Use GNUInstallDirs also on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,22 +49,9 @@ else()
     endforeach ()
 endif()
 
-if (WIN32)
-    if (NOT CMAKE_INSTALL_LIBDIR)
-        set(CMAKE_INSTALL_LIBDIR ".")
-    endif ()
+include(GNUInstallDirs)
+set(INCLUDEDIR_INIT ${PROJECT_NAME})
 
-    if (NOT CMAKE_INSTALL_BINDIR)
-        set(CMAKE_INSTALL_BINDIR ".")
-    endif ()
-
-    if (NOT CMAKE_INSTALL_INCLUDEDIR)
-        set(CMAKE_INSTALL_INCLUDEDIR "include")
-    endif ()
-else()
-    include(GNUInstallDirs)
-    set(INCLUDEDIR_INIT ${PROJECT_NAME})
-endif(WIN32)
 set(${PROJECT_NAME}_INSTALL_INCLUDEDIR
         "${CMAKE_INSTALL_INCLUDEDIR}/${INCLUDEDIR_INIT}" CACHE PATH
         "directory to install ${PROJECT_NAME} include files to")


### PR DESCRIPTION
Despite the name GNUInstallDirs also produces the correct results on Windows, there's no real need for special casing