### PR TITLE
Consistently mark QLatin1String constants as constexpr inline

### DIFF
--- a/lib/e2ee/e2ee_common.h
+++ b/lib/e2ee/e2ee_common.h
@@ -22,20 +22,20 @@
 
 namespace Quotient {
 
-constexpr auto AlgorithmKeyL = "algorithm"_ls;
-constexpr auto RotationPeriodMsKeyL = "rotation_period_ms"_ls;
-constexpr auto RotationPeriodMsgsKeyL = "rotation_period_msgs"_ls;
+constexpr inline auto AlgorithmKeyL = "algorithm"_ls;
+constexpr inline auto RotationPeriodMsKeyL = "rotation_period_ms"_ls;
+constexpr inline auto RotationPeriodMsgsKeyL = "rotation_period_msgs"_ls;
 
-constexpr auto AlgorithmKey = "algorithm"_ls;
-constexpr auto RotationPeriodMsKey = "rotation_period_ms"_ls;
-constexpr auto RotationPeriodMsgsKey = "rotation_period_msgs"_ls;
+constexpr inline auto AlgorithmKey = "algorithm"_ls;
+constexpr inline auto RotationPeriodMsKey = "rotation_period_ms"_ls;
+constexpr inline auto RotationPeriodMsgsKey = "rotation_period_msgs"_ls;
 
-constexpr auto Ed25519Key = "ed25519"_ls;
-constexpr auto Curve25519Key = "curve25519"_ls;
-constexpr auto SignedCurve25519Key = "signed_curve25519"_ls;
+constexpr inline auto Ed25519Key = "ed25519"_ls;
+constexpr inline auto Curve25519Key = "curve25519"_ls;
+constexpr inline auto SignedCurve25519Key = "signed_curve25519"_ls;
 
-constexpr auto OlmV1Curve25519AesSha2AlgoKey = "m.olm.v1.curve25519-aes-sha2"_ls;
-constexpr auto MegolmV1AesSha2AlgoKey = "m.megolm.v1.aes-sha2"_ls;
+constexpr inline auto OlmV1Curve25519AesSha2AlgoKey = "m.olm.v1.curve25519-aes-sha2"_ls;
+constexpr inline auto MegolmV1AesSha2AlgoKey = "m.megolm.v1.aes-sha2"_ls;
 
 constexpr std::array SupportedAlgorithms { OlmV1Curve25519AesSha2AlgoKey,
                                            MegolmV1AesSha2AlgoKey };

--- a/lib/events/accountdataevents.h
+++ b/lib/events/accountdataevents.h
@@ -6,9 +6,9 @@
 #include "event.h"
 
 namespace Quotient {
-constexpr auto FavouriteTag [[maybe_unused]] = "m.favourite"_ls;
-constexpr auto LowPriorityTag [[maybe_unused]] = "m.lowpriority"_ls;
-constexpr auto ServerNoticeTag [[maybe_unused]] = "m.server_notice"_ls;
+constexpr inline auto FavouriteTag = "m.favourite"_ls;
+constexpr inline auto LowPriorityTag = "m.lowpriority"_ls;
+constexpr inline auto ServerNoticeTag = "m.server_notice"_ls;
 
 struct TagRecord {
     Omittable<float> order = none;

--- a/lib/events/encryptedevent.h
+++ b/lib/events/encryptedevent.h
@@ -7,10 +7,10 @@
 
 namespace Quotient {
 
-constexpr auto CiphertextKeyL = "ciphertext"_ls;
-constexpr auto SenderKeyKeyL = "sender_key"_ls;
-constexpr auto DeviceIdKeyL = "device_id"_ls;
-constexpr auto SessionIdKeyL = "session_id"_ls;
+constexpr inline auto CiphertextKeyL = "ciphertext"_ls;
+constexpr inline auto SenderKeyKeyL = "sender_key"_ls;
+constexpr inline auto DeviceIdKeyL = "device_id"_ls;
+constexpr inline auto SessionIdKeyL = "session_id"_ls;
 
 /*
  * While the specification states:

--- a/lib/events/event.h
+++ b/lib/events/event.h
@@ -29,16 +29,16 @@ inline TargetEventT* weakPtrCast(const event_ptr_tt<EventT>& ptr)
 
 // === Standard Matrix key names and basicEventJson() ===
 
-constexpr auto TypeKeyL = "type"_ls;
-constexpr auto BodyKeyL = "body"_ls;
-constexpr auto ContentKeyL = "content"_ls;
-constexpr auto EventIdKeyL = "event_id"_ls;
-constexpr auto SenderKeyL = "sender"_ls;
-constexpr auto RoomIdKeyL = "room_id"_ls;
-constexpr auto UnsignedKeyL = "unsigned"_ls;
-constexpr auto RedactedCauseKeyL = "redacted_because"_ls;
-constexpr auto PrevContentKeyL = "prev_content"_ls;
-constexpr auto StateKeyKeyL = "state_key"_ls;
+constexpr inline auto TypeKeyL = "type"_ls;
+constexpr inline auto BodyKeyL = "body"_ls;
+constexpr inline auto ContentKeyL = "content"_ls;
+constexpr inline auto EventIdKeyL = "event_id"_ls;
+constexpr inline auto SenderKeyL = "sender"_ls;
+constexpr inline auto RoomIdKeyL = "room_id"_ls;
+constexpr inline auto UnsignedKeyL = "unsigned"_ls;
+constexpr inline auto RedactedCauseKeyL = "redacted_because"_ls;
+constexpr inline auto PrevContentKeyL = "prev_content"_ls;
+constexpr inline auto StateKeyKeyL = "state_key"_ls;
 const QString TypeKey { TypeKeyL };
 const QString BodyKey { BodyKeyL };
 const QString ContentKey { ContentKeyL };
@@ -516,7 +516,7 @@ public:
 /// in camelCase, no quotes (an identifier, not a literal).
 #define DEFINE_SIMPLE_EVENT(Name_, Base_, TypeId_, ValueType_, GetterName_,  \
                             JsonKey_)                                        \
-    constexpr auto Name_##ContentKey = JsonKey_##_ls;                        \
+    constexpr inline auto Name_##ContentKey = JsonKey_##_ls;                 \
     class QUOTIENT_API Name_                                                 \
         : public EventTemplate<                                              \
               Name_, Base_,                                                  \

--- a/lib/events/eventrelation.h
+++ b/lib/events/eventrelation.h
@@ -7,8 +7,8 @@
 
 namespace Quotient {
 
-[[maybe_unused]] constexpr auto RelatesToKey = "m.relates_to"_ls;
-[[maybe_unused]] constexpr auto RelTypeKey = "rel_type"_ls;
+constexpr inline auto RelatesToKey = "m.relates_to"_ls;
+constexpr inline auto RelTypeKey = "rel_type"_ls;
 
 struct QUOTIENT_API EventRelation {
     using reltypeid_t = QLatin1String;

--- a/lib/events/keyverificationevent.h
+++ b/lib/events/keyverificationevent.h
@@ -7,7 +7,7 @@
 
 namespace Quotient {
 
-static constexpr auto SasV1Method = "m.sas.v1"_ls;
+constexpr inline auto SasV1Method = "m.sas.v1"_ls;
 
 class QUOTIENT_API KeyVerificationEvent : public Event {
 public:

--- a/lib/events/simplestateevents.h
+++ b/lib/events/simplestateevents.h
@@ -8,7 +8,7 @@
 
 namespace Quotient {
 #define DEFINE_SIMPLE_STATE_EVENT(Name_, TypeId_, ValueType_, ContentKey_)   \
-    constexpr auto Name_##Key = #ContentKey_##_ls;                           \
+    constexpr inline auto Name_##Key = #ContentKey_##_ls;                    \
     class QUOTIENT_API Name_                                                 \
         : public KeylessStateEventBase<                                      \
               Name_, EventContent::SingleKeyValue<ValueType_, Name_##Key>> { \
@@ -25,7 +25,7 @@ DEFINE_SIMPLE_STATE_EVENT(RoomTopicEvent, "m.room.topic", QString, topic)
 DEFINE_SIMPLE_STATE_EVENT(RoomPinnedEvent, "m.room.pinned_messages",
                           QStringList, pinnedEvents)
 
-constexpr auto RoomAliasesEventKey = "aliases"_ls;
+constexpr inline auto RoomAliasesEventKey = "aliases"_ls;
 class QUOTIENT_API RoomAliasesEvent
     : public KeyedStateEventBase<
           RoomAliasesEvent,

--- a/lib/syncdata.h
+++ b/lib/syncdata.h
@@ -9,10 +9,10 @@
 
 namespace Quotient {
 
-constexpr auto UnreadNotificationsKey = "unread_notifications"_ls;
-constexpr auto PartiallyReadCountKey = "x-quotient.since_fully_read_count"_ls;
-constexpr auto NewUnreadCountKey = "org.matrix.msc2654.unread_count"_ls;
-constexpr auto HighlightCountKey = "highlight_count"_ls;
+constexpr inline auto UnreadNotificationsKey = "unread_notifications"_ls;
+constexpr inline auto PartiallyReadCountKey = "x-quotient.since_fully_read_count"_ls;
+constexpr inline auto NewUnreadCountKey = "org.matrix.msc2654.unread_count"_ls;
+constexpr inline auto HighlightCountKey = "highlight_count"_ls;
 
 /// Room summary, as defined in MSC688
 /**


### PR DESCRIPTION
constexpr alone ensures those are compile-time constructed, but without the inline they are duplicated in each translation unit including the corresponding header files (independent of usage).

In a size-optimized build that reduces the library size by almost 3%.