### PR TITLE
Improve alias remapping

### DIFF
--- a/Quotient/connection.cpp
+++ b/Quotient/connection.cpp
@@ -1219,6 +1219,13 @@ void Connection::updateRoomAliases(const QString& roomId,
             if (mappedId == roomId)
                 qCDebug(MAIN)
                     << "Alias" << a << "is already mapped to" << roomId;
+            else if (room(roomId)->successorId() == mappedId || room(mappedId)->predecessorId() == roomId) {
+                qCDebug(MAIN) << "Not remapping alias" << a << "from" <<
+                                mappedId << "to predecessor" << roomId;
+                continue;
+            } else if (room(mappedId)->successorId() == roomId)
+                qCDebug(MAIN) << "Remapping alias" << a << "from" << mappedId
+                    << "to successor" << roomId;
             else
                 qCWarning(MAIN) << "Alias" << a << "will be force-remapped from"
                                 << mappedId << "to" << roomId;


### PR DESCRIPTION
- Don't print a warning if an alias is remapped from a room to its replacement room
- Don't remap aliases from the new room to the old room
(I've never noticed any problems caused by this, but the log message is slightly annoying)