### PR TITLE
Minor Connection/AccountRegistry tweaks

### DIFF
--- a/lib/accountregistry.cpp
+++ b/lib/accountregistry.cpp
@@ -13,8 +13,12 @@ using namespace Quotient;
 
 void AccountRegistry::add(Connection* a)
 {
-    if (contains(a))
+    Q_ASSERT(a != nullptr);
+    if (get(a->userId()) != nullptr) {
+        qWarning(MAIN) << "Attempt to add another connection for the same user "
+                          "id; skipping";
         return;
+    }
     beginInsertRows(QModelIndex(), size(), size());
     push_back(a);
     qDebug(MAIN) << "Added" << a->objectName() << "to the account registry";

--- a/lib/accountregistry.cpp
+++ b/lib/accountregistry.cpp
@@ -147,8 +147,8 @@ void AccountRegistry::invokeLogin()
                                 emit accountsLoadingChanged();
                             });
                     connection->assumeIdentity(
-                        account.userId(), QString::fromUtf8(accessTokenLoadingJob->binaryData()),
-                        account.deviceId());
+                        account.userId(),
+                        QString::fromUtf8(accessTokenLoadingJob->binaryData()));
                 });
     }
 }

--- a/lib/accountregistry.cpp
+++ b/lib/accountregistry.cpp
@@ -66,7 +66,12 @@ QHash<int, QByteArray> AccountRegistry::roleNames() const
 
 Connection* AccountRegistry::get(const QString& userId)
 {
-    for (const auto &connection : *this) {
+    return const_cast<const AccountRegistry*>(this)->get(userId);
+}
+
+Connection* AccountRegistry::get(const QString& userId) const
+{
+    for (const auto& connection : *this) {
         if (connection->userId() == userId)
             return connection;
     }

--- a/lib/accountregistry.cpp
+++ b/lib/accountregistry.cpp
@@ -36,9 +36,8 @@ void AccountRegistry::drop(Connection* a)
 
 bool AccountRegistry::isLoggedIn(const QString &userId) const
 {
-    return std::any_of(cbegin(), cend(), [&userId](const Connection* a) {
-        return a->userId() == userId;
-    });
+    const auto conn = get(userId);
+    return conn != nullptr && conn->isLoggedIn();
 }
 
 QVariant AccountRegistry::data(const QModelIndex& index, int role) const

--- a/lib/accountregistry.cpp
+++ b/lib/accountregistry.cpp
@@ -60,7 +60,8 @@ int AccountRegistry::rowCount(const QModelIndex& parent) const
 
 QHash<int, QByteArray> AccountRegistry::roleNames() const
 {
-    return { { AccountRole, QByteArrayLiteral("connection") }, { UserIdRole, QByteArrayLiteral("userId") } };
+    return { { AccountRole, QByteArrayLiteral("connection") },
+             { UserIdRole, QByteArrayLiteral("userId") } };
 }
 
 Connection* AccountRegistry::get(const QString& userId)
@@ -72,7 +73,8 @@ Connection* AccountRegistry::get(const QString& userId)
     return nullptr;
 }
 
-QKeychain::ReadPasswordJob* AccountRegistry::loadAccessTokenFromKeychain(const QString& userId)
+QKeychain::ReadPasswordJob* AccountRegistry::loadAccessTokenFromKeychain(
+    const QString& userId)
 {
     qCDebug(MAIN) << "Reading access token from keychain for" << userId;
     auto job = new QKeychain::ReadPasswordJob(qAppName(), this);

--- a/lib/accountregistry.cpp
+++ b/lib/accountregistry.cpp
@@ -17,6 +17,7 @@ void AccountRegistry::add(Connection* a)
         return;
     beginInsertRows(QModelIndex(), size(), size());
     push_back(a);
+    qDebug(MAIN) << "Added" << a->objectName() << "to the account registry";
     endInsertRows();
     emit accountCountChanged();
 }
@@ -26,6 +27,8 @@ void AccountRegistry::drop(Connection* a)
     if (const auto idx = indexOf(a); idx != -1) {
         beginRemoveRows(QModelIndex(), idx, idx);
         remove(idx);
+        qDebug(MAIN) << "Removed" << a->objectName()
+                     << "from the account registry";
         endRemoveRows();
     }
     Q_ASSERT(!contains(a));

--- a/lib/accountregistry.h
+++ b/lib/accountregistry.h
@@ -69,6 +69,8 @@ public:
 
     QStringList accountsLoading() const;
 
+    [[deprecated("This may leak Connection objects when failing and cannot be"
+                 "fixed without breaking the API; do not use it")]] //
     void invokeLogin();
 
 Q_SIGNALS:

--- a/lib/accountregistry.h
+++ b/lib/accountregistry.h
@@ -52,7 +52,8 @@ public:
     const_reference front() const { return vector_t::front(); }
     const_reference back() const { return vector_t::back(); }
     bool isLoggedIn(const QString& userId) const;
-    Connection* get(const QString& userId);
+    Connection* get(const QString& userId); // FIXME: remove in 0.8
+    Connection* get(const QString& userId) const;
 
     using vector_t::isEmpty, vector_t::empty;
     using vector_t::size, vector_t::count, vector_t::capacity;

--- a/lib/connection.cpp
+++ b/lib/connection.cpp
@@ -126,7 +126,7 @@ void Connection::resolveServer(const QString& mxid)
                 emit resolveError(tr("Failed resolving the homeserver"));
                 return;
             }
