### PR TITLE
Per-connection E2EE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,6 +179,7 @@ list(APPEND lib_SRCS
 if (${PROJECT_NAME}_ENABLE_E2EE)
     list(APPEND lib_SRCS
         Quotient/database.h Quotient/database.cpp
+        Quotient/connectionencryptiondata_p.h Quotient/connectionencryptiondata_p.cpp
         Quotient/keyverificationsession.h Quotient/keyverificationsession.cpp
         Quotient/e2ee/e2ee_common.cpp # .h is in the common sources list
         Quotient/e2ee/qolmaccount.h Quotient/e2ee/qolmaccount.cpp

--- a/Quotient/connection.cpp
+++ b/Quotient/connection.cpp
@@ -1414,6 +1414,13 @@ Room* Connection::provideRoom(const QString& id, Omittable<JoinState> joinState)
     return room;
 }
 
+#ifdef Quotient_E2EE_ENABLED
+void Connection::setEncryptionDefault(bool useByDefault)
+{
+    Private::encryptionDefault = useByDefault;
+}
+#endif
+
 void Connection::setRoomFactory(room_factory_t f)
 {
     _roomFactory = std::move(f);

--- a/Quotient/connection.h
+++ b/Quotient/connection.h
@@ -525,6 +525,11 @@ public:
     Q_INVOKABLE bool roomSucceeds(const QString& maybePredecessorId,
                                   const QString& maybeSuccessorId) const;
 
+#ifdef Quotient_E2EE_ENABLED
+    //! Set the E2EE default state for any Connection created further
+    static void setEncryptionDefault(bool useByDefault);
+#endif
+
     //! Set a room factory function
     static void setRoomFactory(room_factory_t f);
 

--- a/Quotient/connection_p.h
+++ b/Quotient/connection_p.h
@@ -14,17 +14,17 @@
 #include "csapi/wellknown.h"
 
 #ifdef Quotient_E2EE_ENABLED
-#include "e2ee/qolmaccount.h"
-#include "e2ee/qolmsession.h"
-#include "database.h"
+#    include "connectionencryptiondata_p.h"
 #endif
 
 #include "csapi/account-data.h"
 
-#include "events/encryptedevent.h"
+#include <QtCore/QCoreApplication>
+#include <QtCore/QPointer>
 
-#include <QCoreApplication>
-#include <QPointer>
+namespace Quotient {
+
+class EncryptedEvent;
 
 class Q_DECL_HIDDEN Quotient::Connection::Private {
 public:
@@ -55,36 +55,15 @@ public:
     QMetaObject::Connection syncLoopConnection {};
     int syncTimeout = -1;
 
-#ifdef Quotient_E2EE_ENABLED
-    QSet<QString> trackedUsers;
-    QSet<QString> outdatedUsers;
-    QHash<QString, QHash<QString, DeviceKeys>> deviceKeys;
-    QueryKeysJob *currentQueryKeysJob = nullptr;
-    bool encryptionUpdateRequired = false;
-    Database *database = nullptr;
-    QHash<QString, int> oneTimeKeysCount;
-    std::vector<std::unique_ptr<EncryptedEvent>> pendingEncryptedEvents;
-    void handleEncryptedToDeviceEvent(const EncryptedEvent& event);
-    template <typename... ArgTs>
-    KeyVerificationSession* setupKeyVerificationSession(ArgTs&&... sessionArgs);
-    bool processIfVerificationEvent(const Event &evt, bool encrypted);
-
-    // A map from SenderKey to vector of InboundSession
-    UnorderedMap<QString, std::vector<QOlmSession>> olmSessions;
-
-    QHash<QString, KeyVerificationSession*> verificationSessions;
-    QSet<std::pair<QString, QString>> triedDevices;
-
-    std::unique_ptr<QOlmAccount> olmAccount;
-    bool isUploadingKeys = false;
-    bool firstSync = true;
-#endif // Quotient_E2EE_ENABLED
-
     GetCapabilitiesJob* capabilitiesJob = nullptr;
     GetCapabilitiesJob::Capabilities capabilities;
 
     QVector<GetLoginFlowsJob::LoginFlow> loginFlows;
 
+    std::conditional_t<E2EE_Enabled, bool, const bool> useEncryption = false;
+#ifdef Quotient_E2EE_ENABLED
+    std::unique_ptr<_impl::ConnectionEncryptionData> encryptionData;
+#endif
 
     QPointer<GetWellknownJob> resolverJob = nullptr;
     QPointer<GetLoginFlowsJob> loginFlowsJob = nullptr;
@@ -126,7 +105,6 @@ public:
     void consumeAccountData(Events&& accountDataEvents);
     void consumePresenceData(Events&& presenceData);
     void consumeToDeviceEvents(Events&& toDeviceEvents);
-    void consumeDevicesList(DevicesList&& devicesList);
 
     void packAndSendAccountData(EventPtr&& event)
     {
@@ -152,39 +130,5 @@ public:
 
     void saveAccessTokenToKeychain() const;
     void dropAccessToken();
-
-#ifdef Quotient_E2EE_ENABLED
-    void saveOlmAccount();
-
-    void loadSessions();
-    void saveSession(const QOlmSession& session, const QString& senderKey) const;
-
-    template <typename FnT>
-    std::pair<QString, QString> doDecryptMessage(const QOlmSession& session,
-                                                 const QOlmMessage& message,
-                                                 FnT&& andThen) const;
-
-    std::pair<QString, QString> sessionDecryptMessage(
-        const QJsonObject& personalCipherObject, const QByteArray& senderKey);
-
-    bool isKnownCurveKey(const QString& userId, const QString& curveKey) const;
-
-    void loadOutdatedUserDevices();
-    void saveDevicesList();
-    void loadDevicesList();
-    void handleQueryKeys(const QueryKeysJob* job);
-
-    // This function assumes that an olm session with (user, device) exists
-    std::pair<QOlmMessage::Type, QByteArray> olmEncryptMessage(
-        const QString& userId, const QString& device,
-        const QByteArray& message) const;
-    bool createOlmSession(const QString& targetUserId,
-                          const QString& targetDeviceId,
-                          const OneTimeKeys &oneTimeKeyObject);
-    QString curveKeyForUserDevice(const QString& userId,
-                                  const QString& device) const;
-    QJsonObject assembleEncryptedContent(QJsonObject payloadJson,
-                                         const QString& targetUserId,
-                                         const QString& targetDeviceId) const;
-#endif
 };
+} // namespace Quotient

--- a/Quotient/connection_p.h
+++ b/Quotient/connection_p.h
@@ -98,7 +98,7 @@ public:
                          const std::optional<LoginFlow> &flow = none);
     template <typename... LoginArgTs>
     void loginToServer(LoginArgTs&&... loginArgs);
-    void completeSetup(const QString &mxId);
+    void completeSetup(const QString &mxId, bool mock = false);
     void removeRoom(const QString& roomId);
 
     void consumeRoomData(SyncDataList&& roomDataList, bool fromCache);

--- a/Quotient/connection_p.h
+++ b/Quotient/connection_p.h
@@ -60,9 +60,12 @@ public:
 
     QVector<GetLoginFlowsJob::LoginFlow> loginFlows;
 
-    std::conditional_t<E2EE_Enabled, bool, const bool> useEncryption = false;
 #ifdef Quotient_E2EE_ENABLED
+    static inline bool encryptionDefault = false;
+    bool useEncryption = encryptionDefault;
     std::unique_ptr<_impl::ConnectionEncryptionData> encryptionData;
+#else
+    static constexpr bool useEncryption = false;
 #endif
 
     QPointer<GetWellknownJob> resolverJob = nullptr;

--- a/Quotient/connectionencryptiondata_p.cpp
+++ b/Quotient/connectionencryptiondata_p.cpp
@@ -1,0 +1,754 @@
+#include "connectionencryptiondata_p.h"
+
+#include "room.h"
+#include "settings.h"
+#include "syncdata.h"
+#include "user.h"
+
+#include "e2ee/qolmutility.h"
+
+#include "events/encryptedevent.h"
+#include "events/roomkeyevent.h"
+
+#if QT_VERSION_MAJOR >= 6
+#    include <qt6keychain/keychain.h>
+#else
+#    include <qt5keychain/keychain.h>
+#endif
+
+#include <QtCore/QCoreApplication>
+
+using namespace Quotient;
+using namespace Quotient::_impl;
+
+Expected<PicklingKey, QKeychain::Error> setupPicklingKey(const QString& id)
+{
+    // TODO: Rewrite the whole thing in an async way to get rid of nested event
+    // loops
+    using namespace QKeychain;
+    const auto keychainId = id + "-Pickle"_ls;
+    ReadPasswordJob readJob(qAppName());
+    readJob.setAutoDelete(false);
+    readJob.setKey(keychainId);
+    QEventLoop readLoop;
+    QObject::connect(&readJob, &Job::finished, &readLoop, &QEventLoop::quit);
+    readJob.start();
+    readLoop.exec();
+
+    if (readJob.error() == Error::NoError) {
+        auto&& data = readJob.binaryData();
+        if (data.size() == PicklingKey::extent) {
+            qDebug(E2EE) << "Successfully loaded pickling key from keychain";
+            return PicklingKey::fromByteArray(std::move(data));
+        }
+        qCritical(E2EE) << "The loaded pickling key for" << id << "has length"
+                        << data.size() << "but the library expected"
+                        << PicklingKey::extent;
+        return Error::OtherError;
+    }
+    if (readJob.error() == Error::EntryNotFound) {
+        auto&& picklingKey = PicklingKey::generate();
+        WritePasswordJob writeJob(qAppName());
+        writeJob.setAutoDelete(false);
+        writeJob.setKey(keychainId);
+        writeJob.setBinaryData(picklingKey.viewAsByteArray());
+        QEventLoop writeLoop;
+        QObject::connect(&writeJob, &Job::finished, &writeLoop,
+                         &QEventLoop::quit);
+        writeJob.start();
+        writeLoop.exec();
+
+        if (writeJob.error() == Error::NoError)
+            return std::move(picklingKey);
+
+        qCritical(E2EE) << "Could not save pickling key to keychain: "
+                        << writeJob.errorString();
+        return writeJob.error();
+    }
+    qWarning(E2EE) << "Error loading pickling key - please fix your keychain:"
+                   << readJob.errorString();
+    return readJob.error();
+}
+
+Omittable<std::unique_ptr<ConnectionEncryptionData>>
+ConnectionEncryptionData::setup(Connection* connection)
+{
+    if (auto&& maybePicklingKey = setupPicklingKey(connection->userId())) {
+        auto&& encryptionData = std::make_unique<ConnectionEncryptionData>(
+            connection, std::move(*maybePicklingKey));
+        if (const auto outcome = encryptionData->database.setupOlmAccount(
+                encryptionData->olmAccount)) {
+            // account already existing or there's an error unpickling it
+            if (outcome == OLM_SUCCESS)
+                return std::move(encryptionData);
+
+            qCritical(E2EE) << "Could not unpickle Olm account for"
+                            << connection->objectName();
+            return none;
+        }
+        // A new account has been created
+        auto job = connection->callApi<UploadKeysJob>(
+            encryptionData->olmAccount.deviceKeys());
+        // eData is meant to have the same scope as connection so it's safe
+        // to pass an unguarded pointer to encryption data here
+        QObject::connect(job, &BaseJob::success, connection,
+                         [connection, eData = encryptionData.get()] {
+                             eData->trackedUsers += connection->userId();
+                             eData->outdatedUsers += connection->userId();
+                             eData->encryptionUpdateRequired = true;
+                         });
+        QObject::connect(job, &BaseJob::failure, connection, [job] {
+            qCWarning(E2EE)
+                << "Failed to upload device keys:" << job->errorString();
+        });
+        return std::move(encryptionData);
+    }
+    qCritical(E2EE) << "Could not load or initialise a pickling key for"
+                    << connection->objectName();
+    return none;
+}
+
+void ConnectionEncryptionData::saveDevicesList()
+{
+    database.transaction();
+    auto query =
+        database.prepareQuery(QStringLiteral("DELETE FROM tracked_users"));
+    database.execute(query);
+    query.prepare(QStringLiteral(
+        "INSERT INTO tracked_users(matrixId) VALUES(:matrixId);"));
+    for (const auto& user : trackedUsers) {
+        query.bindValue(":matrixId"_ls, user);
+        database.execute(query);
+    }
+
+    query.prepare(QStringLiteral("DELETE FROM outdated_users"));
+    database.execute(query);
+    query.prepare(QStringLiteral(
+        "INSERT INTO outdated_users(matrixId) VALUES(:matrixId);"));
+    for (const auto& user : outdatedUsers) {
+        query.bindValue(":matrixId"_ls, user);
+        database.execute(query);
+    }
+
+    query.prepare(QStringLiteral(
+        "INSERT INTO tracked_devices"
+        "(matrixId, deviceId, curveKeyId, curveKey, edKeyId, edKey, verified) "
+        "SELECT :matrixId, :deviceId, :curveKeyId, :curveKey, :edKeyId, "
+        ":edKey, :verified WHERE NOT EXISTS(SELECT 1 FROM tracked_devices "
+        "WHERE matrixId=:matrixId AND deviceId=:deviceId);"));
+    for (const auto& [user, devices] : asKeyValueRange(deviceKeys)) {
+        for (const auto& device : devices) {
+            auto keys = device.keys.keys();
+            auto curveKeyId = keys[0].startsWith("curve"_ls) ? keys[0]
+                                                             : keys[1];
+            auto edKeyId = keys[0].startsWith("ed"_ls) ? keys[0] : keys[1];
+
+            query.bindValue(":matrixId"_ls, user);
+            query.bindValue(":deviceId"_ls, device.deviceId);
+            query.bindValue(":curveKeyId"_ls, curveKeyId);
+            query.bindValue(":curveKey"_ls, device.keys[curveKeyId]);
+            query.bindValue(":edKeyId"_ls, edKeyId);
+            query.bindValue(":edKey"_ls, device.keys[edKeyId]);
+            // If the device gets saved here, it can't be verified
+            query.bindValue(":verified"_ls, false);
+
+            database.execute(query);
+        }
+    }
+    database.commit();
+}
+
+void ConnectionEncryptionData::loadDevicesList()
+{
+    auto query =
+        database.prepareQuery(QStringLiteral("SELECT * FROM tracked_users;"));
+    database.execute(query);
+    while (query.next()) {
+        trackedUsers += query.value(0).toString();
+    }
+
+    query =
+        database.prepareQuery(QStringLiteral("SELECT * FROM outdated_users;"));
+    database.execute(query);
+    while (query.next()) {
+        outdatedUsers += query.value(0).toString();
+    }
+
+    query =
+        database.prepareQuery(QStringLiteral("SELECT * FROM tracked_devices;"));
+    database.execute(query);
+    while (query.next()) {
+        deviceKeys[query.value("matrixId"_ls).toString()]
+                  [query.value("deviceId"_ls).toString()] = DeviceKeys{
+                      query.value("matrixId"_ls).toString(),
+                      query.value("deviceId"_ls).toString(),
+                      { SupportedAlgorithms.cbegin(),
+                        SupportedAlgorithms.cend() },
+                      { { query.value("curveKeyId"_ls).toString(),
+                          query.value("curveKey"_ls).toString() },
+                        { query.value("edKeyId"_ls).toString(),
+                          query.value("edKey"_ls).toString() } },
+                      {} // Signatures are not saved/loaded as they are not
+                         // needed after initial validation
+                  };
+    }
+}
+
+QString ConnectionEncryptionData::curveKeyForUserDevice(
+    const QString& userId, const QString& device) const
+{
+    return deviceKeys[userId][device].keys["curve25519:"_ls + device];
+}
+
+bool ConnectionEncryptionData::isKnownCurveKey(const QString& userId,
+                                               const QString& curveKey) const
+{
+    auto query = database.prepareQuery(
+        QStringLiteral("SELECT * FROM tracked_devices WHERE matrixId=:matrixId "
+                       "AND curveKey=:curveKey"));
+    query.bindValue(":matrixId"_ls, userId);
+    query.bindValue(":curveKey"_ls, curveKey);
+    database.execute(query);
+    return query.next();
+}
+
+bool ConnectionEncryptionData::hasOlmSession(const QString& user,
+                                             const QString& deviceId) const
+{
+    const auto& curveKey = curveKeyForUserDevice(user, deviceId);
+    const auto sessionIt = olmSessions.find(curveKey);
+    return sessionIt != olmSessions.cend() && !sessionIt->second.empty();
+}
+
+void ConnectionEncryptionData::onSyncSuccess(SyncData& syncResponse)
+{
+    oneTimeKeysCount = syncResponse.deviceOneTimeKeysCount();
+    if (oneTimeKeysCount[SignedCurve25519Key]
+            < 0.4 * olmAccount.maxNumberOfOneTimeKeys()
+        && !isUploadingKeys) {
+        isUploadingKeys = true;
+        olmAccount.generateOneTimeKeys(olmAccount.maxNumberOfOneTimeKeys() / 2
+                                       - oneTimeKeysCount[SignedCurve25519Key]);
+        auto keys = olmAccount.oneTimeKeys();
+        auto job = olmAccount.createUploadKeyRequest(keys);
+        q->run(job, ForegroundRequest);
+        QObject::connect(job, &BaseJob::success, q,
+                         [this] { olmAccount.markKeysAsPublished(); });
+        QObject::connect(job, &BaseJob::result, q,
+                         [this] { isUploadingKeys = false; });
+    }
+    if(firstSync) {
+        loadDevicesList();
+        firstSync = false;
+    }
+
+    consumeDevicesList(syncResponse.takeDevicesList());
+}
+
+void ConnectionEncryptionData::consumeDevicesList(const DevicesList& devicesList)
+{
+    bool hasNewOutdatedUser = false;
+    for(const auto &changed : devicesList.changed) {
+        if(trackedUsers.contains(changed)) {
+            outdatedUsers += changed;
+            hasNewOutdatedUser = true;
+        }
+    }
+    for(const auto &left : devicesList.left) {
+        trackedUsers -= left;
+        outdatedUsers -= left;
+        deviceKeys.remove(left);
+    }
+    if(hasNewOutdatedUser)
+        loadOutdatedUserDevices();
+}
+
+void ConnectionEncryptionData::loadOutdatedUserDevices()
+{
+    QHash<QString, QStringList> users;
+    for(const auto &user : outdatedUsers) {
+        users[user] += QStringList();
+    }
+    if(currentQueryKeysJob) {
+        currentQueryKeysJob->abandon();
+        currentQueryKeysJob = nullptr;
+    }
+    auto queryKeysJob = q->callApi<QueryKeysJob>(users);
+    currentQueryKeysJob = queryKeysJob;
+    QObject::connect(queryKeysJob, &BaseJob::result, q, [this, queryKeysJob] {
+        currentQueryKeysJob = nullptr;
+        if (queryKeysJob->error() == BaseJob::Success) {
+            handleQueryKeys(queryKeysJob);
+        }
+        emit q->finishedQueryingKeys();
+    });
+}
+
+void ConnectionEncryptionData::consumeToDeviceEvents(Events&& toDeviceEvents)
+{
+    if (!toDeviceEvents.empty()) {
+        qCDebug(E2EE) << "Consuming" << toDeviceEvents.size()
+                      << "to-device events";
+        for (auto&& tdEvt : toDeviceEvents) {
+            if (processIfVerificationEvent(*tdEvt, false))
+                continue;
+            if (auto&& event = eventCast<EncryptedEvent>(std::move(tdEvt))) {
+                if (event->algorithm() != OlmV1Curve25519AesSha2AlgoKey) {
+                    qCDebug(E2EE) << "Unsupported algorithm" << event->id()
+                                  << "for event" << event->algorithm();
+                    continue;
+                }
+                if (isKnownCurveKey(event->senderId(), event->senderKey())) {
+                    handleEncryptedToDeviceEvent(*event);
+                    continue;
+                }
+                trackedUsers += event->senderId();
+                outdatedUsers += event->senderId();
+                encryptionUpdateRequired = true;
+                pendingEncryptedEvents.push_back(std::move(event));
+            }
+        }
+    }
+}
+
+bool ConnectionEncryptionData::processIfVerificationEvent(const Event& evt,
+                                                          bool encrypted)
+{
+    return switchOnType(
+        evt,
+        [this, encrypted](const KeyVerificationRequestEvent& reqEvt) {
+            setupKeyVerificationSession(reqEvt.fullJson()[SenderKey].toString(),
+                                        reqEvt, q, encrypted);
+            return true;
+        },
+        [](const KeyVerificationDoneEvent&) { return true; },
+        [this](const KeyVerificationEvent& kvEvt) {
+            if (auto* const session =
+                    verificationSessions.value(kvEvt.transactionId())) {
+                session->handleEvent(kvEvt);
+                emit q->keyVerificationStateChanged(session, session->state());
+            }
+            return true;
+        },
+        false);
+}
+
+void ConnectionEncryptionData::handleEncryptedToDeviceEvent(
+    const EncryptedEvent& event)
+{
+    const auto [decryptedEvent, olmSessionId] = sessionDecryptMessage(event);
+    if (!decryptedEvent) {
+        qCWarning(E2EE) << "Failed to decrypt event" << event.id();
+        return;
+    }
+
+    if (processIfVerificationEvent(*decryptedEvent, true))
+        return;
+    switchOnType(
+        *decryptedEvent,
+        [this, &event,
+         olmSessionId = olmSessionId](const RoomKeyEvent& roomKeyEvent) {
+            if (auto* detectedRoom = q->room(roomKeyEvent.roomId())) {
+                detectedRoom->handleRoomKeyEvent(roomKeyEvent, event.senderId(),
+                                                 QString::fromLatin1(
+                                                     olmSessionId));
+            } else {
+                qCDebug(E2EE)
+                    << "Encrypted event room id" << roomKeyEvent.roomId()
+                    << "is not found at the connection" << q->objectName();
+            }
+        },
+        [](const Event& evt) {
+            qCWarning(E2EE) << "Skipping encrypted to_device event, type"
+                            << evt.matrixType();
+        });
+}
+
+void ConnectionEncryptionData::handleQueryKeys(const QueryKeysJob* job)
+{
+    const auto newDeviceKeys = job->deviceKeys();
+    for (const auto& [user, keys] : asKeyValueRange(newDeviceKeys)) {
+        const QHash<QString, Quotient::DeviceKeys> oldDevices = deviceKeys[user];
+        deviceKeys[user].clear();
+        for (const auto& device : keys) {
+            if (device.userId != user) {
+                qWarning(E2EE)
+                    << "mxId mismatch during device key verification:"
+                    << device.userId << user;
+                continue;
+            }
+            if (!std::all_of(device.algorithms.cbegin(),
+                             device.algorithms.cend(), isSupportedAlgorithm)) {
+                qWarning(E2EE) << "Unsupported encryption algorithms found"
+                               << device.algorithms;
+                continue;
+            }
+            if (!verifyIdentitySignature(device, device.deviceId,
+                                         device.userId)) {
+                qWarning(E2EE) << "Failed to verify devicekeys signature. "
+                                  "Skipping this device";
+                continue;
+            }
+            const auto keyId = "ed25519:"_ls + device.deviceId;
+            if (const auto oldDeviceKeys = oldDevices.value(device.deviceId);
+                !oldDeviceKeys.deviceId.isEmpty() // i.e. a keys object is found
+                && oldDeviceKeys.keys[keyId] != device.keys[keyId]) {
+                qDebug(E2EE) << "Device reuse detected. Skipping this device";
+                continue;
+            }
+            deviceKeys[user][device.deviceId] = SLICE(device, DeviceKeys);
+        }
+        outdatedUsers -= user;
+    }
+    saveDevicesList();
+
+    // A completely faithful code would call std::partition() with bare
+    // isKnownCurveKey(), then handleEncryptedToDeviceEvent() on each event
+    // with the known key, and then std::erase()... but
+    // handleEncryptedToDeviceEvent() doesn't have side effects on the handled
+    // events so a small corner-cutting should be fine.
+    std::erase_if(pendingEncryptedEvents,
+                  [this](const event_ptr_tt<EncryptedEvent>& pendingEvent) {
+                      if (!isKnownCurveKey(
+                              pendingEvent->fullJson()[SenderKey].toString(),
+                              pendingEvent->contentPart<QString>(SenderKeyKey)))
+                          return false;
+                      handleEncryptedToDeviceEvent(*pendingEvent);
+                      return true;
+                  });
+}
+
+void ConnectionEncryptionData::encryptionUpdate(const QList<User*>& forUsers)
+{
+    for (const auto& user : forUsers)
+        if (!trackedUsers.contains(user->id())) {
+            trackedUsers += user->id();
+            outdatedUsers += user->id();
+            encryptionUpdateRequired = true;
+        }
+}
+
+bool ConnectionEncryptionData::createOlmSession(
+    const QString& targetUserId, const QString& targetDeviceId,
+    const OneTimeKeys& oneTimeKeyObject)
+{
+    static QOlmUtility verifier;
+    qDebug(E2EE) << "Creating a new session for" << targetUserId
+                 << targetDeviceId;
+    if (oneTimeKeyObject.isEmpty()) {
+        qWarning(E2EE) << "No one time key for" << targetUserId
+                       << targetDeviceId;
+        return false;
+    }
+    auto* signedOneTimeKey =
+        std::get_if<SignedOneTimeKey>(&*oneTimeKeyObject.begin());
+    if (!signedOneTimeKey) {
+        qWarning(E2EE) << "No signed one time key for" << targetUserId
+                       << targetDeviceId;
+        return false;
+    }
+    // Verify contents of signedOneTimeKey - for that, drop `signatures` and
+    // `unsigned` and then verify the object against the respective signature
+    const auto signature =
+        signedOneTimeKey->signature(targetUserId, targetDeviceId);
+    if (!verifier.ed25519Verify(
+            q->edKeyForUserDevice(targetUserId, targetDeviceId).toLatin1(),
+            signedOneTimeKey->toJsonForVerification(), signature)) {
+        qWarning(E2EE) << "Failed to verify one-time-key signature for"
+                       << targetUserId << targetDeviceId
+                       << ". Skipping this device.";
+        return false;
+    }
+    const auto recipientCurveKey =
+        curveKeyForUserDevice(targetUserId, targetDeviceId);
+    auto session = olmAccount.createOutboundSession(recipientCurveKey.toLatin1(),
+                                                    signedOneTimeKey->key());
+    if (!session) {
+        qCWarning(E2EE) << "Failed to create olm session for "
+                        << recipientCurveKey << session.error();
+        return false;
+    }
+    saveSession(*session, recipientCurveKey);
+    olmSessions[recipientCurveKey].push_back(std::move(*session));
+    return true;
+}
+
+std::pair<QOlmMessage::Type, QByteArray>
+ConnectionEncryptionData::olmEncryptMessage(const QString& userId,
+                                            const QString& device,
+                                            const QByteArray& message) const
+{
+    const auto& curveKey = curveKeyForUserDevice(userId, device);
+    const auto& olmSession = olmSessions.at(curveKey).front();
+    const auto result = olmSession.encrypt(message);
+    database.updateOlmSession(curveKey, olmSession);
+    return { result.type(), result.toCiphertext() };
+}
+
+QJsonObject ConnectionEncryptionData::assembleEncryptedContent(
+    QJsonObject payloadJson, const QString& targetUserId,
+    const QString& targetDeviceId) const
+{
+    payloadJson.insert(SenderKey, q->userId());
+    payloadJson.insert(
+        "keys"_ls,
+        QJsonObject{ { Ed25519Key, QString::fromLatin1(
+                                       olmAccount.identityKeys().ed25519) } });
+    payloadJson.insert("recipient"_ls, targetUserId);
+    payloadJson.insert(
+        "recipient_keys"_ls,
+        QJsonObject{ { Ed25519Key,
+                       q->edKeyForUserDevice(targetUserId, targetDeviceId) } });
+    const auto [type, cipherText] = olmEncryptMessage(
+        targetUserId, targetDeviceId,
+        QJsonDocument(payloadJson).toJson(QJsonDocument::Compact));
+    QJsonObject encrypted{
+        { curveKeyForUserDevice(targetUserId, targetDeviceId),
+          QJsonObject{ { "type"_ls, type },
+                       { "body"_ls, QString::fromLatin1(cipherText) } } }
+    };
+    return EncryptedEvent(encrypted, QString::fromLatin1(
+                                         olmAccount.identityKeys().curve25519))
+        .contentJson();
+}
+
+std::pair<QByteArray, QByteArray> doDecryptMessage(const QOlmSession& session,
+                                                   const QOlmMessage& message,
+                                                   auto&& andThen)
+{
+    const auto expectedMessage = session.decrypt(message);
+    if (expectedMessage) {
+        const auto result =
+            std::make_pair(*expectedMessage, session.sessionId());
+        andThen();
+        return result;
+    }
+    const auto errorLine = message.type() == QOlmMessage::PreKey
+                               ? "Failed to decrypt prekey message:"
+                               : "Failed to decrypt message:";
+    qCDebug(E2EE) << errorLine << expectedMessage.error();
+    return {};
+}
+
+std::pair<QByteArray, QByteArray> ConnectionEncryptionData::sessionDecryptMessage(
+    const QJsonObject& personalCipherObject, const QString& senderKey)
+{
+    const auto msgType = static_cast<QOlmMessage::Type>(
+        personalCipherObject.value(TypeKey).toInt(-1));
+    if (msgType != QOlmMessage::General && msgType != QOlmMessage::PreKey) {
+        qCWarning(E2EE) << "Olm message has incorrect type" << msgType;
+        return {};
+    }
+    const QOlmMessage message{
+        personalCipherObject.value(BodyKey).toString().toLatin1(), msgType
+    };
+    for (const auto& session : olmSessions[senderKey])
+        if (msgType == QOlmMessage::General
+            || session.matchesInboundSessionFrom(senderKey, message)) {
+            return doDecryptMessage(session, message, [this, &session] {
+                q->database()->setOlmSessionLastReceived(
+                    session.sessionId(), QDateTime::currentDateTime());
+            });
+        }
+
+    if (msgType == QOlmMessage::General) {
+        qCWarning(E2EE) << "Failed to decrypt message";
+        return {};
+    }
+
+    qCDebug(E2EE) << "Creating new inbound session"; // Pre-key messages only
+    auto newSessionResult =
+        olmAccount.createInboundSessionFrom(senderKey.toLatin1(), message);
+    if (!newSessionResult) {
+        qCWarning(E2EE) << "Failed to create inbound session for" << senderKey
+                        << "with error" << newSessionResult.error();
+        return {};
+    }
+    auto&& newSession = std::move(*newSessionResult);
+    if (olmAccount.removeOneTimeKeys(newSession) != OLM_SUCCESS) {
+        qWarning(E2EE) << "Failed to remove one time key for session"
+                       << newSession.sessionId();
+        // Keep going though
+    }
+    return doDecryptMessage(newSession, message, [this, &senderKey, &newSession] {
+        saveSession(newSession, senderKey);
+        olmSessions[senderKey].push_back(std::move(newSession));
+    });
+}
+
+std::pair<EventPtr, QByteArray> ConnectionEncryptionData::sessionDecryptMessage(
+    const EncryptedEvent& encryptedEvent)
+{
+    if (encryptedEvent.algorithm() != OlmV1Curve25519AesSha2AlgoKey)
+        return {};
+
+    const auto identityKey = olmAccount.identityKeys().curve25519;
+    const auto personalCipherObject =
+        encryptedEvent.ciphertext(QString::fromLatin1(identityKey));
+    if (personalCipherObject.isEmpty()) {
+        qDebug(E2EE) << "Encrypted event is not for the current device";
+        return {};
+    }
+    const auto [decrypted, olmSessionId] =
+        sessionDecryptMessage(personalCipherObject, encryptedEvent.senderKey());
+    if (decrypted.isEmpty()) {
+        qDebug(E2EE) << "Problem with new session from senderKey:"
+                     << encryptedEvent.senderKey()
+                     << olmAccount.oneTimeKeys().keys;
+
+        auto query = database.prepareQuery(
+            "SELECT deviceId FROM tracked_devices WHERE curveKey=:curveKey;"_ls);
+        query.bindValue(":curveKey"_ls, encryptedEvent.senderKey());
+        database.execute(query);
+        if (!query.next()) {
+            qCWarning(E2EE) << "Unknown device while trying to recover from "
+                               "broken olm session";
+            return {};
+        }
+        auto senderId = encryptedEvent.senderId();
+        auto deviceId = query.value("deviceId"_ls).toString();
+        QHash<QString, QHash<QString, QString>> hash{
+            { encryptedEvent.senderId(),
+              { { deviceId, "signed_curve25519"_ls } } }
+        };
+        auto job = q->callApi<ClaimKeysJob>(hash);
+        QObject::connect(
+            job, &BaseJob::finished, q, [this, deviceId, job, senderId] {
+                if (triedDevices.contains({ senderId, deviceId })) {
+                    return;
+                }
+                triedDevices += { senderId, deviceId };
+                qDebug(E2EE)
+                    << "Sending dummy event to" << senderId << deviceId;
+                createOlmSession(senderId, deviceId,
+                                 job->oneTimeKeys()[senderId][deviceId]);
+                q->sendToDevice(senderId, deviceId, DummyEvent(), true);
+            });
+        return {};
+    }
+
+    auto&& decryptedEvent =
+        fromJson<EventPtr>(QJsonDocument::fromJson(decrypted));
+
+    if (auto sender = decryptedEvent->fullJson()[SenderKey].toString();
+        sender != encryptedEvent.senderId()) {
+        qWarning(E2EE) << "Found user" << sender << "instead of sender"
+                       << encryptedEvent.senderId() << "in Olm plaintext";
+        return {};
+    }
+
+    auto query = database.prepareQuery(QStringLiteral(
+        "SELECT edKey FROM tracked_devices WHERE curveKey=:curveKey;"));
+    const auto senderKey = encryptedEvent.contentPart<QString>(SenderKeyKey);
+    query.bindValue(":curveKey"_ls, senderKey);
+    database.execute(query);
+    if (!query.next()) {
+        qWarning(E2EE) << "Received olm message from unknown device"
+                       << senderKey;
+        return {};
+    }
+    if (auto edKey =
+            decryptedEvent->fullJson()["keys"_ls][Ed25519Key].toString();
+        edKey.isEmpty() || query.value("edKey"_ls).toString() != edKey) //
+    {
+        qDebug(E2EE) << "Received olm message with invalid ed key";
+        return {};
+    }
+
+    // TODO: keys to constants
+    const auto decryptedEventObject = decryptedEvent->fullJson();
+    if (const auto recipient =
+            decryptedEventObject.value("recipient"_ls).toString();
+        recipient != q->userId()) //
+    {
+        qDebug(E2EE) << "Found user" << recipient << "instead of" << q->userId()
+                     << "in Olm plaintext";
+        return {};
+    }
+    if (const auto ourKey =
+            decryptedEventObject["recipient_keys"_ls][Ed25519Key].toString();
+        ourKey != QString::fromLatin1(olmAccount.identityKeys().ed25519)) //
+    {
+        qDebug(E2EE) << "Found key" << ourKey
+                     << "instead of our own ed25519 key in Olm plaintext";
+        return {};
+    }
+
+    return { std::move(decryptedEvent), olmSessionId };
+}
+
+void ConnectionEncryptionData::sendSessionKeyToDevices(
+    const QString& roomId, const QOlmOutboundGroupSession& outboundSession,
+    const QMultiHash<QString, QString>& devices)
+{
+    const auto& sessionId = outboundSession.sessionId();
+    const auto& sessionKey = outboundSession.sessionKey();
+    const auto& index = outboundSession.sessionMessageIndex();
+    qDebug(E2EE) << "Sending room key to devices:" << sessionId << index;
+    QHash<QString, QHash<QString, QString>> hash;
+    for (const auto& [userId, deviceId] : asKeyValueRange(devices))
+        if (!hasOlmSession(userId, deviceId)) {
+            hash[userId].insert(deviceId, "signed_curve25519"_ls);
+            qDebug(E2EE) << "Adding" << userId << deviceId
+                         << "to keys to claim";
+        }
+
+    const auto sendKey = [devices, this, sessionId, index, sessionKey, roomId] {
+        QHash<QString, QHash<QString, QJsonObject>> usersToDevicesToContent;
+        for (const auto& [targetUserId, targetDeviceId] : asKeyValueRange(devices)) {
+            if (!hasOlmSession(targetUserId, targetDeviceId))
+                continue;
+
+            // Noisy and leaks the key to logs but nice for debugging
+//            qDebug(E2EE) << "Creating the payload for" << targetUserId
+//                         << targetDeviceId << sessionId << sessionKey.toHex();
+            const auto keyEventJson =
+                RoomKeyEvent(MegolmV1AesSha2AlgoKey, roomId,
+                             QString::fromLatin1(sessionId),
+                             QString::fromLatin1(sessionKey))
+                    .fullJson();
+
+            usersToDevicesToContent[targetUserId][targetDeviceId] =
+                assembleEncryptedContent(keyEventJson, targetUserId,
+                                         targetDeviceId);
+        }
+        if (!usersToDevicesToContent.empty()) {
+            q->sendToDevices(EncryptedEvent::TypeId, usersToDevicesToContent);
+            QVector<std::tuple<QString, QString, QString>> receivedDevices;
+            receivedDevices.reserve(devices.size());
+            for (const auto& [user, device] : asKeyValueRange(devices))
+                receivedDevices.push_back(
+                    { user, device, curveKeyForUserDevice(user, device) });
+
+            database.setDevicesReceivedKey(roomId, receivedDevices, sessionId,
+                                           index);
+        }
+    };
+
+    if (hash.isEmpty()) {
+        sendKey();
+        return;
+    }
+
+    auto job = q->callApi<ClaimKeysJob>(hash);
+    QObject::connect(job, &BaseJob::success, q, [job, this, sendKey] {
+        for (const auto oneTimeKeys = job->oneTimeKeys();
+             const auto& [userId, userDevices] : asKeyValueRange(oneTimeKeys)) {
+            for (const auto& [deviceId, keys] : asKeyValueRange(userDevices)) {
+                createOlmSession(userId, deviceId, keys);
+            }
+        }
+        sendKey();
+    });
+}
+
+ConnectionEncryptionData::ConnectionEncryptionData(Connection* connection,
+                                                   PicklingKey&& picklingKey)
+    : q(connection)
+    , olmAccount(q->userId(), q->deviceId())
+    , database(q->userId(), q->deviceId(), std::move(picklingKey), q)
+    , olmSessions(database.loadOlmSessions())
+{
+    QObject::connect(&olmAccount, &QOlmAccount::needsSave, q,
+                     [this] { saveOlmAccount(); });
+}

--- a/Quotient/connectionencryptiondata_p.cpp
+++ b/Quotient/connectionencryptiondata_p.cpp
@@ -752,7 +752,7 @@ ConnectionEncryptionData::ConnectionEncryptionData(Connection* connection,
                                                    PicklingKey&& picklingKey)
     : q(connection)
     , olmAccount(q->userId(), q->deviceId())
-    , database(q->userId(), q->deviceId(), std::move(picklingKey), q)
+    , database(q->userId(), q->deviceId(), std::move(picklingKey))
     , olmSessions(database.loadOlmSessions())
 {
     QObject::connect(&olmAccount, &QOlmAccount::needsSave, q,

--- a/Quotient/connectionencryptiondata_p.h
+++ b/Quotient/connectionencryptiondata_p.h
@@ -1,0 +1,112 @@
+#pragma once
+
+#include "connection.h"
+#include "database.h"
+
+#include "e2ee/qolmaccount.h"
+#include "e2ee/qolmsession.h"
+
+namespace Quotient {
+
+struct DevicesList;
+class EncryptedEvent;
+
+namespace _impl {
+    class ConnectionEncryptionData {
+    public:
+        static Omittable<std::unique_ptr<ConnectionEncryptionData>> setup(
+            Connection* connection);
+
+        Connection* q;
+        QOlmAccount olmAccount;
+        // No easy way in C++ to discern between SQL SELECT from UPDATE, too bad
+        mutable Database database;
+        UnorderedMap<QString, std::vector<QOlmSession>> olmSessions;
+        //! A map from SenderKey to vector of InboundSession
+        QHash<QString, KeyVerificationSession*> verificationSessions{};
+        QSet<QString> trackedUsers{};
+        QSet<QString> outdatedUsers{};
+        QHash<QString, QHash<QString, DeviceKeys>> deviceKeys{};
+        QueryKeysJob* currentQueryKeysJob = nullptr;
+        QSet<std::pair<QString, QString>> triedDevices{};
+        //! An update of internal tracking structures (trackedUsers, e.g.) is
+        //! needed
+        bool encryptionUpdateRequired = false;
+        QHash<QString, int> oneTimeKeysCount{};
+        std::vector<std::unique_ptr<EncryptedEvent>> pendingEncryptedEvents{};
+        bool isUploadingKeys = false;
+        bool firstSync = true;
+
+        void saveDevicesList();
+        void loadDevicesList();
+        QString curveKeyForUserDevice(const QString& userId,
+                                      const QString& device) const;
+        bool isKnownCurveKey(const QString& userId,
+                             const QString& curveKey) const;
+        bool hasOlmSession(const QString &user, const QString &deviceId) const;
+
+        void onSyncSuccess(SyncData &syncResponse);
+        void loadOutdatedUserDevices();
+        void consumeToDeviceEvents(Events&& toDeviceEvents);
+        void encryptionUpdate(const QList<User*>& forUsers);
+
+        bool createOlmSession(const QString& targetUserId,
+                              const QString& targetDeviceId,
+                              const OneTimeKeys& oneTimeKeyObject);
+        void saveSession(const QOlmSession& session, const QString& senderKey)
+        {
+            database.saveOlmSession(senderKey, session,
+                                    QDateTime::currentDateTime());
+        }
+        void saveOlmAccount()
+        {
+            qCDebug(E2EE) << "Saving olm account";
+            database.storeOlmAccount(olmAccount);
+        }
+
+        std::pair<QByteArray, QByteArray> sessionDecryptMessage(
+            const QJsonObject& personalCipherObject, const QString& senderKey);
+        std::pair<EventPtr, QByteArray> sessionDecryptMessage(
+            const EncryptedEvent& encryptedEvent);
+
+        QJsonObject assembleEncryptedContent(
+            QJsonObject payloadJson, const QString& targetUserId,
+            const QString& targetDeviceId) const;
+        void sendSessionKeyToDevices(
+            const QString& roomId,
+            const QOlmOutboundGroupSession& outboundSession,
+            const QMultiHash<QString, QString>& devices);
+
+        template <typename... ArgTs>
+        KeyVerificationSession* setupKeyVerificationSession(
+            ArgTs&&... sessionArgs)
+        {
+            auto session =
+                new KeyVerificationSession(std::forward<ArgTs>(sessionArgs)...);
+            verificationSessions.insert(session->transactionId(), session);
+            QObject::connect(session, &QObject::destroyed, q,
+                             [this, txnId = session->transactionId()] {
+                                 verificationSessions.remove(txnId);
+                             });
+            emit q->newKeyVerificationSession(session);
+            return session;
+        }
+
+        // This is only public to enable std::make_unique; do not use directly,
+        // get an instance from setup() instead
+        ConnectionEncryptionData(Connection* connection,
+                                 PicklingKey&& picklingKey);
+
+    private:
+        void consumeDevicesList(const DevicesList &devicesList);
+        bool processIfVerificationEvent(const Event& evt, bool encrypted);
+        void handleEncryptedToDeviceEvent(const EncryptedEvent& event);
+        void handleQueryKeys(const QueryKeysJob *job);
+
+        // This function assumes that an olm session with (user, device) exists
+        std::pair<QOlmMessage::Type, QByteArray> olmEncryptMessage(
+            const QString& userId, const QString& device,
+            const QByteArray& message) const;
+    };
+} // namespace _impl
+} // namespace Quotient

--- a/Quotient/connectionencryptiondata_p.h
+++ b/Quotient/connectionencryptiondata_p.h
@@ -15,7 +15,7 @@ namespace _impl {
     class ConnectionEncryptionData {
     public:
         static Omittable<std::unique_ptr<ConnectionEncryptionData>> setup(
-            Connection* connection);
+            Connection* connection, bool mock = false);
 
         Connection* q;
         QOlmAccount olmAccount;

--- a/Quotient/database.cpp
+++ b/Quotient/database.cpp
@@ -20,9 +20,8 @@
 using namespace Quotient;
 
 Database::Database(const QString& userId, const QString& deviceId,
-                   PicklingKey&& picklingKey, QObject* parent)
-    : QObject(parent)
-    , m_userId(userId)
+                   PicklingKey&& picklingKey)
+    : m_userId(userId)
     , m_deviceId(deviceId)
     , m_picklingKey(std::move(picklingKey))
 {

--- a/Quotient/database.h
+++ b/Quotient/database.h
@@ -18,12 +18,11 @@ class QOlmSession;
 class QOlmInboundGroupSession;
 class QOlmOutboundGroupSession;
 
-class QUOTIENT_API Database : public QObject
+class QUOTIENT_API Database
 {
-    Q_OBJECT
 public:
     Database(const QString& userId, const QString& deviceId,
-             PicklingKey&& picklingKey, QObject* parent);
+             PicklingKey&& picklingKey);
 
     int version();
     void transaction();

--- a/Quotient/events/encryptedevent.cpp
+++ b/Quotient/events/encryptedevent.cpp
@@ -9,18 +9,18 @@ using namespace Quotient;
 EncryptedEvent::EncryptedEvent(const QJsonObject& ciphertexts,
                                const QString& senderKey)
     : RoomEvent(basicJson(TypeId, { { AlgorithmKeyL, OlmV1Curve25519AesSha2AlgoKey },
-                                    { CiphertextKeyL, ciphertexts },
-                                    { SenderKeyKeyL, senderKey } }))
+                                    { CiphertextKey, ciphertexts },
+                                    { SenderKeyKey, senderKey } }))
 {}
 
 EncryptedEvent::EncryptedEvent(const QByteArray& ciphertext,
                                const QString& senderKey,
                                const QString& deviceId, const QString& sessionId)
     : RoomEvent(basicJson(TypeId, { { AlgorithmKeyL, MegolmV1AesSha2AlgoKey },
-                                    { CiphertextKeyL, QString::fromLatin1(ciphertext) },
-                                    { DeviceIdKeyL, deviceId },
-                                    { SenderKeyKeyL, senderKey },
-                                    { SessionIdKeyL, sessionId } }))
+                                    { CiphertextKey, QString::fromLatin1(ciphertext) },
+                                    { DeviceIdKey, deviceId },
+                                    { SenderKeyKey, senderKey },
+                                    { SessionIdKey, sessionId } }))
 {}
 
 EncryptedEvent::EncryptedEvent(const QJsonObject& obj) : RoomEvent(obj) {}

