### PR TITLE
Add null checks for MxcReply to prevent crashing on bad request

### DIFF
--- a/lib/mxcreply.cpp
+++ b/lib/mxcreply.cpp
@@ -90,10 +90,15 @@ MxcReply::MxcReply()
 
 qint64 MxcReply::readData(char *data, qint64 maxSize)
 {
-    return d->m_device->read(data, maxSize);
+    if(d != nullptr) {
+        return d->m_device->read(data, maxSize);
+    }
+    return -1;
 }
 
 void MxcReply::abort()
 {
-    d->m_reply->abort();
+    if(d != nullptr) {
+        d->m_reply->abort();
+    }
 }


### PR DESCRIPTION
## Problem

[NeoChat would crash mysteriously](https://bugs.kde.org/show_bug.cgi?id=467016) and the stack trace would mention MxcReply for some reason. My first thought is that `m_reply` was null, but this isn't the case. Let's look at the backtrace given:

```
[KCrash Handler]
#4  0x00007f6d95136f38 in Quotient::MxcReply::readData(char*, long long) () from /lib64/libQuotient.so.0.7
#5  0x00007f6d935ede25 in QIODevicePrivate::read(char*, long long, bool) () from /lib64/libQt5Core.so.5
#6  0x00007f6d935ee1d3 in QIODevicePrivate::peek(long long) () from /lib64/libQt5Core.so.5
#7  0x00007f6d935ef5fe in QIODevice::peek(long long) () from /lib64/libQt5Core.so.5
```

Notice how it **stops** at `Mxcreply::readData`, and not inside of `QIODevice` again (because it would then fail on Qt's null check). This means that it's actually calling upon a null `MxcReply::Private` trying to access `m_reply`. This is actually really easy to do, because:

```cpp
MxcReply::MxcReply()
    : d(ZeroImpl<Private>())
{
    static const auto BadRequestPhrase = tr("Bad Request");
```

MxcReplies that actually form bad requests, have null private objects!

## Solution

I just added null checks on `readData` and `abort` (not sure if it's needed there, but just to be safe) to check if `d` is null now. I double-checked Qt documentation, and `QIODevice::readData` should return -1.