### PR TITLE
Tighten up ReactionEvent interface

### DIFF
--- a/lib/events/eventrelation.h
+++ b/lib/events/eventrelation.h
@@ -8,7 +8,7 @@
 namespace Quotient {
 
 [[maybe_unused]] constexpr auto RelatesToKey = "m.relates_to"_ls;
-constexpr auto RelTypeKey = "rel_type"_ls;
+[[maybe_unused]] constexpr auto RelTypeKey = "rel_type"_ls;
 
 struct QUOTIENT_API EventRelation {
     using reltypeid_t = QLatin1String;
@@ -48,5 +48,4 @@ struct QUOTIENT_API JsonObjectConverter<EventRelation> {
     static void fillFrom(const QJsonObject& jo, EventRelation& pod);
 };
 
-}
-
+} // namespace Quotient

--- a/lib/events/reactionevent.h
+++ b/lib/events/reactionevent.h
@@ -8,7 +8,33 @@
 
 namespace Quotient {
 
-DEFINE_SIMPLE_EVENT(ReactionEvent, RoomEvent, "m.reaction", EventRelation,
-                    relation, "m.relates_to")
+class QUOTIENT_API ReactionEvent
+    : public EventTemplate<
+          ReactionEvent, RoomEvent,
+          EventContent::SingleKeyValue<EventRelation, RelatesToKey>> {
+public:
+    QUO_EVENT(ReactionEvent, "m.reaction")
+    static bool isValid(const QJsonObject& fullJson)
+    {
+        return fullJson[ContentKey][RelatesToKey][RelTypeKey].toString()
+               == EventRelation::AnnotationType;
+    }
+
+    [[deprecated("Use a two-argument constructor instead")]] // REMOVEME: 0.8
+    explicit ReactionEvent(const EventRelation& er)
+        : EventTemplate(er)
+    {}
+    ReactionEvent(const QString& eventId, const QString& reactionKey)
+        : EventTemplate(EventRelation::annotate(eventId, reactionKey))
+    {}
+
+    [[deprecated("Use eventId(), key(), or content().value instead")]]
+    EventRelation relation() const { return content().value; }
+    QString eventId() const { return content().value.eventId; }
+    QString key() const { return content().value.key; }
+
+private:
+    explicit ReactionEvent(const QJsonObject& json) : EventTemplate(json) {}
+};
 
 } // namespace Quotient

--- a/quotest/quotest.cpp
+++ b/quotest/quotest.cpp
@@ -371,6 +371,16 @@ TEST_IMPL(sendReaction)
     clog << "Reacting to the newest message in the room" << endl;
     Q_ASSERT(targetRoom->timelineSize() > 0);
     const auto targetEvtId = targetRoom->messageEvents().back()->id();
+
+    // TODO: a separate test unit for reactionevent.h
+    if (loadEvent<ReactionEvent>(RoomEvent::basicJson(
+            ReactionEvent::TypeId,
+            { { RelatesToKey, toJson(EventRelation::replace(targetEvtId)) } }))) {
+        clog << "ReactionEvent can be created with an invalid relation type"
+             << endl;
+        FAIL_TEST();
+    }
+
     const auto key = QStringLiteral("+1");
     const auto txnId = targetRoom->postReaction(targetEvtId, key);
     if (!validatePendingEvent<ReactionEvent>(txnId)) {
@@ -392,8 +402,7 @@ TEST_IMPL(sendReaction)
             const auto* evt =
                 eventCast<const ReactionEvent>(reactions.back());
             FINISH_TEST(is<ReactionEvent>(*evt) && !evt->id().isEmpty()
-                        && evt->relation().key == key
-                        && evt->transactionId() == txnId);
+                        && evt->key() == key && evt->transactionId() == txnId);
             // TODO: Test removing the reaction
         });
     return false;


### PR DESCRIPTION
ReactionEvent is only supposed to carry `m.annotation` relationships and shouldn't be created with anything else. This deprecates the old interface and adds `ReactionEvent::isValid()` that disallows to load reaction events from malformed JSON via `EventMetaType`.