### PR TITLE
Change "user has no name" log from warning to debug

### DIFF
--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -1674,7 +1674,7 @@ void Room::Private::insertMemberIntoMap(User* u)
     const auto maybeUserName =
         currentState.query(u->id(), &RoomMemberEvent::newDisplayName);
     if (!maybeUserName)
-        qCWarning(MEMBERS) << "insertMemberIntoMap():" << u->id()
+        qCDebug(MEMBERS) << "insertMemberIntoMap():" << u->id()
                            << "has no name (even empty)";
     const auto userName = maybeUserName.value_or(QString());
     const auto namesakes = membersMap.values(userName);


### PR DESCRIPTION
While technically a warning, it seems to happen quite a lot, causing a lot of mostly irrelevant warnings in the terminal