### PR TITLE
Consistently use the QLatin1String key constants

### DIFF
--- a/lib/events/event.h
+++ b/lib/events/event.h
@@ -280,7 +280,7 @@ public:
     static QJsonObject basicJson(const QString& matrixType,
                                  const QJsonObject& content)
     {
-        return { { TypeKey, matrixType }, { ContentKey, content } };
+        return { { TypeKeyL, matrixType }, { ContentKeyL, content } };
     }
 
     //! \brief Event Matrix type, as identified by its metatype object

--- a/lib/events/eventrelation.cpp
+++ b/lib/events/eventrelation.cpp
@@ -16,7 +16,7 @@ void JsonObjectConverter<EventRelation>::dumpTo(QJsonObject& jo,
         return;
     }
     jo.insert(RelTypeKey, pod.type);
-    jo.insert(EventIdKey, pod.eventId);
+    jo.insert(EventIdKeyL, pod.eventId);
     if (pod.type == EventRelation::AnnotationType)
         jo.insert(QStringLiteral("key"), pod.key);
 }

--- a/lib/events/reactionevent.h
+++ b/lib/events/reactionevent.h
@@ -16,7 +16,7 @@ public:
     QUO_EVENT(ReactionEvent, "m.reaction")
     static bool isValid(const QJsonObject& fullJson)
     {
-        return fullJson[ContentKey][RelatesToKey][RelTypeKey].toString()
+        return fullJson[ContentKeyL][RelatesToKey][RelTypeKey].toString()
                == EventRelation::AnnotationType;
     }
 

--- a/lib/events/roomevent.cpp
+++ b/lib/events/roomevent.cpp
@@ -51,19 +51,19 @@ QString RoomEvent::stateKey() const
 
 void RoomEvent::setRoomId(const QString& roomId)
 {
-    editJson().insert(RoomIdKey, roomId);
+    editJson().insert(RoomIdKeyL, roomId);
 }
 
 void RoomEvent::setSender(const QString& senderId)
 {
-    editJson().insert(SenderKey, senderId);
+    editJson().insert(SenderKeyL, senderId);
 }
 
 void RoomEvent::setTransactionId(const QString& txnId)
 {
     auto unsignedData = fullJson()[UnsignedKeyL].toObject();
     unsignedData.insert(QStringLiteral("transaction_id"), txnId);
-    editJson().insert(UnsignedKey, unsignedData);
+    editJson().insert(UnsignedKeyL, unsignedData);
     Q_ASSERT(transactionId() == txnId);
 }
 
@@ -71,7 +71,7 @@ void RoomEvent::addId(const QString& newId)
 {
     Q_ASSERT(id().isEmpty());
     Q_ASSERT(!newId.isEmpty());
-    editJson().insert(EventIdKey, newId);
+    editJson().insert(EventIdKeyL, newId);
     qCDebug(EVENTS) << "Event txnId -> id:" << transactionId() << "->" << id();
     Q_ASSERT(id() == newId);
 }

--- a/lib/events/roommessageevent.cpp
+++ b/lib/events/roommessageevent.cpp
@@ -112,7 +112,7 @@ QJsonObject RoomMessageEvent::assembleContentJson(const QString& plainBody,
                    && textContent->relatesTo->type
                           == EventRelation::ReplacementType) {
             auto newContentJson = json.take("m.new_content"_ls).toObject();
-            newContentJson.insert(BodyKey, plainBody);
+            newContentJson.insert(BodyKeyL, plainBody);
             newContentJson.insert(MsgTypeKey, jsonMsgType);
             json.insert(QStringLiteral("m.new_content"), newContentJson);
             json[MsgTypeKey] = jsonMsgType;
@@ -121,7 +121,7 @@ QJsonObject RoomMessageEvent::assembleContentJson(const QString& plainBody,
         }
     }
     json.insert(MsgTypeKey, jsonMsgType);
