### PR TITLE
Truncate ciphertext buffer to actual size during file encryption

### DIFF
--- a/autotests/testfilecrypto.cpp
+++ b/autotests/testfilecrypto.cpp
@@ -12,6 +12,8 @@ void TestFileCrypto::encryptDecryptData()
     QByteArray data = "ABCDEF";
     auto [file, cipherText] = EncryptedFile::encryptFile(data);
     auto decrypted = file.decryptFile(cipherText);
-    QCOMPARE(data, decrypted);
+    QCOMPARE(cipherText.size(), data.size());
+    QCOMPARE(decrypted.size(), data.size());
+    QCOMPARE(decrypted, data);
 }
 QTEST_APPLESS_MAIN(TestFileCrypto)

--- a/autotests/testfilecrypto.cpp
+++ b/autotests/testfilecrypto.cpp
@@ -12,6 +12,7 @@ void TestFileCrypto::encryptDecryptData()
     QByteArray data = "ABCDEF";
     auto [file, cipherText] = EncryptedFile::encryptFile(data);
     auto decrypted = file.decryptFile(cipherText);
+    // AES CTR produces ciphertext of the same size as the original
     QCOMPARE(cipherText.size(), data.size());
     QCOMPARE(decrypted.size(), data.size());
     QCOMPARE(decrypted, data);

--- a/lib/events/encryptedfile.cpp
+++ b/lib/events/encryptedfile.cpp
@@ -67,6 +67,7 @@ std::pair<EncryptedFile, QByteArray> EncryptedFile::encryptFile(const QByteArray
     QByteArray cipherText(plainText.size() + EVP_MAX_BLOCK_LENGTH - 1, '\0');
     EVP_EncryptInit_ex(ctx, EVP_aes_256_ctr(), nullptr, reinterpret_cast<const unsigned char*>(k.data()),reinterpret_cast<const unsigned char*>(iv.data()));
     EVP_EncryptUpdate(ctx, reinterpret_cast<unsigned char*>(cipherText.data()), &length, reinterpret_cast<const unsigned char*>(plainText.data()), plainText.size());
+    cipherText.resize(length);
     EVP_EncryptFinal_ex(ctx, reinterpret_cast<unsigned char*>(cipherText.data()) + length, &length);
     EVP_CIPHER_CTX_free(ctx);
 

--- a/lib/events/encryptedfile.cpp
+++ b/lib/events/encryptedfile.cpp
@@ -64,10 +64,10 @@ std::pair<EncryptedFile, QByteArray> EncryptedFile::encryptFile(const QByteArray
 
     int length;
     auto* ctx = EVP_CIPHER_CTX_new();
-    QByteArray cipherText(plainText.size() + EVP_MAX_BLOCK_LENGTH - 1, '\0');
     EVP_EncryptInit_ex(ctx, EVP_aes_256_ctr(), nullptr, reinterpret_cast<const unsigned char*>(k.data()),reinterpret_cast<const unsigned char*>(iv.data()));
+    const auto blockSize = EVP_CIPHER_CTX_block_size(ctx);
+    QByteArray cipherText(plainText.size() + blockSize - 1, '\0');
     EVP_EncryptUpdate(ctx, reinterpret_cast<unsigned char*>(cipherText.data()), &length, reinterpret_cast<const unsigned char*>(plainText.data()), plainText.size());
-    cipherText.resize(length);
     EVP_EncryptFinal_ex(ctx, reinterpret_cast<unsigned char*>(cipherText.data()) + length, &length);
     EVP_CIPHER_CTX_free(ctx);
 


### PR DESCRIPTION
The ciphertext for AES CTR is exactly as large as the plaintext (not
necessarily a multiple of the blocksize!). By truncating the ciphertext,
we do not send bytes that will be decrypted to gibberish.

As a side node, we probably do not need to initialize the ciphertext
buffer larger than the plaintext size at all, but the OpenSSL docs are a
bit vague about that.