### PR TITLE
NAM: Implement direct media requests fallback

### DIFF
--- a/Quotient/mxcreply.h
+++ b/Quotient/mxcreply.h
@@ -12,9 +12,16 @@ class QUOTIENT_API MxcReply : public QNetworkReply
 {
     Q_OBJECT
 public:
-    explicit MxcReply();
+    enum DeferredFlag { Deferred };
+    enum ErrorFlag { Error };
+
     explicit MxcReply(QNetworkReply* reply,
                       const EncryptedFileMetadata& fileMetadata);
+    explicit MxcReply(DeferredFlag);
+    explicit MxcReply(ErrorFlag);
+
+    void setNetworkReply(QNetworkReply* newReply,
+                         const EncryptedFileMetadata& fileMetadata = {});
 
     qint64 bytesAvailable() const override;
 
@@ -26,6 +33,6 @@ protected:
 
 private:
     class Private;
-    ImplPtr<Private> d;
+    ImplPtr<Private> d = ZeroImpl<Private>();
 };
-}
+} // namespace Quotient

--- a/Quotient/networkaccessmanager.cpp
+++ b/Quotient/networkaccessmanager.cpp
@@ -68,7 +68,7 @@ private:
     QHash<QString, QUrl> baseUrls{};
     QList<QSslError> ignoredSslErrors{};
     // This one is small enough to be atomic and not need a read-write lock
-    std::atomic_flag directMediaRequestsAreAllowed{ false };
+    std::atomic_flag directMediaRequestsAreAllowed{};
 } d;
 
 std::once_flag directMediaRequestsInitFlag;

--- a/Quotient/networkaccessmanager.h
+++ b/Quotient/networkaccessmanager.h
@@ -12,7 +12,9 @@ namespace Quotient {
 class QUOTIENT_API NetworkAccessManager : public QNetworkAccessManager {
     Q_OBJECT
 public:
-    using QNetworkAccessManager::QNetworkAccessManager;
+    static void allowDirectMediaRequests(bool allow = true,
+                                         bool permanent = true);
+    static bool directMediaRequestsAllowed();
 
     static void addBaseUrl(const QString& accountId, const QUrl& homeserver);
     static void dropBaseUrl(const QString& accountId);

--- a/quotest/quotest.cpp
+++ b/quotest/quotest.cpp
@@ -492,10 +492,7 @@ struct DownloadRunner {
 bool TestSuite::testDownload(const TestToken& thisTest, const QUrl& mxcUrl)
 {
     // Testing direct media requests needs explicit allowance
-    QSettings s;
-    static constexpr auto DirectMediaRequestsSetting =
-        "Network/allow_direct_media_requests"_ls;
-    s.setValue(DirectMediaRequestsSetting, true);
+    NetworkAccessManager::allowDirectMediaRequests(true, false);
     if (const auto result = DownloadRunner::run(mxcUrl, 1);
         result.front() != QNetworkReply::NoError) {
         clog << "Direct media request to "
@@ -503,7 +500,7 @@ bool TestSuite::testDownload(const TestToken& thisTest, const QUrl& mxcUrl)
              << " was allowed but failed" << endl;
         FAIL_TEST();
     }
-    s.setValue(DirectMediaRequestsSetting, false);
+    NetworkAccessManager::allowDirectMediaRequests(false, false);
     if (const auto result = DownloadRunner::run(mxcUrl, 1);
         result.front() == QNetworkReply::NoError) {
         clog << "Direct media request to "


### PR DESCRIPTION
(From the commit message:)
This is behind a configuration switch because direct unauthenticated requests are at odds with the Matrix model where clients stick to their homeservers and only homeservers talk to each other. The implementation is also quite inefficient atm, causing a .well-known resolution roundtrip every single time a direct media request is made.