-    json.insert(BodyKey, plainBody);
+    json.insert(BodyKeyL, plainBody);
     return json;
 }
 
@@ -330,9 +330,9 @@ void TextContent::fillJson(QJsonObject &json) const
             relatesTo->type == EventRelation::ReplyType
                 ? QJsonObject { { relatesTo->type,
                                   QJsonObject {
-                                      { EventIdKey, relatesTo->eventId } } } }
+                                      { EventIdKeyL, relatesTo->eventId } } } }
                 : QJsonObject { { RelTypeKey, relatesTo->type },
-                                { EventIdKey, relatesTo->eventId } });
+                                { EventIdKeyL, relatesTo->eventId } });
         if (relatesTo->type == EventRelation::ReplacementType) {
             QJsonObject newContentJson;
             if (mimeType.inherits("text/html")) {

--- a/lib/events/stateevent.h
+++ b/lib/events/stateevent.h
@@ -32,9 +32,9 @@ public:
                                  const QString& stateKey = {},
                                  const QJsonObject& contentJson = {})
     {
-        return { { TypeKey, matrixTypeId },
-                 { StateKeyKey, stateKey },
-                 { ContentKey, contentJson } };
+        return { { TypeKeyL, matrixTypeId },
+                 { StateKeyKeyL, stateKey },
+                 { ContentKeyL, contentJson } };
     }
 
     QString replacedState() const;
@@ -94,7 +94,7 @@ public:
         : StateEvent(EventT::TypeId, stateKey)
         , _content { std::forward<ContentParamTs>(contentParams)... }
     {
-        editJson().insert(ContentKey, toJson(_content));
+        editJson().insert(ContentKeyL, toJson(_content));
     }
 
     const ContentT& content() const { return _content; }

--- a/lib/room.cpp
+++ b/lib/room.cpp
@@ -2643,7 +2643,7 @@ RoomEventPtr makeRedacted(const RoomEvent& target,
     // clang-format puts them in a single column...
     // clang-format off
     static const QStringList keepKeys {
-        EventIdKey, TypeKey, RoomIdKey, SenderKey, StateKeyKey,
+        EventIdKeyL, TypeKeyL, RoomIdKeyL, SenderKeyL, StateKeyKeyL,
         "hashes"_ls, "signatures"_ls, "depth"_ls, "prev_events"_ls,
         "prev_state"_ls, "auth_events"_ls, "origin"_ls, "origin_server_ts"_ls,
         "membership"_ls };
@@ -2683,7 +2683,7 @@ RoomEventPtr makeRedacted(const RoomEvent& target,
             else
                 ++it;
         }
-        originalJson.insert(ContentKey, content);
+        originalJson.insert(ContentKeyL, content);
     }
     auto unsignedData = originalJson.take(UnsignedKeyL).toObject();
     unsignedData[RedactedCauseKeyL] = redaction.fullJson();
@@ -2765,7 +2765,7 @@ RoomEventPtr makeReplaced(const RoomEvent& target,
     auto relations = unsignedData.take("m.relations"_ls).toObject();
     relations["m.replace"_ls] = replacement.id();
     unsignedData.insert(QStringLiteral("m.relations"), relations);
-    originalJson.insert(UnsignedKey, unsignedData);
+    originalJson.insert(UnsignedKeyL, unsignedData);
 
     return loadEvent<RoomEvent>(originalJson);
 }


### PR DESCRIPTION
Prepares for the eventual removal of the QString ones.

Deprecation attributes on the QString ones doesn't work unfortunately, that triggers on every include of event.h (as that is technically a use then, which is exactly the problem we want to fix by removing them). This should work though when turning those into extern/exported declarations.

Another possible approach could be to just make them aliases for the QLatin1Strings. That wont break ABI as they are not part of the ABI at this point. It is potentially an API change though, in case of those keys being used in a place where a QLatin1String would not work. That does seem somewhat unlikely though, given their primary use is with QJson*.