### PR TITLE
Fix CMake configuration when using Qt6

### DIFF
--- a/cmake/QuotientConfig.cmake.in
+++ b/cmake/QuotientConfig.cmake.in
@@ -2,10 +2,10 @@ include(CMakeFindDependencyMacro)
 
 @FIND_DEPS@
 
-include("${CMAKE_CURRENT_LIST_DIR}/QuotientTargets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/@QUOTIENT_LIB_NAME@Targets.cmake")
 
 if (NOT QUOTIENT_FORCE_NAMESPACED_INCLUDES)
-    get_target_property(_include_dir @PROJECT_NAME@ INTERFACE_INCLUDE_DIRECTORIES)
+    get_target_property(_include_dir @QUOTIENT_LIB_NAME@ INTERFACE_INCLUDE_DIRECTORIES)
     list(APPEND _include_dir "${_include_dir}/Quotient")
-    set_target_properties(@PROJECT_NAME@ PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${_include_dir}")
+    set_target_properties(@QUOTIENT_LIB_NAME@ PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${_include_dir}")
 endif()


### PR DESCRIPTION
This wasn't adjusted properly when implementing co-installability.