### PR TITLE
Also send encryption keys to invited users

### DIFF
--- a/lib/connection.cpp
+++ b/lib/connection.cpp
@@ -2124,7 +2124,7 @@ void Connection::Private::loadOutdatedUserDevices()
     currentQueryKeysJob = queryKeysJob;
     connect(queryKeysJob, &BaseJob::failure, q, [this]() {
         currentQueryKeysJob = nullptr;
-        Q_EMIT q->finishedQueryingKeys();
+        emit q->finishedQueryingKeys();
     });
     connect(queryKeysJob, &BaseJob::success, q, [this, queryKeysJob](){
         currentQueryKeysJob = nullptr;

--- a/lib/connection.cpp
+++ b/lib/connection.cpp
@@ -2173,7 +2173,7 @@ void Connection::Private::loadOutdatedUserDevices()
             } else
                 ++i;
         }
-        Q_EMIT q->finishedQueryingKeys();
+        emit q->finishedQueryingKeys();
     });
 }
 

--- a/lib/connection.cpp
+++ b/lib/connection.cpp
@@ -380,6 +380,7 @@ public:
     void loadOutdatedUserDevices();
     void saveDevicesList();
     void loadDevicesList();
+    void handleQueryKeys(QueryKeysJob *job);
 
     // This function assumes that an olm session with (user, device) exists
     std::pair<QOlmMessage::Type, QByteArray> olmEncryptMessage(
@@ -2110,6 +2111,55 @@ bool Connection::isQueryingKeys() const
     return d->currentQueryKeysJob != nullptr;
 }
 
+void Connection::Private::handleQueryKeys(QueryKeysJob *job)
+{
+    const auto data = job->deviceKeys();
+    for(const auto &[user, keys] : asKeyValueRange(data)) {
+        QHash<QString, Quotient::DeviceKeys> oldDevices = deviceKeys[user];
+        deviceKeys[user].clear();
+        for(const auto &device : keys) {
+            if(device.userId != user) {
+                qCWarning(E2EE)
+                    << "mxId mismatch during device key verification:"
+                    << device.userId << user;
+                continue;
+            }
+            if (!std::all_of(device.algorithms.cbegin(),
+                            device.algorithms.cend(),
+                            isSupportedAlgorithm)) {
+                qCWarning(E2EE) << "Unsupported encryption algorithms found"
+                                << device.algorithms;
+                continue;
+            }
+            if (!verifyIdentitySignature(device, device.deviceId,
+                                        device.userId)) {
+                qCWarning(E2EE) << "Failed to verify devicekeys signature. "
+                                "Skipping this device";
+                continue;
+            }
+            if (oldDevices.contains(device.deviceId)) {
+                if (oldDevices[device.deviceId].keys["ed25519:" % device.deviceId] != device.keys["ed25519:" % device.deviceId]) {
+                    qCDebug(E2EE) << "Device reuse detected. Skipping this device";
+                    continue;
+                }
+            }
+            deviceKeys[user][device.deviceId] = SLICE(device, DeviceKeys);
+        }
+        outdatedUsers -= user;
+    }
+    saveDevicesList();
+
+    for(size_t i = 0; i < pendingEncryptedEvents.size();) {
+        if (isKnownCurveKey(
+                pendingEncryptedEvents[i]->fullJson()[SenderKeyL].toString(),
+                pendingEncryptedEvents[i]->contentPart<QString>("sender_key"_ls))) {
+            handleEncryptedToDeviceEvent(*pendingEncryptedEvents[i]);
+            pendingEncryptedEvents.erase(pendingEncryptedEvents.begin() + i);
+        } else
+            ++i;
+    }
+}
+
 void Connection::Private::loadOutdatedUserDevices()
 {
     QHash<QString, QStringList> users;
@@ -2122,56 +2172,10 @@ void Connection::Private::loadOutdatedUserDevices()
     }
     auto queryKeysJob = q->callApi<QueryKeysJob>(users);
     currentQueryKeysJob = queryKeysJob;
