### PR TITLE
Fix Key Verification and its test

### DIFF
--- a/autotests/testkeyverification.cpp
+++ b/autotests/testkeyverification.cpp
@@ -6,7 +6,7 @@
 #include <QTest>
 #include "testutils.h"
 #include <qt_connection_util.h>
-#include <QTimer>
+#include <QtCore/QTimer>
 #include <room.h>
 
 class TestKeyVerificationSession : public QObject

--- a/autotests/testkeyverification.cpp
+++ b/autotests/testkeyverification.cpp
@@ -45,7 +45,7 @@ private Q_SLOTS:
             a->startKeyVerificationSession(b->userId(), b->deviceId());
         });
         connect(b.get(), &Connection::newKeyVerificationSession, this, [&](KeyVerificationSession* session) {
-            connect(session, &KeyVerificationSession::stateChanged, this, [session](){
+            connect(session, &KeyVerificationSession::stateChanged, this, [session] {
                 QVERIFY(session->state() != KeyVerificationSession::CANCELED);
             });
             QVERIFY(session->remoteDeviceId() == a->deviceId());

--- a/autotests/testkeyverification.cpp
+++ b/autotests/testkeyverification.cpp
@@ -20,7 +20,7 @@ private Q_SLOTS:
         CREATE_CONNECTION(b, "alice2", "secret", "AlicePhone")
 
         a->requestDirectChat(b->userId());
-            connectSingleShot(b.get(), &Connection::invitedRoom, this, [=](Quotient::Room* room, Quotient::Room*) {
+        connectSingleShot(b.get(), &Connection::invitedRoom, this, [=](Quotient::Room* room) {
             b->joinRoom(room->id());
             a->room(room->id())->activateEncryption();
         });

--- a/autotests/testkeyverification.cpp
+++ b/autotests/testkeyverification.cpp
@@ -6,6 +6,8 @@
 #include <QTest>
 #include "testutils.h"
 #include <qt_connection_util.h>
+#include <QTimer>
+#include <room.h>
 
 class TestKeyVerificationSession : public QObject
 {
@@ -15,23 +17,37 @@ private Q_SLOTS:
     void testVerification()
     {
         CREATE_CONNECTION(a, "alice1", "secret", "AliceDesktop")
-        CREATE_CONNECTION(b, "alice1", "secret", "AlicePhone")
+        CREATE_CONNECTION(b, "alice2", "secret", "AlicePhone")
+
+        a->requestDirectChat(b->userId());
+            connectSingleShot(b.get(), &Connection::invitedRoom, this, [=](Quotient::Room* room, Quotient::Room*) {
+            b->joinRoom(room->id());
+            a->room(room->id())->activateEncryption();
+        });
 
         QPointer<KeyVerificationSession> aSession{};
         connect(a.get(), &Connection::newKeyVerificationSession, this, [&](KeyVerificationSession* session) {
             aSession = session;
+            QVERIFY(aSession);
+            connect(session, &KeyVerificationSession::stateChanged, this, [session](){
+                QVERIFY(session->state() != KeyVerificationSession::CANCELED);
+            });
             QVERIFY(session->remoteDeviceId() == b->deviceId());
             QVERIFY(session->state() == KeyVerificationSession::WAITINGFORREADY);
             connectSingleShot(session, &KeyVerificationSession::stateChanged, this, [=](){
                 QVERIFY(session->state() == KeyVerificationSession::ACCEPTED || session->state() == KeyVerificationSession::READY);
                 connectSingleShot(session, &KeyVerificationSession::stateChanged, this, [=](){
                     QVERIFY(session->state() == KeyVerificationSession::WAITINGFORVERIFICATION);
-                    session->sendMac();
                 });
             });
         });
-        a->startKeyVerificationSession(b->deviceId());
-        connect(b.get(), &Connection::newKeyVerificationSession, this, [=](KeyVerificationSession* session) {
+        QTimer::singleShot(3000, this, [a, b](){
+            a->startKeyVerificationSession(b->userId(), b->deviceId());
+        });
+        connect(b.get(), &Connection::newKeyVerificationSession, this, [&](KeyVerificationSession* session) {
+            connect(session, &KeyVerificationSession::stateChanged, this, [session](){
+                QVERIFY(session->state() != KeyVerificationSession::CANCELED);
+            });
             QVERIFY(session->remoteDeviceId() == a->deviceId());
             QVERIFY(session->state() == KeyVerificationSession::INCOMING);
             session->sendReady();
@@ -44,6 +60,7 @@ private Q_SLOTS:
                     QVERIFY(aSession);
                     QVERIFY(aSession->sasEmojis() == session->sasEmojis());
                     session->sendMac();
+                    aSession->sendMac();
                     QVERIFY(session->state() == KeyVerificationSession::WAITINGFORMAC);
                 });
             });
@@ -51,8 +68,10 @@ private Q_SLOTS:
         });
         b->syncLoop();
         a->syncLoop();
-        QSignalSpy spy(aSession, &KeyVerificationSession::finished);
-        spy.wait(10000);
+        QSignalSpy spy1(b.get(), &Connection::newKeyVerificationSession);
+        spy1.wait(10000);
+        QSignalSpy spy2(aSession, &KeyVerificationSession::finished);
+        spy2.wait(10000);
     }
 };
 QTEST_GUILESS_MAIN(TestKeyVerificationSession)

--- a/autotests/testkeyverification.cpp
+++ b/autotests/testkeyverification.cpp
@@ -5,7 +5,7 @@
 
 #include <QTest>
 #include "testutils.h"
-#include <QDateTime>
+#include <QtCore/QDateTime>
 #include <e2ee/qolmaccount.h>
 #include "olm/sas.h"
 #include "e2ee/qolmutils.h"

--- a/autotests/testkeyverification.cpp
+++ b/autotests/testkeyverification.cpp
@@ -5,74 +5,61 @@
 
 #include <QTest>
 #include "testutils.h"
-#include <qt_connection_util.h>
-#include <QtCore/QTimer>
-#include <room.h>
+#include <QDateTime>
+#include <e2ee/qolmaccount.h>
+#include "olm/sas.h"
+#include "e2ee/qolmutils.h"
 
 class TestKeyVerificationSession : public QObject
 {
     Q_OBJECT
 
 private Q_SLOTS:
-    void testVerification()
+    void testOutgoing1()
     {
-        CREATE_CONNECTION(a, "alice1", "secret", "AliceDesktop")
-        CREATE_CONNECTION(b, "alice2", "secret", "AlicePhone")
+        auto userId = QStringLiteral("@bob:localhost");
+        auto deviceId = QStringLiteral("DEFABC");
+        auto connection = new Connection();
+        const auto transactionId = "other_transaction_id"_ls;
+        connection->completeSetup("@carl:localhost"_ls);
+        auto session = new KeyVerificationSession("@alice:localhost"_ls, "ABCDEF"_ls, connection);
+        session->sendRequest();
+        QVERIFY(session->state() == KeyVerificationSession::WAITINGFORREADY);
+        session->handleEvent(KeyVerificationReadyEvent(transactionId, "ABCDEF"_ls, {SasV1Method}));
+        QVERIFY(session->state() == KeyVerificationSession::WAITINGFORACCEPT);
+        session->handleEvent(KeyVerificationAcceptEvent(transactionId, "commitment_TODO"_ls));
+        QVERIFY(session->state() == KeyVerificationSession::WAITINGFORKEY);
+        // Since we can't get the events sent by the session, we're limited by what we can test. This means that continuing here would force us to test
+        // the exact same path as the other test, which is useless.
+        // TODO: Test some other path once we're able to.
+    }
 
-        a->requestDirectChat(b->userId());
-        connectSingleShot(b.get(), &Connection::invitedRoom, this, [=](Quotient::Room* room) {
-            b->joinRoom(room->id());
-            a->room(room->id())->activateEncryption();
-        });
+    void testIncoming1()
+    {
+        auto userId = QStringLiteral("@bob:localhost");
+        auto deviceId = QStringLiteral("DEFABC");
+        const auto transactionId = "trans123action123id"_ls;
+        auto connection = new Connection();
+        connection->completeSetup("@carl:localhost"_ls);
+        auto session = new KeyVerificationSession(userId, KeyVerificationRequestEvent(transactionId, deviceId, {SasV1Method}, QDateTime::currentDateTime()), connection, false);
+        QVERIFY(session->state() == KeyVerificationSession::INCOMING);
+        session->sendReady();
+        QVERIFY(session->state() == KeyVerificationSession::WAITINGFORACCEPT);
+        session->handleEvent(KeyVerificationStartEvent(transactionId, deviceId));
+        QVERIFY(session->state() == KeyVerificationSession::ACCEPTED);
+        auto account = new QOlmAccount(userId, deviceId);
+        account->createNewAccount();
 
-        QPointer<KeyVerificationSession> aSession{};
-        connect(a.get(), &Connection::newKeyVerificationSession, this, [&](KeyVerificationSession* session) {
-            aSession = session;
-            QVERIFY(aSession);
-            connect(session, &KeyVerificationSession::stateChanged, this, [session] {
-                QVERIFY(session->state() != KeyVerificationSession::CANCELED);
-            });
-            QVERIFY(session->remoteDeviceId() == b->deviceId());
-            QVERIFY(session->state() == KeyVerificationSession::WAITINGFORREADY);
-            connectSingleShot(session, &KeyVerificationSession::stateChanged, this, [=](){
-                QVERIFY(session->state() == KeyVerificationSession::ACCEPTED || session->state() == KeyVerificationSession::READY);
-                connectSingleShot(session, &KeyVerificationSession::stateChanged, this, [=](){
-                    QVERIFY(session->state() == KeyVerificationSession::WAITINGFORVERIFICATION);
-                    aSession->sendMac();
-                });
-            });
-        });
-        // The delay is added to make sure that the parties have each other's device keys available
-        QTimer::singleShot(3000, this, [a, b] {
-            a->startKeyVerificationSession(b->userId(), b->deviceId());
-        });
-        connect(b.get(), &Connection::newKeyVerificationSession, this, [&](KeyVerificationSession* session) {
-            connect(session, &KeyVerificationSession::stateChanged, this, [session] {
-                QVERIFY(session->state() != KeyVerificationSession::CANCELED);
-            });
-            QVERIFY(session->remoteDeviceId() == a->deviceId());
-            QVERIFY(session->state() == KeyVerificationSession::INCOMING);
-            session->sendReady();
-            // KeyVerificationSession::READY is skipped because we have only one method
-            QVERIFY(session->state() == KeyVerificationSession::WAITINGFORACCEPT);
-            connectSingleShot(session, &KeyVerificationSession::stateChanged, this, [=](){
-                QVERIFY(session->state() == KeyVerificationSession::WAITINGFORKEY || session->state() == KeyVerificationSession::ACCEPTED);
-                connectSingleShot(session, &KeyVerificationSession::stateChanged, this, [=]() {
-                    QVERIFY(session->state() == KeyVerificationSession::WAITINGFORVERIFICATION);
-                    QVERIFY(aSession);
-                    QVERIFY(aSession->sasEmojis() == session->sasEmojis());
-                    session->sendMac();
-                    QVERIFY(session->state() == KeyVerificationSession::WAITINGFORMAC);
-                });
-            });
-
-        });
-        b->syncLoop();
-        a->syncLoop();
-        QSignalSpy spy1(b.get(), &Connection::newKeyVerificationSession);
-        spy1.wait(10000);
-        QSignalSpy spy2(aSession, &KeyVerificationSession::finished);
-        spy2.wait(10000);
+        auto sas = olm_sas(new std::byte[olm_sas_size()]);
+        const auto randomLength = olm_create_sas_random_length(sas);
+        olm_create_sas(sas, RandomBuffer(randomLength), randomLength);
+        QByteArray keyBytes(olm_sas_pubkey_length(sas), '\0');
+        olm_sas_get_pubkey(sas, keyBytes.data(), keyBytes.size());
+        session->handleEvent(KeyVerificationKeyEvent(transactionId, keyBytes));
+        QVERIFY(session->state() == KeyVerificationSession::WAITINGFORVERIFICATION);
+        session->sendMac();
+        QVERIFY(session->state() == KeyVerificationSession::WAITINGFORMAC);
+        //TODO: Send and verify the mac once we have a way of getting the KeyVerificationKeyEvent sent by the session.
     }
 };
 QTEST_GUILESS_MAIN(TestKeyVerificationSession)

--- a/autotests/testkeyverification.cpp
+++ b/autotests/testkeyverification.cpp
@@ -41,7 +41,7 @@ private Q_SLOTS:
                 });
             });
         });
