### PR TITLE
Fix dependency finding in the CMake config file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -327,7 +327,6 @@ target_link_libraries(${QUOTIENT_LIB_NAME} PUBLIC ${Qt}::Core ${Qt}::Network ${Q
 if (Qt STREQUAL Qt5) # See #483
     target_link_libraries(${QUOTIENT_LIB_NAME} PRIVATE ${Qt}::Multimedia)
 endif()
-set(FIND_DEPS "find_dependency(${Qt}Keychain)") # For QuotientConfig.cmake.in
 
 if (${PROJECT_NAME}_ENABLE_E2EE)
     target_link_libraries(${QUOTIENT_LIB_NAME}
@@ -337,10 +336,6 @@ if (${PROJECT_NAME}_ENABLE_E2EE)
         PRIVATE
             OpenSSL::Crypto
     )
-    set(FIND_DEPS "${FIND_DEPS}
-    find_dependency(Olm)
-    find_dependency(OpenSSL)
-    find_dependency(${Qt}Sql)")
 endif()
 
 configure_file(${PROJECT_NAME}.pc.in ${CMAKE_CURRENT_BINARY_DIR}/${QUOTIENT_LIB_NAME}.pc @ONLY NEWLINE_STYLE UNIX)

--- a/cmake/QuotientConfig.cmake.in
+++ b/cmake/QuotientConfig.cmake.in
@@ -1,6 +1,17 @@
 include(CMakeFindDependencyMacro)
 
-@FIND_DEPS@
+find_dependency(@Qt@Gui)
+find_dependency(@Qt@Network)
+find_dependency(@Qt@Keychain)
+if (@Quotient_ENABLE_E2EE@)
+    find_dependency(Olm)
+    find_dependency(OpenSSL)
+    find_dependency(@Qt@Sql)
+endif()
+
+if (NOT @BUILD_SHARED_LIBS@ AND NOT @BUILD_WITH_QT6@)
+    find_dependency(@Qt@Multimedia)
+endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/@QUOTIENT_LIB_NAME@Targets.cmake")
 


### PR DESCRIPTION
We need to find all public link dependencies here when building a shared library, but also all private link dependencies when building a static library.