### PR TITLE
Add missing include in qt_connection_util.h for Qt 6

### DIFF
--- a/Quotient/qt_connection_util.h
+++ b/Quotient/qt_connection_util.h
@@ -5,6 +5,7 @@
 
 #include "function_traits.h"
 
+#include <QtCore/QObject>
 #include <QtCore/QPointer>
 
 namespace Quotient {


### PR DESCRIPTION
QObject is used here, but so far this relied on the the corresponding include happening indirectly. That's no longer the case with Qt 6.