--- a/Quotient/events/encryptedevent.h
+++ b/Quotient/events/encryptedevent.h
@@ -7,10 +7,10 @@
 
 namespace Quotient {
 
-constexpr inline auto CiphertextKeyL = "ciphertext"_ls;
-constexpr inline auto SenderKeyKeyL = "sender_key"_ls;
-constexpr inline auto DeviceIdKeyL = "device_id"_ls;
-constexpr inline auto SessionIdKeyL = "session_id"_ls;
+constexpr inline auto CiphertextKey = "ciphertext"_ls;
+constexpr inline auto SenderKeyKey = "sender_key"_ls;
+constexpr inline auto DeviceIdKey = "device_id"_ls;
+constexpr inline auto SessionIdKey = "session_id"_ls;
 
 /*
  * While the specification states:
@@ -49,19 +49,19 @@ public:
     QString algorithm() const;
     QByteArray ciphertext() const
     {
-        return contentPart<QString>(CiphertextKeyL).toLatin1();
+        return contentPart<QString>(CiphertextKey).toLatin1();
     }
     QJsonObject ciphertext(const QString& identityKey) const
     {
-        return contentPart<QJsonObject>(CiphertextKeyL)
+        return contentPart<QJsonObject>(CiphertextKey)
             .value(identityKey)
             .toObject();
     }
-    QString senderKey() const { return contentPart<QString>(SenderKeyKeyL); }
+    QString senderKey() const { return contentPart<QString>(SenderKeyKey); }
 
     /* device_id and session_id are required with Megolm */
-    QString deviceId() const { return contentPart<QString>(DeviceIdKeyL); }
-    QString sessionId() const { return contentPart<QString>(SessionIdKeyL); }
+    QString deviceId() const { return contentPart<QString>(DeviceIdKey); }
+    QString sessionId() const { return contentPart<QString>(SessionIdKey); }
     RoomEventPtr createDecrypted(const QString &decrypted) const;
 
     void setRelation(const QJsonObject& relation);

--- a/Quotient/events/event.h
+++ b/Quotient/events/event.h
@@ -561,10 +561,10 @@ inline bool is(const Event& e)
 //! the event it must outlive the downcast pointer to keep it from dangling.
 template <EventClass EventT, typename BasePtrT>
 inline auto eventCast(const BasePtrT& eptr)
-    -> decltype(static_cast<EventT*>(&*eptr))
+    -> decltype(static_cast<EventT*>(std::to_address(eptr)))
 {
     return eptr && is<std::decay_t<EventT>>(*eptr)
-               ? static_cast<EventT*>(&*eptr)
+               ? static_cast<EventT*>(std::to_address(eptr))
                : nullptr;
 }
 

--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -66,7 +66,6 @@
 #include "e2ee/e2ee_common.h"
 #include "e2ee/qolmaccount.h"
 #include "e2ee/qolminboundsession.h"
-#include "e2ee/qolmutility.h"
 #include "database.h"
 #endif // Quotient_E2EE_ENABLED
 
@@ -450,7 +449,7 @@ public:
         qCDebug(E2EE) << "Creating new outbound megolm session for room "
                       << q->objectName();
         currentOutboundMegolmSession.emplace();
-        connection->saveCurrentOutboundMegolmSession(
+        connection->database()->saveCurrentOutboundMegolmSession(
             id, *currentOutboundMegolmSession);
 
         addInboundGroupSession(QString::fromLatin1(currentOutboundMegolmSession->sessionId()),
@@ -488,29 +487,34 @@ Room::Room(Connection* connection, QString id, JoinState initialJoinState)
     d->q = this;
     d->displayname = d->calculateDisplayname(); // Set initial "Empty room" name
 #ifdef Quotient_E2EE_ENABLED
-    connectSingleShot(this, &Room::encryption, this, [this, connection](){
-        connection->encryptionUpdate(this);
-    });
-    connect(this, &Room::memberListChanged, this, [this, connection] {
-        if(usesEncryption()) {
-            connection->encryptionUpdate(this, d->usersInvited);
+    if (connection->encryptionEnabled()) {
+        connectSingleShot(this, &Room::encryption, this, [this, connection] {
+            connection->encryptionUpdate(this);
+        });
+        connect(this, &Room::memberListChanged, this, [this, connection] {
+            if(usesEncryption()) {
+                connection->encryptionUpdate(this, d->usersInvited);
+            }
+        });
+        d->groupSessions = connection->loadRoomMegolmSessions(this);
+        d->currentOutboundMegolmSession =
+            connection->database()->loadCurrentOutboundMegolmSession(id);
+        if (d->currentOutboundMegolmSession
+            && d->shouldRotateMegolmSession()) {
+            d->currentOutboundMegolmSession.reset();
         }
-    });
-    d->groupSessions = connection->loadRoomMegolmSessions(this);
-    d->currentOutboundMegolmSession =
-        connection->loadCurrentOutboundMegolmSession(id);
-    if (d->currentOutboundMegolmSession && d->shouldRotateMegolmSession()) {
-        d->currentOutboundMegolmSession.reset();
-    }
-    connect(this, &Room::userRemoved, this, [this] {
-        if (d->hasValidMegolmSession()) {
-            qCDebug(E2EE) << "Rotating the megolm session because a user left";
-            d->createMegolmSession();
-        }
-    });
+        connect(this, &Room::userRemoved, this, [this] {
+            if (d->hasValidMegolmSession()) {
+                qCDebug(E2EE)
+                    << "Rotating the megolm session because a user left";
+                d->createMegolmSession();
+            }
+        });
 
-    connect(this, &Room::beforeDestruction, this,
-            [id,connection] { connection->database()->clearRoomData(id); });
+        connect(this, &Room::beforeDestruction, this, [id, connection] {
+            connection->database()->clearRoomData(id);
+        });
+    }
 #endif
     qCDebug(STATE) << "New" << terse << initialJoinState << "Room:" << id;
 }
@@ -1623,7 +1627,8 @@ void Room::handleRoomKeyEvent(const RoomKeyEvent& roomKeyEvent,
                                   olmSessionId)) {
         qCWarning(E2EE) << "added new inboundGroupSession:"
                         << d->groupSessions.size();
-        auto undecryptedEvents = d->undecryptedEvents[roomKeyEvent.sessionId()];
+        const auto undecryptedEvents =
+            d->undecryptedEvents[roomKeyEvent.sessionId()];
         for (const auto& eventId : undecryptedEvents) {
             const auto pIdx = d->eventsIndex.constFind(eventId);
             if (pIdx == d->eventsIndex.cend())
@@ -2022,32 +2027,38 @@ QString Room::Private::doSendEvent(const RoomEvent* pEvent)
     std::unique_ptr<EncryptedEvent> encryptedEvent;
 
     if (q->usesEncryption()) {
-#ifndef Quotient_E2EE_ENABLED
-        qWarning() << "This build of libQuotient does not support E2EE.";
-        return {};
-#else
+        if (!connection->encryptionEnabled()) {
+            qWarning(E2EE) << "Room" << q->objectName()
+                           << "uses encryption but E2EE is switched off for"
+                           << connection->objectName()
+                           << "- the message won't be sent";
+            onEventSendingFailure(txnId);
+            return txnId;
+        }
+#ifdef Quotient_E2EE_ENABLED
         if (!hasValidMegolmSession() || shouldRotateMegolmSession()) {
             createMegolmSession();
         }
 
         // Send the session to other people
+        // FIXME: Take the sync/async logic to Connection in 0.8
         if (connection->isQueryingKeys()) {
-            connectSingleShot(connection, &Connection::finishedQueryingKeys, q,
-                              [this] {
+            connectSingleShot(connection, &Connection::finishedQueryingKeys,
+                              q, [this] {
                                   connection->sendSessionKeyToDevices(
                                       id, *currentOutboundMegolmSession,
                                       getDevicesWithoutKey());
                               });
         } else {
-            connection->sendSessionKeyToDevices(id,
-                                                *currentOutboundMegolmSession,
-                                                getDevicesWithoutKey());
+            connection->sendSessionKeyToDevices(
+                id, *currentOutboundMegolmSession, getDevicesWithoutKey());
         }
 
-        const auto encrypted = currentOutboundMegolmSession->encrypt(QJsonDocument(pEvent->fullJson()).toJson());
+        const auto encrypted = currentOutboundMegolmSession->encrypt(
+            QJsonDocument(pEvent->fullJson()).toJson());
         currentOutboundMegolmSession->setMessageCount(
             currentOutboundMegolmSession->messageCount() + 1);
-        connection->saveCurrentOutboundMegolmSession(
+        connection->database()->saveCurrentOutboundMegolmSession(
             id, *currentOutboundMegolmSession);
         encryptedEvent = makeEvent<EncryptedEvent>(
             encrypted, QString::fromLatin1(connection->olmAccount()->identityKeys().curve25519),
@@ -2055,10 +2066,12 @@ QString Room::Private::doSendEvent(const RoomEvent* pEvent)
         encryptedEvent->setTransactionId(QString::fromLatin1(connection->generateTxnId()));
         encryptedEvent->setRoomId(id);
         encryptedEvent->setSender(connection->userId());
-        if(pEvent->contentJson().contains("m.relates_to"_ls)) {
-            encryptedEvent->setRelation(pEvent->contentJson()["m.relates_to"_ls].toObject());
+        if (pEvent->contentJson().contains("m.relates_to"_ls)) {
+            encryptedEvent->setRelation(
+                pEvent->contentJson()["m.relates_to"_ls].toObject());
         }
-        // We show the unencrypted event locally while pending. The echo check will throw the encrypted version out
+        // We show the unencrypted event locally while pending. The echo
+        // check will throw the encrypted version out
         _event = encryptedEvent.get();
 #endif
     }
@@ -2619,23 +2632,26 @@ void Room::Private::dropExtraneousEvents(RoomEvents& events) const
 void Room::Private::decryptIncomingEvents(RoomEvents& events)
 {
 #ifdef Quotient_E2EE_ENABLED
-    QElapsedTimer et;
-    et.start();
-    size_t totalDecrypted = 0;
-    for (auto& eptr : events)
-        if (const auto& eeptr = eventCast<EncryptedEvent>(eptr)) {
-            if (eeptr->isRedacted())
-                continue;
-            if (auto decrypted = q->decryptMessage(*eeptr)) {
-                ++totalDecrypted;
-                auto&& oldEvent = eventCast<EncryptedEvent>(
-                    std::exchange(eptr, std::move(decrypted)));
-                eptr->setOriginalEvent(std::move(oldEvent));
-            } else
-                undecryptedEvents[eeptr->sessionId()] += eeptr->id();
-        }
-    if (totalDecrypted > 5 || et.nsecsElapsed() >= ProfilerMinNsecs)
-        qDebug(PROFILER) << "Decrypted" << totalDecrypted << "events in" << et;
+    if (connection->encryptionEnabled()) {
+        QElapsedTimer et;
+        et.start();
+        size_t totalDecrypted = 0;
+        for (auto& eptr : events)
+            if (const auto& eeptr = eventCast<EncryptedEvent>(eptr)) {
+                if (eeptr->isRedacted())
+                    continue;
+                if (auto decrypted = q->decryptMessage(*eeptr)) {
+                    ++totalDecrypted;
+                    auto&& oldEvent = eventCast<EncryptedEvent>(
+                        std::exchange(eptr, std::move(decrypted)));
+                    eptr->setOriginalEvent(std::move(oldEvent));
+                } else
+                    undecryptedEvents[eeptr->sessionId()] += eeptr->id();
+            }
+        if (totalDecrypted > 5 || et.nsecsElapsed() >= ProfilerMinNsecs)
+            qDebug(PROFILER)
+                << "Decrypted" << totalDecrypted << "events in" << et;
+    }
 #endif
 }
 

--- a/Quotient/user.cpp
+++ b/Quotient/user.cpp
@@ -48,10 +48,6 @@ User::User(QString userId, Connection* connection)
     : QObject(connection), d(makeImpl<Private>(std::move(userId)))
 {
     setObjectName(id());
-    if (connection->userId() == id()) {
-        // Load profile information for local user.
-        load();
-    }
 }
 
 Connection* User::connection() const

--- a/Quotient/util.cpp
+++ b/Quotient/util.cpp
@@ -138,9 +138,5 @@ int Quotient::patchVersion()
 
 bool Quotient::encryptionSupported()
 {
-#ifdef Quotient_E2EE_ENABLED
-    return true;
-#else
-    return false;
-#endif
+    return E2EE_Enabled;
 }

--- a/Quotient/util.h
+++ b/Quotient/util.h
@@ -282,5 +282,14 @@ QUOTIENT_API QString versionString();
 QUOTIENT_API int majorVersion();
 QUOTIENT_API int minorVersion();
 QUOTIENT_API int patchVersion();
+
+//! Compile-time constant to determine whether the library is compiled with E2EE
+constexpr auto E2EE_Enabled =
+#ifdef Quotient_E2EE_ENABLED
+    true;
+#else
+    false;
+#endif
+
 QUOTIENT_API bool encryptionSupported();
 } // namespace Quotient

--- a/autotests/testutils.cpp
+++ b/autotests/testutils.cpp
@@ -24,6 +24,7 @@ std::shared_ptr<Quotient::Connection> Quotient::createTestConnection(
     static constexpr auto homeserverAddr = "localhost:1234"_ls;
     NetworkAccessManager::instance()->ignoreSslErrors(true);
     auto c = std::make_shared<Connection>();
+    c->enableEncryption(E2EE_Enabled);
     const QString userId{ u'@' % localUserName % u':' % homeserverAddr };
     c->setHomeserver(QUrl(u"https://" % homeserverAddr));
     if (!waitForSignal(c, &Connection::loginFlowsChanged)


### PR DESCRIPTION
This PR refactors `Connection`, pulling out E2EE-related parts in a separate class that is only instantiated if `Connection::enableEncryption(true)` is called. Attention: this means that clients should explicitly call `Connection::enableEncryption()` on each connection before logging in. Leaving E2EE off keeps a client entirely away from the local database and the pickling key, and nothing involved in E2EE is sent or processed by this connection.

Along with this:
- `makeMockConnection()` can be used in either E2EE or non-E2EE mode
- no more falling back to a mock (i.e. zero-length) pickling key if the keychain is not in order or there's something wrong with the keychain entry for the account (for now, Debug builds will trigger an assertion failure; Release builds will disable encryption, cry in logs, and move on).

Closes #603. 