### PR TITLE
Check that decrypted events are for the current room

### DIFF
--- a/lib/room.cpp
+++ b/lib/room.cpp
@@ -1487,7 +1487,13 @@ RoomEventPtr Room::decryptMessage(const EncryptedEvent& encryptedEvent)
         // qCWarning(E2EE) << "Encrypted message is empty";
         return {};
     }
-    return encryptedEvent.createDecrypted(decrypted);
+    auto decryptedEvent = encryptedEvent.createDecrypted(decrypted);
+    if (decryptedEvent->roomId() == id()) {
+        return decryptedEvent;
+    } else {
+        qCWarning(E2EE) << "Decrypted event" << encryptedEvent.id() << "not for this room; discarding.";
+        return nullptr;
+    }
 #endif // Quotient_E2EE_ENABLED
 }
 

--- a/lib/room.cpp
+++ b/lib/room.cpp
@@ -1490,10 +1490,9 @@ RoomEventPtr Room::decryptMessage(const EncryptedEvent& encryptedEvent)
     auto decryptedEvent = encryptedEvent.createDecrypted(decrypted);
     if (decryptedEvent->roomId() == id()) {
         return decryptedEvent;
-    } else {
-        qCWarning(E2EE) << "Decrypted event" << encryptedEvent.id() << "not for this room; discarding.";
-        return nullptr;
     }
+    qCWarning(E2EE) << "Decrypted event" << encryptedEvent.id() << "not for this room; discarding.";
+    return {};
 #endif // Quotient_E2EE_ENABLED
 }
 


### PR DESCRIPTION
In the future we should probably set some flag that the event wasn't decrypted because it is fishy, but for now this is good enough.
All current consumers of this function check if the returned event is null.