### PR TITLE
Remove Room::reset*Count() functions

### DIFF
--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -1230,23 +1230,7 @@ qsizetype Room::notificationCount() const
     return d->unreadStats.notableCount;
 }
 
-void Room::resetNotificationCount()
-{
-    if (d->unreadStats.notableCount == 0)
-        return;
-    d->unreadStats.notableCount = 0;
-    emit notificationCountChanged();
-}
-
 qsizetype Room::highlightCount() const { return d->serverHighlightCount; }
-
-void Room::resetHighlightCount()
-{
-    if (d->serverHighlightCount == 0)
-        return;
-    d->serverHighlightCount = 0;
-    emit highlightCountChanged();
-}
 
 void Room::switchVersion(QString newVersion)
 {

--- a/Quotient/room.h
+++ b/Quotient/room.h
@@ -628,9 +628,6 @@ public:
     //! \sa unreadStats, lastLocalReadReceipt
     qsizetype notificationCount() const;
 
-    [[deprecated("Use setReadReceipt() to drive changes in notification count")]]
-    Q_INVOKABLE void resetNotificationCount();
-
     //! \brief Get the number of highlights since the last read receipt
     //!
     //! As of 0.7, this is defined by the homeserver as Quotient doesn't process
@@ -638,9 +635,6 @@ public:
     //!
     //! \sa unreadStats, lastLocalReadReceipt
     qsizetype highlightCount() const;
-
-    [[deprecated("Use setReadReceipt() to drive changes in highlightCount")]]
-    Q_INVOKABLE void resetHighlightCount();
 
     /** Check whether the room has account data of the given type
      * Tags and read markers are not supported by this method _yet_.


### PR DESCRIPTION
They were deprecated since 0.7 and now seem to break unread counts logic implemented in 0.7.

Hopefully closes #588 (by making it impossible to break `Room::P::unreadStats` with those calls).