-            QUrl baseUrl { d->resolverJob->data().homeserver.baseUrl };
+            const QUrl baseUrl { d->resolverJob->data().homeserver.baseUrl };
             if (baseUrl.isEmpty()) {
                 qCWarning(MAIN) << "base_url not provided, FAIL_PROMPT";
                 emit resolveError(
@@ -2321,7 +2321,7 @@ void Connection::sendSessionKeyToDevices(
                          << "to keys to claim";
         }
 
-    auto sendKey = [devices, this, sessionId, index, sessionKey, roomId] {
+    const auto sendKey = [devices, this, sessionId, index, sessionKey, roomId] {
         QHash<QString, QHash<QString, QJsonObject>> usersToDevicesToContent;
         for (const auto& [targetUserId, targetDeviceId] : asKeyValueRange(devices)) {
             if (!hasOlmSession(targetUserId, targetDeviceId))
@@ -2350,7 +2350,7 @@ void Connection::sendSessionKeyToDevices(
             database()->setDevicesReceivedKey(roomId, receivedDevices,
                                               sessionId, index);
         }
-};
+    };
 
     if (hash.isEmpty()) {
         sendKey();

--- a/lib/connection.cpp
+++ b/lib/connection.cpp
@@ -81,6 +81,7 @@ Connection::Connection(const QUrl& server, QObject* parent)
     //connect(qApp, &QCoreApplication::aboutToQuit, this, &Connection::saveOlmAccount);
 #endif
     d->q = this; // All d initialization should occur before this line
+    setObjectName(server.toString());
 }
 
 Connection::Connection(QObject* parent) : Connection({}, parent) {}
@@ -358,11 +359,13 @@ void Connection::Private::checkAndConnect(const QString& userId,
                                           const std::optional<LoginFlow>& flow)
 {
     if (data->baseUrl().isValid() && (!flow || loginFlows.contains(*flow))) {
+        q->setObjectName(userId % u"(?)");
         connectFn();
         return;
     }
     // Not good to go, try to ascertain the homeserver URL and flows
     if (userId.startsWith(u'@') && userId.indexOf(u':') != -1) {
+        q->setObjectName(userId % u"(?)");
         q->resolveServer(userId);
         if (flow)
             connectSingleShot(q, &Connection::loginFlowsChanged, q,

--- a/lib/connection.h
+++ b/lib/connection.h
@@ -566,10 +566,17 @@ public Q_SLOTS:
 
     //! \brief Use an existing access token to connect to the homeserver
     //!
+    //! This is the old signature that will be deprecated in 0.8; since 0.7.2,
+    //! device id is resolved from the access token. Use 2-arg assumeIdentity()
+    void assumeIdentity(const QString& mxId, const QString& accessToken,
+                        [[maybe_unused]] const QString& deviceId);
+
+    //! \brief Use an existing access token to connect to the homeserver
+    //!
     //! Similar to loginWithPassword(), this method checks that the homeserver
     //! URL is valid and tries to resolve it from the MXID in case it is not.
-    void assumeIdentity(const QString& mxId, const QString& accessToken,
-                        const QString& deviceId);
+    //! \since 0.7.2
+    void assumeIdentity(const QString& mxId, const QString& accessToken);
 
     //! Explicitly request capabilities from the server
     void reloadCapabilities();

--- a/lib/connection.h
+++ b/lib/connection.h
@@ -568,6 +568,8 @@ public Q_SLOTS:
     //!
     //! This is the old signature that will be deprecated in 0.8; since 0.7.2,
     //! device id is resolved from the access token. Use 2-arg assumeIdentity()
+    [[deprecated("Device id is now resolved from accessToken; use "
+                 "assumeIdentity(QString, QString) instead of this overload")]] //
     void assumeIdentity(const QString& mxId, const QString& accessToken,
                         [[maybe_unused]] const QString& deviceId);
 

--- a/lib/connection_p.h
+++ b/lib/connection_p.h
@@ -26,12 +26,6 @@
 #include <QCoreApplication>
 #include <QPointer>
 
-#if QT_VERSION_MAJOR >= 6
-#    include <qt6keychain/keychain.h>
-#else
-#    include <qt5keychain/keychain.h>
-#endif
-
 class Q_DECL_HIDDEN Quotient::Connection::Private {
 public:
     explicit Private(std::unique_ptr<ConnectionData>&& connection)
@@ -156,31 +150,8 @@ public:
 
     std::pair<EventPtr, QString> sessionDecryptMessage(const EncryptedEvent& encryptedEvent);
 
-    void saveAccessTokenToKeychain() const
-    {
-        qCDebug(MAIN) << "Saving access token to keychain for" << q->userId();
-        auto job = new QKeychain::WritePasswordJob(qAppName());
-        job->setAutoDelete(true);
-        job->setKey(q->userId());
-        job->setBinaryData(data->accessToken());
-        job->start();
-        //TODO error handling
-    }
-    void dropAccessToken()
-    {
-        qCDebug(MAIN) << "Removing access token from keychain for" << q->userId();
-        auto job = new QKeychain::DeletePasswordJob(qAppName());
-        job->setAutoDelete(true);
-        job->setKey(q->userId());
-        job->start();
-
-        auto pickleJob = new QKeychain::DeletePasswordJob(qAppName());
-        pickleJob->setAutoDelete(true);
-        pickleJob->setKey(q->userId() + "-Pickle"_ls);
-        pickleJob->start();
-        //TODO error handling
-
-        data->setToken({});}
+    void saveAccessTokenToKeychain() const;
+    void dropAccessToken();
 
 #ifdef Quotient_E2EE_ENABLED
     void saveOlmAccount();

--- a/lib/events/encryptedevent.cpp
+++ b/lib/events/encryptedevent.cpp
@@ -3,7 +3,6 @@
 
 #include "encryptedevent.h"
 #include "e2ee/e2ee_common.h"
-#include "logging.h"
 
 using namespace Quotient;
 
@@ -24,11 +23,7 @@ EncryptedEvent::EncryptedEvent(const QByteArray& ciphertext,
                                     { SessionIdKeyL, sessionId } }))
 {}
 
-EncryptedEvent::EncryptedEvent(const QJsonObject& obj)
-    : RoomEvent(obj)
-{
-    qCDebug(E2EE) << "Encrypted event from" << senderId();
-}
+EncryptedEvent::EncryptedEvent(const QJsonObject& obj) : RoomEvent(obj) {}
 
 QString EncryptedEvent::algorithm() const
 {

--- a/lib/events/encryptedevent.h
+++ b/lib/events/encryptedevent.h
@@ -43,6 +43,7 @@ public:
     explicit EncryptedEvent(const QByteArray& ciphertext,
                             const QString& senderKey, const QString& deviceId,
                             const QString& sessionId);
+    // TODO: replace with 'using RoomEvent::RoomEvent' in 0.8
     explicit EncryptedEvent(const QJsonObject& obj);
 
     QString algorithm() const;


### PR DESCRIPTION
A small pile of fixes and tweaks that I got from finalising Quaternion 0.0.96 beta. Notable things are deprecating `AccountRegistry::invokeLogin()` and making `Connection::assumeIdentity()` to ignore the device id because it can be (and better be) resolved from the access token anyway.