### PR TITLE
Unexport private classes

### DIFF
--- a/lib/avatar.cpp
+++ b/lib/avatar.cpp
@@ -17,7 +17,7 @@
 using namespace Quotient;
 using std::move;
 
-class Avatar::Private {
+class Q_DECL_HIDDEN Avatar::Private {
 public:
     explicit Private(QUrl url = {}) : _url(std::move(url)) {}
     ~Private()

--- a/lib/connection.cpp
+++ b/lib/connection.cpp
@@ -78,7 +78,7 @@ HashT remove_if(HashT& hashMap, Pred pred)
     return removals;
 }
 
-class Connection::Private {
+class Q_DECL_HIDDEN Connection::Private {
 public:
     explicit Private(std::unique_ptr<ConnectionData>&& connection)
         : data(std::move(connection))

--- a/lib/jobs/basejob.cpp
+++ b/lib/jobs/basejob.cpp
@@ -60,7 +60,7 @@ QDebug BaseJob::Status::dumpToLog(QDebug dbg) const
     return dbg << ": " << message;
 }
 
-class BaseJob::Private {
+class Q_DECL_HIDDEN BaseJob::Private {
 public:
     struct JobTimeoutConfig {
         seconds jobTimeout;

--- a/lib/jobs/downloadfilejob.cpp
+++ b/lib/jobs/downloadfilejob.cpp
@@ -14,7 +14,7 @@
 #endif
 
 using namespace Quotient;
-class DownloadFileJob::Private {
+class Q_DECL_HIDDEN DownloadFileJob::Private {
 public:
     Private() : tempFile(new QTemporaryFile()) {}
 

--- a/lib/mxcreply.cpp
+++ b/lib/mxcreply.cpp
@@ -13,7 +13,7 @@
 
 using namespace Quotient;
 
-class MxcReply::Private
+class Q_DECL_HIDDEN MxcReply::Private
 {
 public:
     explicit Private(QNetworkReply* r = nullptr)

--- a/lib/networkaccessmanager.cpp
+++ b/lib/networkaccessmanager.cpp
@@ -15,7 +15,7 @@
 
 using namespace Quotient;
 
-class NetworkAccessManager::Private {
+class Q_DECL_HIDDEN NetworkAccessManager::Private {
 public:
     explicit Private(NetworkAccessManager* q)
         : q(q)

--- a/lib/room.cpp
+++ b/lib/room.cpp
@@ -79,7 +79,7 @@ using std::llround;
 
 enum EventsPlacement : int { Older = -1, Newer = 1 };
 
-class Room::Private {
+class Q_DECL_HIDDEN Room::Private {
 public:
     /// Map of user names to users
     /** User names potentially duplicate, hence QMultiHash. */

--- a/lib/ssosession.cpp
+++ b/lib/ssosession.cpp
@@ -14,7 +14,7 @@
 
 using namespace Quotient;
 
-class SsoSession::Private {
+class Q_DECL_HIDDEN SsoSession::Private {
 public:
     Private(SsoSession* q, QString initialDeviceName = {},
             QString deviceId = {}, Connection* connection = nullptr)

--- a/lib/user.cpp
+++ b/lib/user.cpp
@@ -25,7 +25,7 @@
 
 using namespace Quotient;
 
-class User::Private {
+class Q_DECL_HIDDEN User::Private {
 public:
     Private(QString userId) : id(std::move(userId)), hueF(stringToHueF(id)) { }
 


### PR DESCRIPTION
Nested classes by default inherit the visibility of their outer class, so we need to explicitly set that back to hidden.