### PR TITLE
Be consistent with inserting QByteArrays or QStrings into the database

### DIFF
--- a/lib/connection.cpp
+++ b/lib/connection.cpp
@@ -2494,10 +2494,10 @@ void Connection::sendToDevice(const QString& targetUserId,
                   { { targetUserId, { { targetDeviceId, contentJson } } } });
 }
 
-bool Connection::isVerifiedSession(const QString& megolmSessionId) const
+bool Connection::isVerifiedSession(const QByteArray& megolmSessionId) const
 {
     auto query = database()->prepareQuery("SELECT olmSessionId FROM inbound_megolm_sessions WHERE sessionId=:sessionId;"_ls);
-    query.bindValue(":sessionId", megolmSessionId.toLatin1());
+    query.bindValue(":sessionId", megolmSessionId);
     database()->execute(query);
     if (!query.next()) {
         return false;

--- a/lib/connection.cpp
+++ b/lib/connection.cpp
@@ -2497,14 +2497,14 @@ void Connection::sendToDevice(const QString& targetUserId,
 bool Connection::isVerifiedSession(const QString& megolmSessionId) const
 {
     auto query = database()->prepareQuery("SELECT olmSessionId FROM inbound_megolm_sessions WHERE sessionId=:sessionId;"_ls);
-    query.bindValue(":sessionId", megolmSessionId);
+    query.bindValue(":sessionId", megolmSessionId.toLatin1());
     database()->execute(query);
     if (!query.next()) {
         return false;
     }
     auto olmSessionId = query.value("olmSessionId").toString();
     query.prepare("SELECT senderKey FROM olm_sessions WHERE sessionId=:sessionId;"_ls);
-    query.bindValue(":sessionId", olmSessionId);
+    query.bindValue(":sessionId", olmSessionId.toLatin1());
     database()->execute(query);
     if (!query.next()) {
         return false;

--- a/lib/connection.h
+++ b/lib/connection.h
@@ -338,7 +338,7 @@ public:
                       const Event& event, bool encrypted);
 
     /// Returns true if this megolm session comes from a verified device
-    bool isVerifiedSession(const QString& megolmSessionId) const;
+    bool isVerifiedSession(const QByteArray& megolmSessionId) const;
 
     void sendSessionKeyToDevices(const QString& roomId,
                                  const QByteArray& sessionId,

--- a/lib/database.cpp
+++ b/lib/database.cpp
@@ -348,7 +348,7 @@ void Database::setOlmSessionLastReceived(const QString& sessionId, const QDateTi
 {
     auto query = prepareQuery(QStringLiteral("UPDATE olm_sessions SET lastReceived=:lastReceived WHERE sessionId=:sessionId;"));
     query.bindValue(":lastReceived", timestamp);
-    query.bindValue(":sessionId", sessionId);
+    query.bindValue(":sessionId", sessionId.toLatin1());
     transaction();
     execute(query);
     commit();
@@ -405,7 +405,7 @@ void Database::setDevicesReceivedKey(const QString& roomId, const QVector<std::t
         query.bindValue(":userId", user);
         query.bindValue(":deviceId", device);
         query.bindValue(":identityKey", curveKey);
-        query.bindValue(":sessionId", sessionId);
+        query.bindValue(":sessionId", sessionId.toLatin1());
         query.bindValue(":i", index);
         execute(query);
     }
@@ -418,7 +418,7 @@ QMultiHash<QString, QString> Database::devicesWithoutKey(
 {
     auto query = prepareQuery(QStringLiteral("SELECT userId, deviceId FROM sent_megolm_sessions WHERE roomId=:roomId AND sessionId=:sessionId"));
     query.bindValue(":roomId", roomId);
-    query.bindValue(":sessionId", sessionId);
+    query.bindValue(":sessionId", sessionId.toLatin1());
     transaction();
     execute(query);
     commit();

--- a/lib/database.cpp
+++ b/lib/database.cpp
@@ -344,11 +344,11 @@ void Database::clearRoomData(const QString& roomId)
     commit();
 }
 
-void Database::setOlmSessionLastReceived(const QString& sessionId, const QDateTime& timestamp)
+void Database::setOlmSessionLastReceived(const QByteArray& sessionId, const QDateTime& timestamp)
 {
     auto query = prepareQuery(QStringLiteral("UPDATE olm_sessions SET lastReceived=:lastReceived WHERE sessionId=:sessionId;"));
     query.bindValue(":lastReceived", timestamp);
-    query.bindValue(":sessionId", sessionId.toLatin1());
+    query.bindValue(":sessionId", sessionId);
     transaction();
     execute(query);
     commit();
@@ -396,7 +396,7 @@ Omittable<QOlmOutboundGroupSession> Database::loadCurrentOutboundMegolmSession(
     return none;
 }
 
-void Database::setDevicesReceivedKey(const QString& roomId, const QVector<std::tuple<QString, QString, QString>>& devices, const QString& sessionId, int index)
+void Database::setDevicesReceivedKey(const QString& roomId, const QVector<std::tuple<QString, QString, QString>>& devices, const QByteArray& sessionId, int index)
 {
     transaction();
     for (const auto& [user, device, curveKey] : devices) {
@@ -405,7 +405,7 @@ void Database::setDevicesReceivedKey(const QString& roomId, const QVector<std::t
         query.bindValue(":userId", user);
         query.bindValue(":deviceId", device);
         query.bindValue(":identityKey", curveKey);
-        query.bindValue(":sessionId", sessionId.toLatin1());
+        query.bindValue(":sessionId", sessionId);
         query.bindValue(":i", index);
         execute(query);
     }
@@ -414,11 +414,11 @@ void Database::setDevicesReceivedKey(const QString& roomId, const QVector<std::t
 
 QMultiHash<QString, QString> Database::devicesWithoutKey(
     const QString& roomId, QMultiHash<QString, QString> devices,
-    const QString& sessionId)
+    const QByteArray& sessionId)
 {
     auto query = prepareQuery(QStringLiteral("SELECT userId, deviceId FROM sent_megolm_sessions WHERE roomId=:roomId AND sessionId=:sessionId"));
     query.bindValue(":roomId", roomId);
-    query.bindValue(":sessionId", sessionId.toLatin1());
+    query.bindValue(":sessionId", sessionId);
     transaction();
     execute(query);
     commit();

--- a/lib/database.h
+++ b/lib/database.h
@@ -50,7 +50,7 @@ public:
                                                        const QString& sessionId,
                                                        qint64 index);
     void clearRoomData(const QString& roomId);
-    void setOlmSessionLastReceived(const QString& sessionId,
+    void setOlmSessionLastReceived(const QByteArray& sessionId,
                                    const QDateTime& timestamp);
     Omittable<QOlmOutboundGroupSession> loadCurrentOutboundMegolmSession(
         const QString& roomId);
@@ -61,12 +61,12 @@ public:
     // Returns a map UserId -> [DeviceId] that have not received key yet
     QMultiHash<QString, QString> devicesWithoutKey(
         const QString& roomId, QMultiHash<QString, QString> devices,
-        const QString& sessionId);
+        const QByteArray& sessionId);
     // 'devices' contains tuples {userId, deviceId, curveKey}
     void setDevicesReceivedKey(
         const QString& roomId,
         const QVector<std::tuple<QString, QString, QString>>& devices,
-        const QString& sessionId, int index);
+        const QByteArray& sessionId, int index);
 
     bool isSessionVerified(const QString& edKey);
     void setSessionVerified(const QString& edKeyId);


### PR DESCRIPTION
Otherwise the queries will give unexpected results; in this case, breaking the check if a session is verified