### PR TITLE
Fix redactions

### DIFF
--- a/Quotient/events/event.h
+++ b/Quotient/events/event.h
@@ -331,7 +331,7 @@ public:
     //!     },
     //!     3); /* the default value to return if nothing above matched */
     //! \endcode
-    //! As the example shows, the last parameter can optionally be either
+    //! As the example shows, the last parameter can optionally be
     //! a plain returned value instead of a visitor.
     template <typename... VisitorTs>
     auto switchOnType(VisitorTs&&... visitors) const;

--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -2660,7 +2660,7 @@ RoomEventPtr makeRedacted(const RoomEvent& target,
     // clang-format puts them in a single column...
     // clang-format off
     static const QStringList keepKeys {
-        EventIdKey, TypeKey, RoomIdKey, SenderKey, StateKeyKey,
+        EventIdKey, TypeKey, RoomIdKey, SenderKey, StateKeyKey, ContentKey,
         "hashes"_ls, "signatures"_ls, "depth"_ls, "prev_events"_ls,
         "prev_state"_ls, "auth_events"_ls, "origin"_ls, "origin_server_ts"_ls,
         "membership"_ls };

--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -2663,13 +2663,11 @@ RoomEventPtr makeRedacted(const RoomEvent& target,
 {
     // The logic below faithfully follows the spec despite quite a few of
     // the preserved keys being only relevant for homeservers. Just in case.
-    // clang-format off
     static const QStringList TopLevelKeysToKeep{
-        EventIdKey, TypeKey, RoomIdKey, SenderKey, StateKeyKey, ContentKey,
-        "hashes"_ls, "signatures"_ls, "depth"_ls, "prev_events"_ls,
-        "auth_events"_ls, "origin"_ls, "origin_server_ts"_ls
+        EventIdKey,  TypeKey,          RoomIdKey,        SenderKey,
+        StateKeyKey, ContentKey,       "hashes"_ls,      "signatures"_ls,
+        "depth"_ls,  "prev_events"_ls, "auth_events"_ls, "origin_server_ts"_ls
     };
-    // clang-format on
 
     auto originalJson = target.fullJson();
     for (auto it = originalJson.begin(); it != originalJson.end();) {

--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -2859,12 +2859,11 @@ void Room::Private::addRelation(const ReactionEvent& reactionEvt)
 inline bool isEditing(const RoomEventPtr& ep)
 {
     Q_ASSERT(ep);
-    if (is<RedactionEvent>(*ep))
-        return true;
-    if (auto* msgEvent = eventCast<RoomMessageEvent>(ep))
-        return !msgEvent->replacedEvent().isEmpty();
-
-    return false;
+    return ep->switchOnType([](const RedactionEvent&) { return true; },
+                     [](const RoomMessageEvent& rme) {
+                         return !rme.replacedEvent().isEmpty();
+                     },
+                     false);
 }
 
 Room::Changes Room::Private::addNewMessageEvents(RoomEvents&& events)


### PR DESCRIPTION
Upon probing beyond the most basic redaction case (message events) the library code suddenly turned out to be quite buggy; this PR addresses what I could quickly find. Most important are the first and the last commits; while fixing `processStateEvents()` I also figured that it would be quite natural to have `Event::switchOnType()` next to `Quotient::switchOnType()` (and the member call doesn't need those `clang-format off/on` instructions to make it more readable) - so I added that.