-        QTimer::singleShot(3000, this, [a, b](){
+        QTimer::singleShot(3000, this, [a, b] {
             a->startKeyVerificationSession(b->userId(), b->deviceId());
         });
         connect(b.get(), &Connection::newKeyVerificationSession, this, [&](KeyVerificationSession* session) {

--- a/autotests/testkeyverification.cpp
+++ b/autotests/testkeyverification.cpp
@@ -38,9 +38,11 @@ private Q_SLOTS:
                 QVERIFY(session->state() == KeyVerificationSession::ACCEPTED || session->state() == KeyVerificationSession::READY);
                 connectSingleShot(session, &KeyVerificationSession::stateChanged, this, [=](){
                     QVERIFY(session->state() == KeyVerificationSession::WAITINGFORVERIFICATION);
+                    aSession->sendMac();
                 });
             });
         });
+        // The delay is added to make sure that the parties have each other's device keys available
         QTimer::singleShot(3000, this, [a, b] {
             a->startKeyVerificationSession(b->userId(), b->deviceId());
         });
@@ -60,7 +62,6 @@ private Q_SLOTS:
                     QVERIFY(aSession);
                     QVERIFY(aSession->sasEmojis() == session->sasEmojis());
                     session->sendMac();
-                    aSession->sendMac();
                     QVERIFY(session->state() == KeyVerificationSession::WAITINGFORMAC);
                 });
             });

