### PR TITLE
Draft: Make internal includes work independent of the include search path(s)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,12 @@ set(${PROJECT_NAME}_INSTALL_INCLUDEDIR
         "${CMAKE_INSTALL_INCLUDEDIR}/${INCLUDEDIR_INIT}" CACHE PATH
         "directory to install ${PROJECT_NAME} include files to")
 
+if (${PROJECT_NAME}_INSTALL_INCLUDEDIR STREQUAL ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME})
+    set(LEGACY_INCLUDE_SEARCH_PATH ${${PROJECT_NAME}_INSTALL_INCLUDEDIR})
+else()
+    message("Not using namespaced include install layout, this is deprecated")
+endif()
+
 # Instruct CMake to run moc automatically when needed.
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
@@ -305,7 +311,8 @@ endif ()
 
 target_include_directories(${PROJECT_NAME} PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/lib>
-    $<INSTALL_INTERFACE:${${PROJECT_NAME}_INSTALL_INCLUDEDIR}>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+    $<INSTALL_INTERFACE:${LEGACY_INCLUDE_SEARCH_PATH}> # TODO this should be added manually in the cmake config file, behind a consumer-controlled switch
 )
 
 target_link_libraries(${PROJECT_NAME} PUBLIC ${Qt}::Core ${Qt}::Network ${Qt}::Gui qt${${Qt}Core_VERSION_MAJOR}keychain)
@@ -343,7 +350,6 @@ endif()
 install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}Targets
         LIBRARY RUNTIME
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        INCLUDES DESTINATION ${${PROJECT_NAME}_INSTALL_INCLUDEDIR}
 )
 install(DIRECTORY lib/ DESTINATION ${${PROJECT_NAME}_INSTALL_INCLUDEDIR}
         FILES_MATCHING PATTERN "*.h")

--- a/gtad/gtad.yaml
+++ b/gtad/gtad.yaml
@@ -87,16 +87,17 @@ analyzer:
         +on:
         - /state_event.yaml$/:
             type: StateEventPtr
-            imports: '"events/stateevent.h"'
+            imports: '"../events/stateevent.h"'
         - /(room|client)_event.yaml$/:
             type: RoomEventPtr
-            imports: '"events/roomevent.h"'
+            imports: '"../events/roomevent.h"'
         - /event(_without_room_id)?.yaml$/:
             type: EventPtr
-            imports: '"events/event.h"'
+            imports: '"../events/event.h"'
       - +set:
           # This renderer applies to everything actually $ref'ed
           # (not substituted)
+          # TODO this would need to go up as many levels first as we are currently nested (for the file we are generating, not for $ref!)
           _importRenderer: '"{{#segments}}{{_}}{{#_join}}/{{/_join}}{{/segments}}.h"'
         +on:
         - '/^(\./)?definitions/request_email_validation.yaml$/':
@@ -130,7 +131,7 @@ analyzer:
       - RoomFilter: # A structure inside Filter, same story as with *_filter.yaml
       - OneTimeKeys:
           type: OneTimeKeys
-          imports: '"e2ee/e2ee_common.h"'
+          imports: '"../e2ee/e2ee_common.h"'
       - //: *UseOmittable
     - array:
       - string: QStringList
@@ -139,7 +140,7 @@ analyzer:
         - /^Notification|Result|ChildRoomsChunk$/: "std::vector<{{1}}>"
         - /^StrippedChildStateEvent$|state_event.yaml$/:
             type: StateEvents
-            imports: '"events/stateevent.h"' # For StrippedChildStateEvent
+            imports: '"../events/stateevent.h"' # For StrippedChildStateEvent
         - /(room|client)_event.yaml$/: RoomEvents
         - /event(_without_room_id)?.yaml$/: Events
       - //: "QVector<{{1}}>"

--- a/gtad/operation.h.mustache
+++ b/gtad/operation.h.mustache
@@ -4,7 +4,7 @@ SPDX-License-Identifier: LGPL-2.1-or-later
 }}{{>preamble}}
 #pragma once
 
