### PR TITLE
Actually mark global QString constants as deprecated

### DIFF
--- a/Quotient/connection.cpp
+++ b/Quotient/connection.cpp
@@ -1876,7 +1876,7 @@ void Connection::Private::handleQueryKeys(const QueryKeysJob* job)
     std::erase_if(pendingEncryptedEvents,
                   [this](const event_ptr_tt<EncryptedEvent>& pendingEvent) {
                       if (!isKnownCurveKey(
-                              pendingEvent->fullJson()[SenderKeyL].toString(),
+                              pendingEvent->fullJson()[SenderKey].toString(),
                               pendingEvent->contentPart<QString>(SenderKeyKeyL)))
                           return false;
                       handleEncryptedToDeviceEvent(*pendingEvent);
@@ -2123,7 +2123,7 @@ QJsonObject Connection::Private::assembleEncryptedContent(
     QJsonObject payloadJson, const QString& targetUserId,
     const QString& targetDeviceId) const
 {
-    payloadJson.insert(SenderKeyL, data->userId());
+    payloadJson.insert(SenderKey, data->userId());
 //    eventJson.insert("sender_device"_ls, data->deviceId());
     payloadJson.insert("keys"_ls,
                        QJsonObject{
@@ -2199,7 +2199,7 @@ std::pair<EventPtr, QString> Connection::Private::sessionDecryptMessage(
     auto&& decryptedEvent =
         fromJson<EventPtr>(QJsonDocument::fromJson(decrypted.toUtf8()));
 
-    if (auto sender = decryptedEvent->fullJson()[SenderKeyL].toString();
+    if (auto sender = decryptedEvent->fullJson()[SenderKey].toString();
         sender != encryptedEvent.senderId()) {
         qWarning(E2EE) << "Found user" << sender << "instead of sender"
                        << encryptedEvent.senderId() << "in Olm plaintext";
@@ -2247,13 +2247,13 @@ std::pair<QString, QString> Connection::Private::sessionDecryptMessage(
     const QJsonObject& personalCipherObject, const QByteArray& senderKey)
 {
     const auto msgType = static_cast<QOlmMessage::Type>(
-        personalCipherObject.value(TypeKeyL).toInt(-1));
+        personalCipherObject.value(TypeKey).toInt(-1));
     if (msgType != QOlmMessage::General && msgType != QOlmMessage::PreKey) {
         qCWarning(E2EE) << "Olm message has incorrect type" << msgType;
         return {};
     }
     QOlmMessage message {
-        personalCipherObject.value(BodyKeyL).toString().toLatin1(), msgType
+        personalCipherObject.value(BodyKey).toString().toLatin1(), msgType
     };
     for (const auto& session : olmSessions[QString::fromLatin1(senderKey)])
         if (msgType == QOlmMessage::General

--- a/Quotient/events/event.cpp
+++ b/Quotient/events/event.cpp
@@ -50,8 +50,8 @@ void AbstractEventMetaType::addDerived(const AbstractEventMetaType* newType)
 Event::Event(const QJsonObject& json)
     : _json(json)
 {
-    if (!json.contains(ContentKeyL)
-        && !json.value(UnsignedKeyL).toObject().contains(RedactedCauseKeyL)) {
+    if (!json.contains(ContentKey)
+        && !json.value(UnsignedKey).toObject().contains(RedactedCauseKey)) {
         qCWarning(EVENTS) << "Event without 'content' node";
         qCWarning(EVENTS) << formatJson << json;
     }
@@ -59,18 +59,18 @@ Event::Event(const QJsonObject& json)
 
 Event::~Event() = default;
 
-QString Event::matrixType() const { return fullJson()[TypeKeyL].toString(); }
+QString Event::matrixType() const { return fullJson()[TypeKey].toString(); }
 
 QByteArray Event::originalJson() const { return QJsonDocument(_json).toJson(); }
 
 const QJsonObject Event::contentJson() const
 {
-    return fullJson()[ContentKeyL].toObject();
+    return fullJson()[ContentKey].toObject();
 }
 
 const QJsonObject Event::unsignedJson() const
 {
-    return fullJson()[UnsignedKeyL].toObject();
+    return fullJson()[UnsignedKey].toObject();
 }
 
 bool Event::isStateEvent() const { return is<StateEvent>(); }

--- a/Quotient/events/event.h
+++ b/Quotient/events/event.h
@@ -29,24 +29,26 @@ inline TargetEventT* weakPtrCast(const event_ptr_tt<EventT>& ptr)
 
 // === Standard Matrix key names and basicEventJson() ===
 
-constexpr inline auto TypeKeyL = "type"_ls;
-constexpr inline auto BodyKeyL = "body"_ls;
-constexpr inline auto ContentKeyL = "content"_ls;
-constexpr inline auto EventIdKeyL = "event_id"_ls;
-constexpr inline auto SenderKeyL = "sender"_ls;
-constexpr inline auto RoomIdKeyL = "room_id"_ls;
-constexpr inline auto UnsignedKeyL = "unsigned"_ls;
-constexpr inline auto RedactedCauseKeyL = "redacted_because"_ls;
-constexpr inline auto PrevContentKeyL = "prev_content"_ls;
-constexpr inline auto StateKeyKeyL = "state_key"_ls;
-[[deprecated("use TypeKeyL")]] constexpr inline auto TypeKey = TypeKeyL;
-[[deprecated("use BodyKeyL")]] constexpr inline auto BodyKey = BodyKeyL;
-[[deprecated("use ContentKeyL")]] constexpr inline auto ContentKey = ContentKeyL;
-[[deprecated("use EventIdKeyL")]] constexpr inline auto EventIdKey = EventIdKeyL;
-[[deprecated("use SenderKeyL")]] constexpr inline auto SenderKey = SenderKeyL;
-[[deprecated("use RoomIdKeyL")]] constexpr inline auto RoomIdKey = RoomIdKeyL;
-[[deprecated("use UnsignedKeyL")]] constexpr inline auto UnsignedKey = UnsignedKeyL;
-[[deprecated("use StateKeyKeyL")]] constexpr inline auto StateKeyKey = StateKeyKeyL;
+constexpr inline auto TypeKey = "type"_ls;
+constexpr inline auto BodyKey = "body"_ls;
+constexpr inline auto ContentKey = "content"_ls;
+constexpr inline auto EventIdKey = "event_id"_ls;
+constexpr inline auto SenderKey = "sender"_ls;
+constexpr inline auto RoomIdKey = "room_id"_ls;
+constexpr inline auto UnsignedKey = "unsigned"_ls;
+constexpr inline auto RedactedCauseKey = "redacted_because"_ls;
+constexpr inline auto PrevContentKey = "prev_content"_ls;
+constexpr inline auto StateKeyKey = "state_key"_ls;
+[[deprecated("use TypeKey")]] constexpr inline auto TypeKeyL = TypeKey;
+[[deprecated("use BodyKey")]] constexpr inline auto BodyKeyL = BodyKey;
+[[deprecated("use ContentKey")]] constexpr inline auto ContentKeyL = ContentKey;
+[[deprecated("use EventIdKey")]] constexpr inline auto EventIdKeyL = EventIdKey;
+[[deprecated("use SenderKey")]] constexpr inline auto SenderKeyL = SenderKey;
+[[deprecated("use RoomIdKey")]] constexpr inline auto RoomIdKeyL = RoomIdKey;
+[[deprecated("use UnsignedKey")]] constexpr inline auto UnsignedKeyL = UnsignedKey;
+[[deprecated("use RedactedCauseKey")]] constexpr inline auto RedactedCauseKeyL = RedactedCauseKey;
+[[deprecated("use PrevContentKey")]] constexpr inline auto PrevContentKeyL = PrevContentKey;
+[[deprecated("use StateKeyKey")]] constexpr inline auto StateKeyKeyL = StateKeyKey;
 
 using event_type_t = QLatin1String;
 

--- a/Quotient/events/event.h
+++ b/Quotient/events/event.h
@@ -39,14 +39,14 @@ constexpr inline auto UnsignedKeyL = "unsigned"_ls;
 constexpr inline auto RedactedCauseKeyL = "redacted_because"_ls;
 constexpr inline auto PrevContentKeyL = "prev_content"_ls;
 constexpr inline auto StateKeyKeyL = "state_key"_ls;
-const QString TypeKey { TypeKeyL };
-const QString BodyKey { BodyKeyL };
-const QString ContentKey { ContentKeyL };
-const QString EventIdKey { EventIdKeyL };
-const QString SenderKey { SenderKeyL };
-const QString RoomIdKey { RoomIdKeyL };
-const QString UnsignedKey { UnsignedKeyL };
-const QString StateKeyKey { StateKeyKeyL };
+[[deprecated("use TypeKeyL")]] constexpr inline auto TypeKey = TypeKeyL;
+[[deprecated("use BodyKeyL")]] constexpr inline auto BodyKey = BodyKeyL;
+[[deprecated("use ContentKeyL")]] constexpr inline auto ContentKey = ContentKeyL;
+[[deprecated("use EventIdKeyL")]] constexpr inline auto EventIdKey = EventIdKeyL;
+[[deprecated("use SenderKeyL")]] constexpr inline auto SenderKey = SenderKeyL;
+[[deprecated("use RoomIdKeyL")]] constexpr inline auto RoomIdKey = RoomIdKeyL;
+[[deprecated("use UnsignedKeyL")]] constexpr inline auto UnsignedKey = UnsignedKeyL;
+[[deprecated("use StateKeyKeyL")]] constexpr inline auto StateKeyKey = StateKeyKeyL;
 
 using event_type_t = QLatin1String;
 

--- a/Quotient/events/event.h
+++ b/Quotient/events/event.h
@@ -235,7 +235,7 @@ template <EventClass EventT>
 inline event_ptr_tt<EventT> loadEvent(const QJsonObject& fullJson)
 {
     return mostSpecificMetaType<EventT>().loadFrom(
-        fullJson, fullJson[TypeKeyL].toString());
+        fullJson, fullJson[TypeKey].toString());
 }
 
 //! \brief Create an event from a type string and content JSON
@@ -282,7 +282,7 @@ public:
     static QJsonObject basicJson(const QString& matrixType,
                                  const QJsonObject& content)
     {
-        return { { TypeKeyL, matrixType }, { ContentKeyL, content } };
+        return { { TypeKey, matrixType }, { ContentKey, content } };
     }
 
     //! \brief Event Matrix type, as identified by its metatype object

--- a/Quotient/events/eventrelation.cpp
+++ b/Quotient/events/eventrelation.cpp
@@ -16,7 +16,7 @@ void JsonObjectConverter<EventRelation>::dumpTo(QJsonObject& jo,
         return;
     }
     jo.insert(RelTypeKey, pod.type);
-    jo.insert(EventIdKeyL, pod.eventId);
+    jo.insert(EventIdKey, pod.eventId);
     if (pod.type == EventRelation::AnnotationType)
         jo.insert(QStringLiteral("key"), pod.key);
 }
@@ -27,11 +27,11 @@ void JsonObjectConverter<EventRelation>::fillFrom(const QJsonObject& jo,
     if (const auto replyJson = jo.value(EventRelation::ReplyType).toObject();
         !replyJson.isEmpty()) {
         pod.type = EventRelation::ReplyType;
-        fromJson(replyJson[EventIdKeyL], pod.eventId);
+        fromJson(replyJson[EventIdKey], pod.eventId);
     } else {
         // The experimental logic for generic relationships (MSC1849)
         fromJson(jo[RelTypeKey], pod.type);
-        fromJson(jo[EventIdKeyL], pod.eventId);
+        fromJson(jo[EventIdKey], pod.eventId);
         if (pod.type == EventRelation::AnnotationType)
             fromJson(jo["key"_ls], pod.key);
     }

--- a/Quotient/events/reactionevent.h
+++ b/Quotient/events/reactionevent.h
@@ -16,7 +16,7 @@ public:
     QUO_EVENT(ReactionEvent, "m.reaction")
     static bool isValid(const QJsonObject& fullJson)
     {
-        return fullJson[ContentKeyL][RelatesToKey][RelTypeKey].toString()
+        return fullJson[ContentKey][RelatesToKey][RelTypeKey].toString()
                == EventRelation::AnnotationType;
     }
 

--- a/Quotient/events/roomcreateevent.cpp
+++ b/Quotient/events/roomcreateevent.cpp
@@ -25,8 +25,8 @@ QString RoomCreateEvent::version() const
 RoomCreateEvent::Predecessor RoomCreateEvent::predecessor() const
 {
     const auto predJson = contentPart<QJsonObject>("predecessor"_ls);
-    return { fromJson<QString>(predJson[RoomIdKeyL]),
-             fromJson<QString>(predJson[EventIdKeyL]) };
+    return { fromJson<QString>(predJson[RoomIdKey]),
+             fromJson<QString>(predJson[EventIdKey]) };
 }
 
 bool RoomCreateEvent::isUpgrade() const

--- a/Quotient/events/roomevent.cpp
+++ b/Quotient/events/roomevent.cpp
@@ -10,14 +10,14 @@ using namespace Quotient;
 
 RoomEvent::RoomEvent(const QJsonObject& json) : Event(json)
 {
-    if (const auto redaction = unsignedPart<QJsonObject>(RedactedCauseKeyL);
+    if (const auto redaction = unsignedPart<QJsonObject>(RedactedCauseKey);
         !redaction.isEmpty())
         _redactedBecause = loadEvent<RedactionEvent>(redaction);
 }
 
 RoomEvent::~RoomEvent() = default; // Let the smart pointer do its job
 
-QString RoomEvent::id() const { return fullJson()[EventIdKeyL].toString(); }
+QString RoomEvent::id() const { return fullJson()[EventIdKey].toString(); }
 
 QDateTime RoomEvent::originTimestamp() const
 {
@@ -26,12 +26,12 @@ QDateTime RoomEvent::originTimestamp() const
 
 QString RoomEvent::roomId() const
 {
-    return fullJson()[RoomIdKeyL].toString();
+    return fullJson()[RoomIdKey].toString();
 }
 
 QString RoomEvent::senderId() const
 {
-    return fullJson()[SenderKeyL].toString();
+    return fullJson()[SenderKey].toString();
 }
 
 QString RoomEvent::redactionReason() const
@@ -46,24 +46,24 @@ QString RoomEvent::transactionId() const
 
 QString RoomEvent::stateKey() const
 {
-    return fullJson()[StateKeyKeyL].toString();
+    return fullJson()[StateKeyKey].toString();
 }
 
 void RoomEvent::setRoomId(const QString& roomId)
 {
-    editJson().insert(RoomIdKeyL, roomId);
+    editJson().insert(RoomIdKey, roomId);
 }
 
 void RoomEvent::setSender(const QString& senderId)
 {
-    editJson().insert(SenderKeyL, senderId);
+    editJson().insert(SenderKey, senderId);
 }
 
 void RoomEvent::setTransactionId(const QString& txnId)
 {
-    auto unsignedData = fullJson()[UnsignedKeyL].toObject();
+    auto unsignedData = fullJson()[UnsignedKey].toObject();
     unsignedData.insert(QStringLiteral("transaction_id"), txnId);
-    editJson().insert(UnsignedKeyL, unsignedData);
+    editJson().insert(UnsignedKey, unsignedData);
     Q_ASSERT(transactionId() == txnId);
 }
 
@@ -71,7 +71,7 @@ void RoomEvent::addId(const QString& newId)
 {
     Q_ASSERT(id().isEmpty());
     Q_ASSERT(!newId.isEmpty());
-    editJson().insert(EventIdKeyL, newId);
+    editJson().insert(EventIdKey, newId);
     qCDebug(EVENTS) << "Event txnId -> id:" << transactionId() << "->" << id();
     Q_ASSERT(id() == newId);
 }

--- a/Quotient/events/roommessageevent.cpp
+++ b/Quotient/events/roommessageevent.cpp
@@ -112,16 +112,16 @@ QJsonObject RoomMessageEvent::assembleContentJson(const QString& plainBody,
                    && textContent->relatesTo->type
                           == EventRelation::ReplacementType) {
             auto newContentJson = json.take("m.new_content"_ls).toObject();
-            newContentJson.insert(BodyKeyL, plainBody);
+            newContentJson.insert(BodyKey, plainBody);
             newContentJson.insert(MsgTypeKey, jsonMsgType);
             json.insert(QStringLiteral("m.new_content"), newContentJson);
             json[MsgTypeKey] = jsonMsgType;
-            json[BodyKeyL] = "* "_ls + plainBody;
+            json[BodyKey] = "* "_ls + plainBody;
             return json;
         }
     }
     json.insert(MsgTypeKey, jsonMsgType);
-    json.insert(BodyKeyL, plainBody);
+    json.insert(BodyKey, plainBody);
     return json;
 }
 
@@ -180,7 +180,7 @@ RoomMessageEvent::RoomMessageEvent(const QJsonObject& obj)
     if (isRedacted())
         return;
     const QJsonObject content = contentJson();
-    if (content.contains(MsgTypeKey) && content.contains(BodyKeyL)) {
+    if (content.contains(MsgTypeKey) && content.contains(BodyKey)) {
         auto msgtype = content[MsgTypeKey].toString();
         bool msgTypeFound = false;
         for (const auto& mt : msgTypes)
@@ -212,7 +212,7 @@ QString RoomMessageEvent::rawMsgtype() const
 
 QString RoomMessageEvent::plainBody() const
 {
-    return contentPart<QString>(BodyKeyL);
+    return contentPart<QString>(BodyKey);
 }
 
 QMimeType RoomMessageEvent::mimeType() const
@@ -258,7 +258,7 @@ QString RoomMessageEvent::replacedBy() const
     // clang-format off
     return unsignedPart<QJsonObject>("m.relations"_ls)
             .value("m.replace"_ls).toObject()
-            .value(EventIdKeyL).toString();
+            .value(EventIdKey).toString();
     // clang-format on
 }
 
@@ -312,7 +312,7 @@ TextContent::TextContent(const QJsonObject& json)
         // Falling back to plain text, as there's no standard way to describe
         // rich text in messages.
         mimeType = PlainTextMimeType;
-        body = actualJson[BodyKeyL].toString();
+        body = actualJson[BodyKey].toString();
     }
 }
 
@@ -330,9 +330,9 @@ void TextContent::fillJson(QJsonObject &json) const
             relatesTo->type == EventRelation::ReplyType
                 ? QJsonObject { { relatesTo->type,
                                   QJsonObject {
-                                      { EventIdKeyL, relatesTo->eventId } } } }
+                                      { EventIdKey, relatesTo->eventId } } } }
                 : QJsonObject { { RelTypeKey, relatesTo->type },
-                                { EventIdKeyL, relatesTo->eventId } });
+                                { EventIdKey, relatesTo->eventId } });
         if (relatesTo->type == EventRelation::ReplacementType) {
             QJsonObject newContentJson;
             if (mimeType.inherits("text/html"_ls)) {

--- a/Quotient/events/roommessageevent.h
+++ b/Quotient/events/roommessageevent.h
@@ -55,7 +55,7 @@ public:
     void editContent(VisitorT&& visitor)
     {
         visitor(*_content);
-        editJson()[ContentKeyL] = assembleContentJson(plainBody(), rawMsgtype(),
+        editJson()[ContentKey] = assembleContentJson(plainBody(), rawMsgtype(),
                                                       _content.data());
     }
     QMimeType mimeType() const;

--- a/Quotient/events/stateevent.cpp
+++ b/Quotient/events/stateevent.cpp
@@ -9,7 +9,7 @@ using namespace Quotient;
 StateEvent::StateEvent(const QJsonObject& json)
     : RoomEvent(json)
 {
-    Q_ASSERT_X(json.contains(StateKeyKeyL), __FUNCTION__,
+    Q_ASSERT_X(json.contains(StateKeyKey), __FUNCTION__,
                "Attempt to create a state event without state key");
 }
 
@@ -20,7 +20,7 @@ StateEvent::StateEvent(event_type_t type, const QString& stateKey,
 
 bool StateEvent::repeatsState() const
 {
-    return contentJson() == unsignedPart<QJsonObject>(PrevContentKeyL);
+    return contentJson() == unsignedPart<QJsonObject>(PrevContentKey);
 }
 
 QString StateEvent::replacedState() const
@@ -32,7 +32,7 @@ void StateEvent::dumpTo(QDebug dbg) const
 {
     if (!stateKey().isEmpty())
         dbg << '<' << stateKey() << "> ";
-    if (const auto prevContentJson = unsignedPart<QJsonObject>(PrevContentKeyL);
+    if (const auto prevContentJson = unsignedPart<QJsonObject>(PrevContentKey);
         !prevContentJson.isEmpty())
         dbg << QJsonDocument(prevContentJson).toJson(QJsonDocument::Compact)
             << " -> ";

--- a/Quotient/events/stateevent.h
+++ b/Quotient/events/stateevent.h
@@ -13,7 +13,7 @@ public:
 
     static bool isValid(const QJsonObject& fullJson)
     {
-        return fullJson.contains(StateKeyKeyL);
+        return fullJson.contains(StateKeyKey);
     }
 
     //! \brief Static setting of whether a given even type uses state keys
@@ -32,9 +32,9 @@ public:
                                  const QString& stateKey = {},
                                  const QJsonObject& contentJson = {})
     {
-        return { { TypeKeyL, matrixTypeId },
-                 { StateKeyKeyL, stateKey },
-                 { ContentKeyL, contentJson } };
+        return { { TypeKey, matrixTypeId },
+                 { StateKeyKey, stateKey },
+                 { ContentKey, contentJson } };
     }
 
     QString replacedState() const;
@@ -76,7 +76,7 @@ public:
         explicit Prev(const QJsonObject& unsignedJson)
             : senderId(fromJson<QString>(unsignedJson["prev_sender"_ls]))
             , content(
-                  fromJson<Omittable<ContentT>>(unsignedJson[PrevContentKeyL]))
+                  fromJson<Omittable<ContentT>>(unsignedJson[PrevContentKey]))
         {}
 
         QString senderId;
@@ -94,7 +94,7 @@ public:
         : StateEvent(EventT::TypeId, stateKey)
         , _content { std::forward<ContentParamTs>(contentParams)... }
     {
-        editJson().insert(ContentKeyL, toJson(_content));
+        editJson().insert(ContentKey, toJson(_content));
     }
 
     const ContentT& content() const { return _content; }
@@ -103,7 +103,7 @@ public:
     void editContent(VisitorT&& visitor)
     {
         visitor(_content);
-        editJson()[ContentKeyL] = toJson(_content);
+        editJson()[ContentKey] = toJson(_content);
     }
     const Omittable<ContentT>& prevContent() const { return _prev.content; }
     QString prevSenderId() const { return _prev.senderId; }

--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -2651,7 +2651,7 @@ RoomEventPtr makeRedacted(const RoomEvent& target,
     // clang-format puts them in a single column...
     // clang-format off
     static const QStringList keepKeys {
-        EventIdKeyL, TypeKeyL, RoomIdKeyL, SenderKeyL, StateKeyKeyL,
+        EventIdKey, TypeKey, RoomIdKey, SenderKey, StateKeyKey,
         "hashes"_ls, "signatures"_ls, "depth"_ls, "prev_events"_ls,
         "prev_state"_ls, "auth_events"_ls, "origin"_ls, "origin_server_ts"_ls,
         "membership"_ls };
@@ -2681,20 +2681,20 @@ RoomEventPtr makeRedacted(const RoomEvent& target,
         find_if(begin(keepContentKeysMap), end(keepContentKeysMap),
                 [&target](const auto& t) { return target.type() == t.first; });
     if (keepContentKeys == end(keepContentKeysMap)) {
-        originalJson.remove(ContentKeyL);
-        originalJson.remove(PrevContentKeyL);
+        originalJson.remove(ContentKey);
+        originalJson.remove(PrevContentKey);
     } else {
-        auto content = originalJson.take(ContentKeyL).toObject();
+        auto content = originalJson.take(ContentKey).toObject();
         for (auto it = content.begin(); it != content.end();) {
             if (!keepContentKeys->second.contains(it.key()))
                 it = content.erase(it);
             else
                 ++it;
         }
-        originalJson.insert(ContentKeyL, content);
+        originalJson.insert(ContentKey, content);
     }
-    auto unsignedData = originalJson.take(UnsignedKeyL).toObject();
-    unsignedData[RedactedCauseKeyL] = redaction.fullJson();
+    auto unsignedData = originalJson.take(UnsignedKey).toObject();
+    unsignedData[RedactedCauseKey] = redaction.fullJson();
     originalJson.insert(QStringLiteral("unsigned"), unsignedData);
 
     return loadEvent<RoomEvent>(originalJson);
@@ -2767,13 +2767,13 @@ RoomEventPtr makeReplaced(const RoomEvent& target,
         newContent["m.relates_to"_ls] = targetReply;
     }
     auto originalJson = target.fullJson();
-    originalJson[ContentKeyL] = newContent;
+    originalJson[ContentKey] = newContent;
 
-    auto unsignedData = originalJson.take(UnsignedKeyL).toObject();
+    auto unsignedData = originalJson.take(UnsignedKey).toObject();
     auto relations = unsignedData.take("m.relations"_ls).toObject();
     relations["m.replace"_ls] = replacement.id();
     unsignedData.insert("m.relations"_ls, relations);
-    originalJson.insert(UnsignedKeyL, unsignedData);
+    originalJson.insert(UnsignedKey, unsignedData);
 
     return loadEvent<RoomEvent>(originalJson);
 }
@@ -3499,7 +3499,7 @@ QJsonObject Room::Private::toJson() const
             auto json = evt->fullJson();
             auto unsignedJson = evt->unsignedJson();
             unsignedJson.remove(QStringLiteral("prev_content"));
-            json[UnsignedKeyL] = unsignedJson;
+            json[UnsignedKey] = unsignedJson;
             stateEvents.append(json);
         }
 


### PR DESCRIPTION
Technically this is an API change as their type changes from QString to QLatin1String now, but given that QLatin1String can be used almost everywhere a QString can be used (and those constants are for use with the Qt JSON API anyway), this should be fine.

This is not an ABI change as those constants are not part of the ABI but are copied into every translation unit regardless of their use there. With that no longer happening now we also save ~12kB of binary size on a size-optimized build of libQuotient.