--- a/autotests/testkeyverification.cpp
+++ b/autotests/testkeyverification.cpp
@@ -29,7 +29,7 @@ private Q_SLOTS:
         connect(a.get(), &Connection::newKeyVerificationSession, this, [&](KeyVerificationSession* session) {
             aSession = session;
             QVERIFY(aSession);
-            connect(session, &KeyVerificationSession::stateChanged, this, [session](){
+            connect(session, &KeyVerificationSession::stateChanged, this, [session] {
                 QVERIFY(session->state() != KeyVerificationSession::CANCELED);
             });
             QVERIFY(session->remoteDeviceId() == b->deviceId());

--- a/autotests/testkeyverification.cpp
+++ b/autotests/testkeyverification.cpp
@@ -19,9 +19,8 @@ private Q_SLOTS:
     {
         auto userId = QStringLiteral("@bob:localhost");
         auto deviceId = QStringLiteral("DEFABC");
-        auto connection = new Connection();
+        auto connection = Connection::makeMockConnection("@carl:localhost"_ls);
         const auto transactionId = "other_transaction_id"_ls;
-        connection->completeSetup("@carl:localhost"_ls);
         auto session = new KeyVerificationSession("@alice:localhost"_ls, "ABCDEF"_ls, connection);
         session->sendRequest();
         QVERIFY(session->state() == KeyVerificationSession::WAITINGFORREADY);
@@ -39,8 +38,7 @@ private Q_SLOTS:
         auto userId = QStringLiteral("@bob:localhost");
         auto deviceId = QStringLiteral("DEFABC");
         const auto transactionId = "trans123action123id"_ls;
-        auto connection = new Connection();
-        connection->completeSetup("@carl:localhost"_ls);
+        auto connection = Connection::makeMockConnection("@carl:localhost"_ls);
         auto session = new KeyVerificationSession(userId, KeyVerificationRequestEvent(transactionId, deviceId, {SasV1Method}, QDateTime::currentDateTime()), connection, false);
         QVERIFY(session->state() == KeyVerificationSession::INCOMING);
         session->sendReady();

--- a/lib/connection.cpp
+++ b/lib/connection.cpp
@@ -998,7 +998,7 @@ bool Connection::Private::processIfVerificationEvent(const Event& evt,
         [this, encrypted](const KeyVerificationRequestEvent& reqEvt) {
             const auto sessionIter = verificationSessions.insert(
                 reqEvt.transactionId(),
-                new KeyVerificationSession(q->userId(), reqEvt, q, encrypted));
+                new KeyVerificationSession(reqEvt.fullJson()["sender"].toString(), reqEvt, q, encrypted));
             emit q->newKeyVerificationSession(*sessionIter);
             return true;
         },
@@ -2445,9 +2445,10 @@ void Connection::saveCurrentOutboundMegolmSession(
                                                   session);
 }
 
-void Connection::startKeyVerificationSession(const QString& deviceId)
+void Connection::startKeyVerificationSession(const QString& userId, const QString& deviceId)
 {
-    auto* const session = new KeyVerificationSession(userId(), deviceId, this);
+    auto* const session = new KeyVerificationSession(userId, deviceId, this);
+    d->verificationSessions.insert(session->transactionId(), session);
     emit newKeyVerificationSession(session);
 }
 

--- a/lib/connection.cpp
+++ b/lib/connection.cpp
@@ -2487,7 +2487,9 @@ bool Connection::isVerifiedSession(const QString& megolmSessionId) const
 }
 #endif
 
-void Connection::completeSetup(const QString &mxId)
+Connection* Connection::makeMockConnection(const QString& mxId)
 {
-    d->completeSetup(mxId);
+    auto* c = new Connection;
+    c->d->completeSetup(mxId);
+    return c;
 }

--- a/lib/connection.cpp
+++ b/lib/connection.cpp
@@ -2486,3 +2486,8 @@ bool Connection::isVerifiedSession(const QString& megolmSessionId) const
     return query.next() && query.value("verified").toBool();
 }
 #endif
+
+void Connection::completeSetup(const QString &mxId)
+{
+    d->completeSetup(mxId);
+}

--- a/lib/connection.h
+++ b/lib/connection.h
@@ -705,8 +705,7 @@ public Q_SLOTS:
     void encryptionUpdate(Room *room);
 #endif
 
-    // WARNING: Use only for unit tests! This will not lead to a correctly working connection!
-    void completeSetup(const QString& mxId);
+    static Connection* makeMockConnection(const QString& mxId);
 
 Q_SIGNALS:
     /// \brief Initial server resolution has failed

--- a/lib/connection.h
+++ b/lib/connection.h
@@ -705,6 +705,9 @@ public Q_SLOTS:
     void encryptionUpdate(Room *room);
 #endif
 
+    // WARNING: Use only for unit tests! This will not lead to a correctly working connection!
+    void completeSetup(const QString& mxId);
+
 Q_SIGNALS:
     /// \brief Initial server resolution has failed
     ///

--- a/lib/connection.h
+++ b/lib/connection.h
@@ -700,7 +700,7 @@ public Q_SLOTS:
     virtual LeaveRoomJob* leaveRoom(Room* room);
 
 #ifdef Quotient_E2EE_ENABLED
-    void startKeyVerificationSession(const QString& deviceId);
+    void startKeyVerificationSession(const QString& userId, const QString& deviceId);
 
     void encryptionUpdate(Room *room);
 #endif

--- a/lib/jobs/basejob.cpp
+++ b/lib/jobs/basejob.cpp
@@ -353,7 +353,6 @@ void BaseJob::initiate(ConnectionData* connData, bool inBackground)
     } else {
         qCCritical(d->logCat)
             << "Developers, ensure the Connection is valid before using it";
-        Q_ASSERT(false);
         setStatus(IncorrectRequest, tr("Invalid server connection"));
     }
     // The status is no good, finalise

--- a/lib/keyverificationsession.cpp
+++ b/lib/keyverificationsession.cpp
@@ -499,3 +499,8 @@ QString KeyVerificationSession::remoteDeviceId() const
 {
     return m_remoteDeviceId;
 }
+
+QString KeyVerificationSession::transactionId() const
+{
+    return m_transactionId;
+}

--- a/lib/keyverificationsession.cpp
+++ b/lib/keyverificationsession.cpp
@@ -91,7 +91,7 @@ void KeyVerificationSession::handleEvent(const KeyVerificationEvent& baseEvent)
                 return true;
             },
             [this](const KeyVerificationStartEvent& event) {
-                if (state() != WAITINGFORREADY && state() != READY)
+                if (state() != WAITINGFORREADY && state() != READY && state() != WAITINGFORACCEPT)
                     return false;
                 handleStart(event);
                 return true;
@@ -102,7 +102,7 @@ void KeyVerificationSession::handleEvent(const KeyVerificationEvent& baseEvent)
                 // ACCEPTED is also fine here because it's possible to receive
                 // ready and start in the same sync, in which case start might
                 // be handled before ready.
-                return state() == WAITINGFORREADY || state() == ACCEPTED;
+                return state() == READY || state() == WAITINGFORACCEPT || state() == ACCEPTED;
             },
             [this](const KeyVerificationAcceptEvent& event) {
                 if (state() != WAITINGFORACCEPT)

--- a/lib/keyverificationsession.h
+++ b/lib/keyverificationsession.h
@@ -99,6 +99,7 @@ public:
     Error error() const;
 
     QString remoteDeviceId() const;
+    QString transactionId() const;
 
 public Q_SLOTS:
     void sendRequest();


### PR DESCRIPTION
- Add outgoing sessions to the list as well
- Verify that session wasn't cancelled
- Test session between different accounts in order to not mess up the database
- Make sure we have the key for the other party by being in an encrypted room
- Make it possible to verify keys of other users
- Capture QPointer by reference to correctly share the session