### PR TITLE
Fix verification

### DIFF
--- a/lib/connection.cpp
+++ b/lib/connection.cpp
@@ -1006,8 +1006,7 @@ bool Connection::Private::processIfVerificationEvent(const Event& evt,
             emit q->newKeyVerificationSession(*sessionIter);
             return true;
         },
-        [](const KeyVerificationDoneEvent& doneEvt) {
-            Q_UNUSED(doneEvt)
+        [](const KeyVerificationDoneEvent&) {
             return true;
         },
         [this](const KeyVerificationEvent& kvEvt) {

--- a/lib/connection.cpp
+++ b/lib/connection.cpp
@@ -1006,6 +1006,10 @@ bool Connection::Private::processIfVerificationEvent(const Event& evt,
             emit q->newKeyVerificationSession(*sessionIter);
             return true;
         },
+        [](const KeyVerificationDoneEvent& doneEvt) {
+            Q_UNUSED(doneEvt)
+            return true;
+        },
         [this](const KeyVerificationEvent& kvEvt) {
             if (auto* const session =
                 verificationSessions.value(kvEvt.transactionId())) {

--- a/lib/keyverificationsession.cpp
+++ b/lib/keyverificationsession.cpp
@@ -120,7 +120,7 @@ void KeyVerificationSession::handleEvent(const KeyVerificationEvent& baseEvent)
                 return true;
             },
             [this](const KeyVerificationMacEvent& event) {
-                if (state() != WAITINGFORMAC)
+                if (state() != WAITINGFORMAC && state() != WAITINGFORVERIFICATION)
                     return false;
                 handleMac(event);
                 return true;


### PR DESCRIPTION
Contains two fixes:

- When receiving the mac, we can also be in WAITINGFORVERIFICATION state
- Ignore all KeyVerificationDone events; we don't do anything with them anyway and sometimes receive them after the session is destructed