### PR TITLE
Keep track of read bytes on MxcReply and reimplement bytesAvailable

### DIFF
--- a/lib/mxcreply.cpp
+++ b/lib/mxcreply.cpp
@@ -102,3 +102,11 @@ void MxcReply::abort()
         d->m_reply->abort();
     }
 }
+
+qint64 MxcReply::bytesAvailable() const
+{
+    if (d != nullptr) {
+        return d->m_device->bytesAvailable() + QNetworkReply::bytesAvailable();
+    }
+    return 0;
+}

--- a/lib/mxcreply.h
+++ b/lib/mxcreply.h
@@ -18,6 +18,8 @@ public:
     explicit MxcReply(QNetworkReply *reply);
     MxcReply(QNetworkReply* reply, Room* room, const QString& eventId);
 
+    qint64 bytesAvailable() const override;
+
 public Q_SLOTS:
     void abort() override;
 


### PR DESCRIPTION
## Problem

NeoChat has a weird issue where WebP images don't load properly, and will spit one of two errors:

* `Sequential Devices not supported` which is reported on Qt5 without KDE's patches, and is not related to this issue.
* `QWebpHandler: Insufficient data available in sequential device`. This happens because the Qt WebP image format plugin internally checks whether or not there's enough bytes in the device before continuing to read and returns this error if bytesAvailable() is below the size reported in the header. When testing, this usually means it's 0, see below for why.

WebP images over a certain size will fail to load, which is probably most of them (I believe the limit is around 16 kilobytes).

### Fixing Qt?

At first I thought [this was a Qt issue](https://codereview.qt-project.org/c/qt/qtimageformats/+/455097), but the qtimageformats maintainer pointed out that WebP actually worked fine with QNetworkReply and I discovered that the true issue is that MxcReply wasn't set up properly to return a valid number of bytes. This patch aims to fix that so the WebP image format plugin will chug along fine, plus other image formats if they do something similiar in the future.

## Solution

I reimplemented `QIODevice::bytesAvailable()` and returned the bytesAvailable from the underlying `m_device`. However, this isn't perfect because _sometimes_ `readData` is called **before** `bytesAvailable` (thus, a call to bytesAvailable() would return 0 which isn't exactly true). Fun, so I record the amount of bytes read and add that up with the returned bytesAvailable. Note that the WebP image format plugin internally calls `bytesAvailable` specifically, so it makes sense to work around it here.