### PR TITLE
Improve room alias management

### DIFF
--- a/lib/connection.cpp
+++ b/lib/connection.cpp
@@ -18,6 +18,7 @@
 
 #include "csapi/account-data.h"
 #include "csapi/capabilities.h"
+#include "csapi/directory.h"
 #include "csapi/joining.h"
 #include "csapi/leaving.h"
 #include "csapi/logout.h"
@@ -1490,6 +1491,23 @@ Room* Connection::roomByAlias(const QString& roomAlias, JoinStates states) const
     qCWarning(MAIN) << "Room for alias" << roomAlias
                     << "is not found under account" << userId();
     return nullptr;
+}
+
+void Connection::mapAlias(const QString& roomId, const QString& alias)
+{
+    auto getRoomIdByAliasJob = callApi<GetRoomIdByAliasJob>(alias);
+    connect(getRoomIdByAliasJob, &BaseJob::success, this, [this, getRoomIdByAliasJob, alias, roomId] {
+        if (!getRoomIdByAliasJob->roomId().isEmpty()) {
+            qWarning(MAIN) << "Alias" << alias << "is already mapped to" << getRoomIdByAliasJob->roomId();
+        } else {
+            callApi<SetRoomAliasJob>(alias, roomId);
+        }
+    });
+}
+
+void Connection::unmapAlias(const QString& alias)
+{
+    callApi<DeleteRoomAliasJob>(alias);
 }
 
 void Connection::updateRoomAliases(const QString& roomId,

--- a/lib/connection.h
+++ b/lib/connection.h
@@ -288,6 +288,15 @@ public:
     Q_INVOKABLE Quotient::Room* roomByAlias(
         const QString& roomAlias,
         Quotient::JoinStates states = JoinState::Invite | JoinState::Join) const;
+
+    //! \brief Map an alias to a room ID on the server.
+    //!
+    //! \note This is different to Room::setLocalAliases as that can only
+    //!       get the room to publish an alias that is already mapped.
+    //! \sa Room::setLocalAliases
+    Q_INVOKABLE void mapAlias(const QString& roomId, const QString& alias);
+    //! Unmap an alias from a room ID on the server.
+    Q_INVOKABLE void unmapAlias(const QString& alias);
     //! \brief Update the internal map of room aliases to IDs
     //!
     //! This is used to maintain the internal index of room aliases.

--- a/lib/connection.h
+++ b/lib/connection.h
@@ -289,13 +289,19 @@ public:
         const QString& roomAlias,
         Quotient::JoinStates states = JoinState::Invite | JoinState::Join) const;
 
-    //! \brief Map an alias to a room ID on the server.
+    //! \brief Map an alias to a room ID on the user's current server.
     //!
-    //! \note This is different to Room::setLocalAliases as that can only
-    //!       get the room to publish an alias that is already mapped.
-    //! \sa Room::setLocalAliases
+    //! This uses the room alias endpoint from the matrix specification
+    //! https://spec.matrix.org/v1.5/client-server-api/#room-aliases
+    //!
+    //! \note This is different to Room::setLocalAliases and
+    //!       Room::setCanonicalAlias as they can only get the room to publish
+    //!       an alias that is already mapped.
+    //!       i.e. Use this function first to map an alias then Room::setLocalAliases
+    //!       or Room::setCanonicalAlias to publish the alias officially.
+    //! \sa Room::setLocalAliases, Room::setCanonicalAlias
     Q_INVOKABLE void mapAlias(const QString& roomId, const QString& alias);
-    //! Unmap an alias from a room ID on the server.
+    //! Unmap an alias from a room ID on the user's current server.
     Q_INVOKABLE void unmapAlias(const QString& alias);
     //! \brief Update the internal map of room aliases to IDs
     //!

--- a/lib/room.h
+++ b/lib/room.h
@@ -836,10 +836,17 @@ public Q_SLOTS:
                                      const QString& stateKey,
                                      const QJsonObject& contentJson);
     void setName(const QString& newName);
-    void setCanonicalAlias(const QString& newAlias);
+
+    //! \brief Map an alias to this room on the server.
+    //!
+    //! \note This is different to setLocalAliases as that can only
+    //!       get the room to publish an alias that is already mapped.
+    //! \sa setLocalAliases
+    Q_INVOKABLE void mapAlias(const QString& alias) const;
+    Q_INVOKABLE void setCanonicalAlias(const QString& newAlias);
     void setPinnedEvents(const QStringList& events);
     /// Set room aliases on the user's current server
-    void setLocalAliases(const QStringList& aliases);
+    Q_INVOKABLE void setLocalAliases(const QStringList& aliases);
     void setTopic(const QString& newTopic);
 
     /// You shouldn't normally call this method; it's here for debugging

--- a/lib/room.h
+++ b/lib/room.h
@@ -837,15 +837,23 @@ public Q_SLOTS:
                                      const QJsonObject& contentJson);
     void setName(const QString& newName);
 
-    //! \brief Map an alias to this room on the server.
+    //! \brief Map an alias to this room on the user's current server.
     //!
-    //! \note This is different to setLocalAliases as that can only
-    //!       get the room to publish an alias that is already mapped.
-    //! \sa setLocalAliases
+    //! Convenience function to call Connection::mapAlias with this room's ID
+    //! \sa Connection::mapAlias
     Q_INVOKABLE void mapAlias(const QString& alias) const;
+    //! \brief Publish the given alias as the room's canonical alias.
+    //!
+    //! The alias that is published must already have been mapped to the room
+    //! on the server.
+    //! \sa Room::mapAlias
     Q_INVOKABLE void setCanonicalAlias(const QString& newAlias);
     void setPinnedEvents(const QStringList& events);
-    /// Set room aliases on the user's current server
+    /// \brief Publish list of alt aliases for the room on the user's current server.
+    //!
+    //! The aliases that are published must already have been mapped to the room
+    //! on the server.
+    //! \sa Room::mapAlias
     Q_INVOKABLE void setLocalAliases(const QStringList& aliases);
     void setTopic(const QString& newTopic);
 


### PR DESCRIPTION
- modify setCanonicalAlias and setLocalAliases to prevent the same alias being the canonical and an alt alias (the server doesn't prevent this)
- add functions to connection to map and unmap aliases on the server
- add function to map an alias to the current room on the server