-    connect(queryKeysJob, &BaseJob::failure, q, [this]() {
-        currentQueryKeysJob = nullptr;
-        emit q->finishedQueryingKeys();
-    });
     connect(queryKeysJob, &BaseJob::success, q, [this, queryKeysJob](){
         currentQueryKeysJob = nullptr;
-        const auto data = queryKeysJob->deviceKeys();
-        for(const auto &[user, keys] : asKeyValueRange(data)) {
-            QHash<QString, Quotient::DeviceKeys> oldDevices = deviceKeys[user];
-            deviceKeys[user].clear();
-            for(const auto &device : keys) {
-                if(device.userId != user) {
-                    qCWarning(E2EE)
-                        << "mxId mismatch during device key verification:"
-                        << device.userId << user;
-                    continue;
-                }
-                if (!std::all_of(device.algorithms.cbegin(),
-                                 device.algorithms.cend(),
-                                 isSupportedAlgorithm)) {
-                    qCWarning(E2EE) << "Unsupported encryption algorithms found"
-                                    << device.algorithms;
-                    continue;
-                }
-                if (!verifyIdentitySignature(device, device.deviceId,
-                                             device.userId)) {
-                    qCWarning(E2EE) << "Failed to verify devicekeys signature. "
-                                       "Skipping this device";
-                    continue;
-                }
-                if (oldDevices.contains(device.deviceId)) {
-                    if (oldDevices[device.deviceId].keys["ed25519:" % device.deviceId] != device.keys["ed25519:" % device.deviceId]) {
-                        qCDebug(E2EE) << "Device reuse detected. Skipping this device";
-                        continue;
-                    }
-                }
-                deviceKeys[user][device.deviceId] = SLICE(device, DeviceKeys);
-            }
-            outdatedUsers -= user;
-        }
-        saveDevicesList();
-
-        for(size_t i = 0; i < pendingEncryptedEvents.size();) {
-            if (isKnownCurveKey(
-                    pendingEncryptedEvents[i]->fullJson()[SenderKeyL].toString(),
-                    pendingEncryptedEvents[i]->contentPart<QString>("sender_key"_ls))) {
-                handleEncryptedToDeviceEvent(*pendingEncryptedEvents[i]);
-                pendingEncryptedEvents.erase(pendingEncryptedEvents.begin() + i);
-            } else
-                ++i;
+        if (queryKeysJob->error() == BaseJob::Success) {
+            handleQueryKeys(queryKeysJob);
         }
         emit q->finishedQueryingKeys();
     });

--- a/lib/connection.h
+++ b/lib/connection.h
@@ -698,7 +698,8 @@ public Q_SLOTS:
 #ifdef Quotient_E2EE_ENABLED
     void startKeyVerificationSession(const QString& userId, const QString& deviceId);
 
-    void encryptionUpdate(Room *room);
+    void encryptionUpdate(Room* room, const QList<User*>& invited = {});
+    bool isQueryingKeys() const;
 #endif
 
     static Connection* makeMockConnection(const QString& mxId);
@@ -867,6 +868,7 @@ Q_SIGNALS:
         const Quotient::KeyVerificationSession* session,
         Quotient::KeyVerificationSession::State state);
     void sessionVerified(const QString& userId, const QString& deviceId);
+    bool finishedQueryingKeys();
 #endif
 
 protected:

--- a/lib/room.cpp
+++ b/lib/room.cpp
@@ -498,7 +498,7 @@ Room::Room(Connection* connection, QString id, JoinState initialJoinState)
     connectSingleShot(this, &Room::encryption, this, [this, connection](){
         connection->encryptionUpdate(this);
     });
-    connect(this, &Room::memberListChanged, this, [this, connection](){
+    connect(this, &Room::memberListChanged, this, [this, connection] {
         if(usesEncryption()) {
             connection->encryptionUpdate(this, d->usersInvited);
         }

--- a/lib/room.cpp
+++ b/lib/room.cpp
@@ -468,7 +468,7 @@ public:
     QMultiHash<QString, QString> getDevicesWithoutKey() const
     {
         QMultiHash<QString, QString> devices;
-        for (const auto& user : q->users())
+        for (const auto& user : q->users() + usersInvited)
             for (const auto& deviceId : connection->devicesForUser(user->id()))
                 devices.insert(user->id(), deviceId);
 
@@ -498,9 +498,9 @@ Room::Room(Connection* connection, QString id, JoinState initialJoinState)
     connectSingleShot(this, &Room::encryption, this, [this, connection](){
         connection->encryptionUpdate(this);
     });
-    connect(this, &Room::userAdded, this, [this, connection](){
+    connect(this, &Room::memberListChanged, this, [this, connection](){
         if(usesEncryption()) {
-            connection->encryptionUpdate(this);
+            connection->encryptionUpdate(this, d->usersInvited);
         }
     });
     d->groupSessions = connection->loadRoomMegolmSessions(this);
@@ -2027,11 +2027,21 @@ QString Room::Private::doSendEvent(const RoomEvent* pEvent)
         if (!hasValidMegolmSession() || shouldRotateMegolmSession()) {
             createMegolmSession();
         }
+
         // Send the session to other people
-        connection->sendSessionKeyToDevices(
-            id, currentOutboundMegolmSession->sessionId(),
-            currentOutboundMegolmSession->sessionKey(), getDevicesWithoutKey(),
-            currentOutboundMegolmSession->sessionMessageIndex());
+        if (connection->isQueryingKeys()) {
+            connectSingleShot(connection, &Connection::finishedQueryingKeys, q, [this]{
+                connection->sendSessionKeyToDevices(
+                    id, currentOutboundMegolmSession->sessionId(),
+                    currentOutboundMegolmSession->sessionKey(), getDevicesWithoutKey(),
+                    currentOutboundMegolmSession->sessionMessageIndex());
+            });
+        } else {
+            connection->sendSessionKeyToDevices(
+                id, currentOutboundMegolmSession->sessionId(),
+                currentOutboundMegolmSession->sessionKey(), getDevicesWithoutKey(),
+                currentOutboundMegolmSession->sessionMessageIndex());
+        }
 
         const auto encrypted = currentOutboundMegolmSession->encrypt(QJsonDocument(pEvent->fullJson()).toJson());
         currentOutboundMegolmSession->setMessageCount(


### PR DESCRIPTION
As part of that, wait until any in-flight key queries are finished to make sure that we're not missing devices.