### PR TITLE
Make it easier to create a dummy connection for unit testing

### DIFF
--- a/lib/connection.cpp
+++ b/lib/connection.cpp
@@ -615,6 +615,16 @@ void Connection::Private::completeSetup(const QString& mxId)
     q->reloadCapabilities();
 }
 
+void Connection::setupDummyConnection(const QString &mixd, const QString &deviceId, const QUrl &homeserver)
+{
+	d->data->setUserId(mixd);
+	d->data->setDeviceId(deviceId);
+	setHomeserver(homeserver);
+    user(d->data->userId()); // Creates a User object for the local user
+    d->database = new Database(d->data->userId(), d->data->deviceId(), this);
+    d->olmAccount = std::make_unique<QOlmAccount>(d->data->userId(), d->data->deviceId(), this);
+}
+
 void Connection::Private::checkAndConnect(const QString& userId,
                                           const std::function<void()>& connectFn,
                                           const std::optional<LoginFlow>& flow)

--- a/lib/connection.h
+++ b/lib/connection.h
@@ -500,6 +500,9 @@ public:
     /// Saves the olm account data to disk. Usually doesn't need to be called manually.
     void saveOlmAccount();
 
+    /// This api can be used by clients to create unit tests
+    void setupDummyConnection(const QString &mixd, const QString &deviceId, const QUrl &homeserver);
+
 public Q_SLOTS:
     /// \brief Set the homeserver base URL and retrieve its login flows
     ///


### PR DESCRIPTION
This just make sure that the database and old account are setup when
using the connection class.