### PR TITLE
Fix Matrix URI parsing

### DIFF
--- a/Quotient/uri.cpp
+++ b/Quotient/uri.cpp
@@ -84,7 +84,7 @@ static inline auto matrixToUrlRegexInit()
 {
     // See https://matrix.org/docs/spec/appendices#matrix-to-navigation
     const QRegularExpression MatrixToUrlRE {
-        "^/(?<main>[^:]+:[^/?]+)(/(?<sec>(\\$|%24)[^?]+))?(\\?(?<query>.+))?$"_ls
+        "^/(?<main>[^:]+(:|%3A|%3a)[^/?]+)(/(?<sec>(\\$|%24)[^?]+))?(\\?(?<query>.+))?$"_ls
     };
     Q_ASSERT(MatrixToUrlRE.isValid());
     return MatrixToUrlRE;


### PR DESCRIPTION
Matrix URIs are encoded in standard URL encoding, with special characters replaced with "%"hex ASCII.  Handle the ':' hex encoding so internal links are properly handled.