### PR TITLE
Immediately create a new megolm session when user leaves instead of

### DIFF
--- a/lib/room.cpp
+++ b/lib/room.cpp
@@ -521,7 +521,9 @@ Room::Room(Connection* connection, QString id, JoinState initialJoinState)
         if (!usesEncryption()) {
             return;
         }
-        d->currentOutboundMegolmSession = nullptr;
+        if (d->hasValidMegolmSession()) {
+            d->createMegolmSession();
+        }
         qCDebug(E2EE) << "Invalidating current megolm session because user left";
 
     });


### PR DESCRIPTION
deferring until sending event