### PR TITLE
Move replaced event getters to RoomMessageEvent

### DIFF
--- a/lib/events/roomevent.cpp
+++ b/lib/events/roomevent.cpp
@@ -34,20 +34,6 @@ QString RoomEvent::senderId() const
     return fullJson()[SenderKeyL].toString();
 }
 
-bool RoomEvent::isReplaced() const
-{
-    return unsignedPart<QJsonObject>("m.relations"_ls).contains("m.replace");
-}
-
-QString RoomEvent::replacedBy() const
-{
-    // clang-format off
-    return unsignedPart<QJsonObject>("m.relations"_ls)
-            .value("m.replace"_ls).toObject()
-            .value(EventIdKeyL).toString();
-    // clang-format on
-}
-
 QString RoomEvent::redactionReason() const
 {
     return isRedacted() ? _redactedBecause->reason() : QString {};

--- a/lib/events/roomevent.h
+++ b/lib/events/roomevent.h
@@ -22,12 +22,6 @@ public:
     QDateTime originTimestamp() const;
     QString roomId() const;
     QString senderId() const;
-    //! \brief Determine whether the event has been replaced
-    //!
-    //! \return true if this event has been overridden by another event
-    //!         with `"rel_type": "m.replace"`; false otherwise
-    bool isReplaced() const;
-    QString replacedBy() const;
     bool isRedacted() const { return bool(_redactedBecause); }
     const event_ptr_tt<RedactionEvent>& redactedBecause() const
     {

--- a/lib/events/roommessageevent.cpp
+++ b/lib/events/roommessageevent.cpp
@@ -248,6 +248,20 @@ QString RoomMessageEvent::replacedEvent() const
     return isReplacement(rel) ? rel->eventId : QString();
 }
 
+bool RoomMessageEvent::isReplaced() const
+{
+    return unsignedPart<QJsonObject>("m.relations"_ls).contains(u"m.replace");
+}
+
+QString RoomMessageEvent::replacedBy() const
+{
+    // clang-format off
+    return unsignedPart<QJsonObject>("m.relations"_ls)
+            .value("m.replace"_ls).toObject()
+            .value(EventIdKeyL).toString();
+    // clang-format on
+}
+
 QString rawMsgTypeForMimeType(const QMimeType& mimeType)
 {
     auto name = mimeType.name();

--- a/lib/events/roommessageevent.h
+++ b/lib/events/roommessageevent.h
@@ -77,9 +77,18 @@ public:
     //!         such as m.image, or generic binary content, i.e. m.file);
     //!         false otherwise
     bool hasThumbnail() const;
+
     //! \brief Obtain id of an event replaced by the current one
     //! \sa RoomEvent::isReplaced, RoomEvent::replacedBy
     QString replacedEvent() const;
+
+    //! \brief Determine whether the event has been replaced
+    //!
+    //! \return true if this event has been overridden by another event
+    //!         with `"rel_type": "m.replace"`; false otherwise
+    bool isReplaced() const;
+
+    QString replacedBy() const;
 
     static QString rawMsgTypeForUrl(const QUrl& url);
     static QString rawMsgTypeForFile(const QFileInfo& fi);


### PR DESCRIPTION
Aligns Quotient with v1.4 spec. If needed, I can provide deprecated methods in the old place; but AIUI it's enough (and more correct) to downcast to `RoomMessageEvent` and only check them if the downcast is not null.

Closes #490.