### PR TITLE
Fix QTcpServer not working when proxy is applied

### DIFF
--- a/lib/ssosession.cpp
+++ b/lib/ssosession.cpp
@@ -10,6 +10,7 @@
 #include <QtNetwork/QTcpSocket>
 #include <QtCore/QCoreApplication>
 #include <QtCore/QStringBuilder>
+#include <QNetworkProxy>
 
 using namespace Quotient;
 
@@ -22,9 +23,11 @@ public:
         , connection(connection)
     {
         auto* server = new QTcpServer(q);
+        // User might apply an application level proxy and we don't need them here.
+        server->setProxy(QNetworkProxy::NoProxy);
         if (!server->listen())
             qCritical(MAIN)
-                << "Could not open the port, SSO callback won't work";
+                << "Could not open the port, SSO callback won't work:" << server->errorString();
         // The "/returnToApplication" part is just a hint for the end-user,
         // the callback will work without it equally well.
         callbackUrl = QStringLiteral("http://localhost:%1/returnToApplication")


### PR DESCRIPTION
User might want to set-up an application level proxy to the main application, in this case, `QTcpServer` will uses the default proxy. If user set a Socks5 proxy for example, the QTcpServer will fail to `listen()`. To reproduce this issue, you can setup a socks5 proxy by using `ssh`'s `-D` argument, or any transparent proxy tools.

By explicitly set proxy to `NoProxy`, we will be able to ensure the local server work properly again.

This patch also adds `errorString()` to log when it's failed to `listen()`. The error message can be very useful to let developer know what went wrong and in this case it helps me find the source of the issue :)