### PR TITLE
Use QOlmMessage::Type in more places

### DIFF
--- a/lib/connection.cpp
+++ b/lib/connection.cpp
@@ -274,10 +274,10 @@ public:
         QString decrypted;
         int type = personalCipherObject.value(TypeKeyL).toInt(-1);
         QByteArray body = personalCipherObject.value(BodyKeyL).toString().toLatin1();
-        if (type == 0) {
+        if (type == QOlmMessage::PreKey) {
             QOlmMessage preKeyMessage(body, QOlmMessage::PreKey);
             decrypted = sessionDecryptPrekey(preKeyMessage, senderKey, account);
-        } else if (type == 1) {
+        } else if (type == QOlmMessage::General) {
             QOlmMessage message(body, QOlmMessage::General);
             decrypted = sessionDecryptGeneral(message, senderKey);
         }

--- a/lib/e2ee/qolmmessage.h
+++ b/lib/e2ee/qolmmessage.h
@@ -22,8 +22,8 @@ class QUOTIENT_API QOlmMessage : public QByteArray {
     Q_GADGET
 public:
     enum Type {
+        PreKey = 0,
         General,
-        PreKey,
     };
     Q_ENUM(Type)
 


### PR DESCRIPTION
Make sure that the enum values correspond to the values used in the spec
and use them instead of magic constants