### PR TITLE
Fix signature verification for incoming one time keys

### DIFF
--- a/lib/connection.cpp
+++ b/lib/connection.cpp
@@ -2301,7 +2301,6 @@ bool Connection::Private::createOlmSession(const QString& targetUserId,
                                            const QString& targetDeviceId,
                                            const OneTimeKeys& oneTimeKeyObject)
 {
-    static QOlmUtility verifier;
     qDebug(E2EE) << "Creating a new session for" << targetUserId
                  << targetDeviceId;
     if (oneTimeKeyObject.isEmpty()) {

--- a/lib/connection.cpp
+++ b/lib/connection.cpp
@@ -2322,11 +2322,7 @@ bool Connection::Private::createOlmSession(const QString& targetUserId,
         signedOneTimeKey
             ->signatures[targetUserId]["ed25519:"_ls % targetDeviceId]
             .toLatin1();
-    if (!verifier.ed25519Verify(
-            edKeyForUserDevice(targetUserId, targetDeviceId).toLatin1(),
-            QJsonDocument(toJson(SignedOneTimeKey { signedOneTimeKey->key, {} }))
-                .toJson(QJsonDocument::Compact),
-            signature)) {
+    if (!ed25519VerifySignature(edKeyForUserDevice(targetUserId, targetDeviceId), toJson(SignedOneTimeKey { signedOneTimeKey->key, {} }), signature)) {
         qWarning(E2EE) << "Failed to verify one-time-key signature for" << targetUserId
                        << targetDeviceId << ". Skipping this device.";
         return false;


### PR DESCRIPTION
We didn't remove the signatures field before checking the signature for validity.
By using Quotient::ed25519VerifySignature, this is handled automatically