-#include "jobs/basejob.h"
+#include "../jobs/basejob.h"
 {{#imports}}
 #include {{_}}{{/imports}}
 {{#operations.producesNonJson?}}

--- a/lib/csapi/account-data.h
+++ b/lib/csapi/account-data.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "jobs/basejob.h"
+#include "../jobs/basejob.h"
 
 namespace Quotient {
 

--- a/lib/csapi/admin.h
+++ b/lib/csapi/admin.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "jobs/basejob.h"
+#include "../jobs/basejob.h"
 
 namespace Quotient {
 

--- a/lib/csapi/administrative_contact.h
+++ b/lib/csapi/administrative_contact.h
@@ -4,12 +4,12 @@
 
 #pragma once
 
+#include "../jobs/basejob.h"
+
 #include "csapi/definitions/auth_data.h"
 #include "csapi/definitions/request_email_validation.h"
 #include "csapi/definitions/request_msisdn_validation.h"
 #include "csapi/definitions/request_token_response.h"
-
-#include "jobs/basejob.h"
 
 namespace Quotient {
 

--- a/lib/csapi/appservice_room_directory.h
+++ b/lib/csapi/appservice_room_directory.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "jobs/basejob.h"
+#include "../jobs/basejob.h"
 
 namespace Quotient {
 

--- a/lib/csapi/banning.h
+++ b/lib/csapi/banning.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "jobs/basejob.h"
+#include "../jobs/basejob.h"
 
 namespace Quotient {
 

--- a/lib/csapi/capabilities.h
+++ b/lib/csapi/capabilities.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "jobs/basejob.h"
+#include "../jobs/basejob.h"
 
 namespace Quotient {
 

--- a/lib/csapi/content-repo.h
+++ b/lib/csapi/content-repo.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "jobs/basejob.h"
+#include "../jobs/basejob.h"
 
 #include <QtCore/QIODevice>
 #include <QtNetwork/QNetworkReply>

--- a/lib/csapi/create_room.h
+++ b/lib/csapi/create_room.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "jobs/basejob.h"
+#include "../jobs/basejob.h"
 
 namespace Quotient {
 

--- a/lib/csapi/cross_signing.h
+++ b/lib/csapi/cross_signing.h
@@ -4,10 +4,10 @@
 
 #pragma once
 
+#include "../jobs/basejob.h"
+
 #include "csapi/definitions/auth_data.h"
 #include "csapi/definitions/cross_signing_key.h"
-
-#include "jobs/basejob.h"
 
 namespace Quotient {
 

--- a/lib/csapi/device_management.h
+++ b/lib/csapi/device_management.h
@@ -4,10 +4,10 @@
 
 #pragma once
 
+#include "../jobs/basejob.h"
+
 #include "csapi/definitions/auth_data.h"
 #include "csapi/definitions/client_device.h"
-
-#include "jobs/basejob.h"
 
 namespace Quotient {
 

--- a/lib/csapi/directory.h
+++ b/lib/csapi/directory.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "jobs/basejob.h"
+#include "../jobs/basejob.h"
 
 namespace Quotient {
 

--- a/lib/csapi/event_context.h
+++ b/lib/csapi/event_context.h
@@ -4,9 +4,9 @@
 
 #pragma once
 
-#include "events/roomevent.h"
-#include "events/stateevent.h"
-#include "jobs/basejob.h"
+#include "../events/roomevent.h"
+#include "../events/stateevent.h"
+#include "../jobs/basejob.h"
 
 namespace Quotient {
 

--- a/lib/csapi/filter.h
+++ b/lib/csapi/filter.h
@@ -4,9 +4,9 @@
 
 #pragma once
 
-#include "csapi/definitions/sync_filter.h"
+#include "../jobs/basejob.h"
 
-#include "jobs/basejob.h"
+#include "csapi/definitions/sync_filter.h"
 
 namespace Quotient {
 

--- a/lib/csapi/inviting.h
+++ b/lib/csapi/inviting.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "jobs/basejob.h"
+#include "../jobs/basejob.h"
 
 namespace Quotient {
 

--- a/lib/csapi/joining.h
+++ b/lib/csapi/joining.h
@@ -4,9 +4,9 @@
 
 #pragma once
 
-#include "csapi/definitions/third_party_signed.h"
+#include "../jobs/basejob.h"
 
-#include "jobs/basejob.h"
+#include "csapi/definitions/third_party_signed.h"
 
 namespace Quotient {
 

--- a/lib/csapi/keys.h
+++ b/lib/csapi/keys.h
@@ -4,12 +4,11 @@
 
 #pragma once
 
+#include "../e2ee/e2ee_common.h"
+#include "../jobs/basejob.h"
+
 #include "csapi/definitions/cross_signing_key.h"
 #include "csapi/definitions/device_keys.h"
-
-#include "e2ee/e2ee_common.h"
-
-#include "jobs/basejob.h"
 
 namespace Quotient {
 

--- a/lib/csapi/kicking.h
+++ b/lib/csapi/kicking.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "jobs/basejob.h"
+#include "../jobs/basejob.h"
 
 namespace Quotient {
 

--- a/lib/csapi/knocking.h
+++ b/lib/csapi/knocking.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "jobs/basejob.h"
+#include "../jobs/basejob.h"
 
 namespace Quotient {
 

--- a/lib/csapi/leaving.h
+++ b/lib/csapi/leaving.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "jobs/basejob.h"
+#include "../jobs/basejob.h"
 
 namespace Quotient {
 

--- a/lib/csapi/list_joined_rooms.h
+++ b/lib/csapi/list_joined_rooms.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "jobs/basejob.h"
+#include "../jobs/basejob.h"
 
 namespace Quotient {
 

--- a/lib/csapi/list_public_rooms.h
+++ b/lib/csapi/list_public_rooms.h
@@ -4,9 +4,9 @@
 
 #pragma once
 
-#include "csapi/definitions/public_rooms_response.h"
+#include "../jobs/basejob.h"
 
-#include "jobs/basejob.h"
+#include "csapi/definitions/public_rooms_response.h"
 
 namespace Quotient {
 

--- a/lib/csapi/login.h
+++ b/lib/csapi/login.h
@@ -4,10 +4,10 @@
 
 #pragma once
 
+#include "../jobs/basejob.h"
+
 #include "csapi/definitions/user_identifier.h"
 #include "csapi/definitions/wellknown/full.h"
-
-#include "jobs/basejob.h"
 
 namespace Quotient {
 

--- a/lib/csapi/logout.h
+++ b/lib/csapi/logout.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "jobs/basejob.h"
+#include "../jobs/basejob.h"
 
 namespace Quotient {
 

--- a/lib/csapi/message_pagination.h
+++ b/lib/csapi/message_pagination.h
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include "events/roomevent.h"
-#include "jobs/basejob.h"
+#include "../events/roomevent.h"
+#include "../jobs/basejob.h"
 
 namespace Quotient {
 

--- a/lib/csapi/notifications.h
+++ b/lib/csapi/notifications.h
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include "events/event.h"
-#include "jobs/basejob.h"
+#include "../events/event.h"
+#include "../jobs/basejob.h"
 
 namespace Quotient {
 

--- a/lib/csapi/openid.h
+++ b/lib/csapi/openid.h
@@ -4,9 +4,9 @@
 
 #pragma once
 
-#include "csapi/definitions/openid_token.h"
+#include "../jobs/basejob.h"
 
-#include "jobs/basejob.h"
+#include "csapi/definitions/openid_token.h"
 
 namespace Quotient {
 

--- a/lib/csapi/peeking_events.h
+++ b/lib/csapi/peeking_events.h
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include "events/roomevent.h"
-#include "jobs/basejob.h"
+#include "../events/roomevent.h"
+#include "../jobs/basejob.h"
 
 namespace Quotient {
 

--- a/lib/csapi/presence.h
+++ b/lib/csapi/presence.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "jobs/basejob.h"
+#include "../jobs/basejob.h"
 
 namespace Quotient {
 

--- a/lib/csapi/profile.h
+++ b/lib/csapi/profile.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "jobs/basejob.h"
+#include "../jobs/basejob.h"
 
 namespace Quotient {
 

--- a/lib/csapi/pusher.h
+++ b/lib/csapi/pusher.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "jobs/basejob.h"
+#include "../jobs/basejob.h"
 
 namespace Quotient {
 

--- a/lib/csapi/pushrules.h
+++ b/lib/csapi/pushrules.h
@@ -4,11 +4,11 @@
 
 #pragma once
 
+#include "../jobs/basejob.h"
+
 #include "csapi/definitions/push_condition.h"
 #include "csapi/definitions/push_rule.h"
 #include "csapi/definitions/push_ruleset.h"
-
-#include "jobs/basejob.h"
 
 namespace Quotient {
 

--- a/lib/csapi/read_markers.h
+++ b/lib/csapi/read_markers.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "jobs/basejob.h"
+#include "../jobs/basejob.h"
 
 namespace Quotient {
 

--- a/lib/csapi/receipts.h
+++ b/lib/csapi/receipts.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "jobs/basejob.h"
+#include "../jobs/basejob.h"
 
 namespace Quotient {
 

--- a/lib/csapi/redaction.h
+++ b/lib/csapi/redaction.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "jobs/basejob.h"
+#include "../jobs/basejob.h"
 
 namespace Quotient {
 

--- a/lib/csapi/refresh.h
+++ b/lib/csapi/refresh.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "jobs/basejob.h"
+#include "../jobs/basejob.h"
 
 namespace Quotient {
 

--- a/lib/csapi/registration.h
+++ b/lib/csapi/registration.h
@@ -4,12 +4,12 @@
 
 #pragma once
 
+#include "../jobs/basejob.h"
+
 #include "csapi/definitions/auth_data.h"
 #include "csapi/definitions/request_email_validation.h"
 #include "csapi/definitions/request_msisdn_validation.h"
 #include "csapi/definitions/request_token_response.h"
-
-#include "jobs/basejob.h"
 
 namespace Quotient {
 

--- a/lib/csapi/registration_tokens.h
+++ b/lib/csapi/registration_tokens.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "jobs/basejob.h"
+#include "../jobs/basejob.h"
 
 namespace Quotient {
 

--- a/lib/csapi/relations.h
+++ b/lib/csapi/relations.h
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include "events/roomevent.h"
-#include "jobs/basejob.h"
+#include "../events/roomevent.h"
+#include "../jobs/basejob.h"
 
 namespace Quotient {
 

--- a/lib/csapi/report_content.h
+++ b/lib/csapi/report_content.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "jobs/basejob.h"
+#include "../jobs/basejob.h"
 
 namespace Quotient {
 

--- a/lib/csapi/room_send.h
+++ b/lib/csapi/room_send.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "jobs/basejob.h"
+#include "../jobs/basejob.h"
 
 namespace Quotient {
 

--- a/lib/csapi/room_state.h
+++ b/lib/csapi/room_state.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "jobs/basejob.h"
+#include "../jobs/basejob.h"
 
 namespace Quotient {
 

--- a/lib/csapi/room_upgrades.h
+++ b/lib/csapi/room_upgrades.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "jobs/basejob.h"
+#include "../jobs/basejob.h"
 
 namespace Quotient {
 

--- a/lib/csapi/rooms.h
+++ b/lib/csapi/rooms.h
@@ -4,9 +4,9 @@
 
 #pragma once
 
-#include "events/roomevent.h"
-#include "events/stateevent.h"
-#include "jobs/basejob.h"
+#include "../events/roomevent.h"
+#include "../events/stateevent.h"
+#include "../jobs/basejob.h"
 
 namespace Quotient {
 

--- a/lib/csapi/search.h
+++ b/lib/csapi/search.h
@@ -4,11 +4,11 @@
 
 #pragma once
 
-#include "csapi/definitions/room_event_filter.h"
+#include "../events/roomevent.h"
+#include "../events/stateevent.h"
+#include "../jobs/basejob.h"
 
-#include "events/roomevent.h"
-#include "events/stateevent.h"
-#include "jobs/basejob.h"
+#include "csapi/definitions/room_event_filter.h"
 
 namespace Quotient {
 

--- a/lib/csapi/space_hierarchy.h
+++ b/lib/csapi/space_hierarchy.h
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include "events/stateevent.h"
-#include "jobs/basejob.h"
+#include "../events/stateevent.h"
+#include "../jobs/basejob.h"
 
 namespace Quotient {
 

--- a/lib/csapi/sso_login_redirect.h
+++ b/lib/csapi/sso_login_redirect.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "jobs/basejob.h"
+#include "../jobs/basejob.h"
 
 namespace Quotient {
 

--- a/lib/csapi/tags.h
+++ b/lib/csapi/tags.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "jobs/basejob.h"
+#include "../jobs/basejob.h"
 
 namespace Quotient {
 

--- a/lib/csapi/third_party_lookup.h
+++ b/lib/csapi/third_party_lookup.h
@@ -4,11 +4,11 @@
 
 #pragma once
 
+#include "../jobs/basejob.h"
+
 #include "csapi/../application-service/definitions/location.h"
 #include "csapi/../application-service/definitions/protocol.h"
 #include "csapi/../application-service/definitions/user.h"
-
-#include "jobs/basejob.h"
 
 namespace Quotient {
 

--- a/lib/csapi/third_party_membership.h
+++ b/lib/csapi/third_party_membership.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "jobs/basejob.h"
+#include "../jobs/basejob.h"
 
 namespace Quotient {
 

--- a/lib/csapi/threads_list.h
+++ b/lib/csapi/threads_list.h
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include "events/roomevent.h"
-#include "jobs/basejob.h"
+#include "../events/roomevent.h"
+#include "../jobs/basejob.h"
 
 namespace Quotient {
 

--- a/lib/csapi/to_device.h
+++ b/lib/csapi/to_device.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "jobs/basejob.h"
+#include "../jobs/basejob.h"
 
 namespace Quotient {
 

--- a/lib/csapi/typing.h
+++ b/lib/csapi/typing.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "jobs/basejob.h"
+#include "../jobs/basejob.h"
 
 namespace Quotient {
 

--- a/lib/csapi/users.h
+++ b/lib/csapi/users.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "jobs/basejob.h"
+#include "../jobs/basejob.h"
 
 namespace Quotient {
 

--- a/lib/csapi/versions.h
+++ b/lib/csapi/versions.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "jobs/basejob.h"
+#include "../jobs/basejob.h"
 
 namespace Quotient {
 

--- a/lib/csapi/voip.h
+++ b/lib/csapi/voip.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "jobs/basejob.h"
+#include "../jobs/basejob.h"
 
 namespace Quotient {
 

--- a/lib/csapi/wellknown.h
+++ b/lib/csapi/wellknown.h
@@ -4,9 +4,9 @@
 
 #pragma once
 
-#include "csapi/definitions/wellknown/full.h"
+#include "../jobs/basejob.h"
 
-#include "jobs/basejob.h"
+#include "csapi/definitions/wellknown/full.h"
 
 namespace Quotient {
 

--- a/lib/csapi/whoami.h
+++ b/lib/csapi/whoami.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "jobs/basejob.h"
+#include "../jobs/basejob.h"
 
 namespace Quotient {
 

--- a/lib/e2ee/e2ee_common.h
+++ b/lib/e2ee/e2ee_common.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "converters.h"
+#include "../converters.h"
 
 #include <QtCore/QMetaType>
 #include <QtCore/QStringBuilder>
@@ -13,7 +13,7 @@
 #include <array>
 
 #ifdef Quotient_E2EE_ENABLED
-#    include "expected.h"
+#    include "../expected.h"
 
 #    include <olm/error.h>
 #    include <span>

--- a/lib/events/event.h
+++ b/lib/events/event.h
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include "converters.h"
-#include "function_traits.h"
+#include "../converters.h"
+#include "../function_traits.h"
 #include "single_key_value.h"
 
 namespace Quotient {

--- a/lib/events/eventcontent.h
+++ b/lib/events/eventcontent.h
@@ -7,7 +7,7 @@
 // message events as well as other events (e.g., avatars).
 
 #include "filesourceinfo.h"
-#include "quotient_export.h"
+#include "../quotient_export.h"
 
 #include <QtCore/QJsonObject>
 #include <QtCore/QMetaType>

--- a/lib/events/single_key_value.h
+++ b/lib/events/single_key_value.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "converters.h"
+#include "../converters.h"
 
 namespace Quotient {
 

--- a/lib/jobs/basejob.h
+++ b/lib/jobs/basejob.h
@@ -5,9 +5,9 @@
 #pragma once
 
 #include "requestdata.h"
-#include "logging.h"
-#include "converters.h" // Common for csapi/ headers even though not used here
-#include "quotient_common.h" // For DECL_DEPRECATED_ENUMERATOR
+#include "../logging.h"
+#include "../converters.h" // Common for csapi/ headers even though not used here
+#include "../quotient_common.h" // For DECL_DEPRECATED_ENUMERATOR
 
 #include <QtCore/QObject>
 #include <QtCore/QStringBuilder>

--- a/lib/jobs/downloadfilejob.h
+++ b/lib/jobs/downloadfilejob.h
@@ -3,9 +3,9 @@
 
 #pragma once
 
-#include "csapi/content-repo.h"
+#include "../csapi/content-repo.h"
 
-#include "events/filesourceinfo.h"
+#include "../events/filesourceinfo.h"
 
 namespace Quotient {
 class QUOTIENT_API DownloadFileJob : public GetContentJob {

--- a/lib/jobs/mediathumbnailjob.h
+++ b/lib/jobs/mediathumbnailjob.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "csapi/content-repo.h"
+#include "../csapi/content-repo.h"
 
 #include <QtGui/QPixmap>
 

--- a/lib/jobs/requestdata.h
+++ b/lib/jobs/requestdata.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "util.h"
+#include "../util.h"
 
 class QJsonObject;
 class QJsonArray;


### PR DESCRIPTION
This is necessary in order to be able to remove `include/Quotient` from the include search path to force namespaced includes in consumer code.

This is still vastly incomplete on the non-generated header files, so consider those only as an example. The real blocker however are the includes to referenced types in the generated headers.