### PR TITLE
Compare olm account unpickling result with OLM success

### DIFF
--- a/lib/connection.cpp
+++ b/lib/connection.cpp
@@ -648,7 +648,7 @@ void Connection::Private::completeSetup(const QString& mxId)
         });
     } else {
         // account already existing
-        if (!olmAccount->unpickle(database->accountPickle(), picklingMode))
+        if (olmAccount->unpickle(database->accountPickle(), picklingMode) != OLM_SUCCESS)
             qWarning(E2EE)
                 << "Could not unpickle Olm account, E2EE won't be available";
     }


### PR DESCRIPTION
Instead of assuming that 0 means failure, which is wrong