### PR TITLE
asKeyValueRange: support accepting rvalues

### DIFF
--- a/Quotient/connectionencryptiondata_p.cpp
+++ b/Quotient/connectionencryptiondata_p.cpp
@@ -372,8 +372,7 @@ void ConnectionEncryptionData::handleEncryptedToDeviceEvent(
 
 void ConnectionEncryptionData::handleQueryKeys(const QueryKeysJob* job)
 {
-    const auto newDeviceKeys = job->deviceKeys();
-    for (const auto& [user, keys] : asKeyValueRange(newDeviceKeys)) {
+    for (const auto& [user, keys] : asKeyValueRange(job->deviceKeys())) {
         const QHash<QString, Quotient::DeviceKeys> oldDevices = deviceKeys[user];
         deviceKeys[user].clear();
         for (const auto& device : keys) {

--- a/Quotient/e2ee/qolmaccount.cpp
+++ b/Quotient/e2ee/qolmaccount.cpp
@@ -192,8 +192,7 @@ UnsignedOneTimeKeys QOlmAccount::oneTimeKeys() const
 OneTimeKeys QOlmAccount::signOneTimeKeys(const UnsignedOneTimeKeys &keys) const
 {
     OneTimeKeys signedOneTimeKeys;
-    for (const auto& curveKeys = keys.curve25519();
-         const auto& [keyId, key] : asKeyValueRange(curveKeys))
+    for (const auto& [keyId, key] : asKeyValueRange(keys.curve25519()))
         signedOneTimeKeys.insert("signed_curve25519:"_ls % keyId,
                                  SignedOneTimeKey {
                                      key, m_userId, m_deviceId,

--- a/autotests/testolmaccount.cpp
+++ b/autotests/testolmaccount.cpp
@@ -204,11 +204,10 @@ void TestOlmAccount::uploadOneTimeKeys()
     auto nKeys = olmAccount->generateOneTimeKeys(5);
     QCOMPARE(nKeys, 5);
 
-    auto oneTimeKeys = olmAccount->oneTimeKeys();
+    const auto oneTimeKeys = olmAccount->oneTimeKeys();
 
     OneTimeKeys oneTimeKeysHash;
-    const auto curve = oneTimeKeys.curve25519();
-    for (const auto &[keyId, key] : asKeyValueRange(curve)) {
+    for (const auto& [keyId, key] : asKeyValueRange(oneTimeKeys.curve25519())) {
         oneTimeKeysHash["curve25519:"_ls + keyId] = key;
     }
     auto request = new UploadKeysJob(none, oneTimeKeysHash);
@@ -230,11 +229,7 @@ void TestOlmAccount::uploadSignedOneTimeKeys()
     QCOMPARE(nKeys, 5);
 
     auto oneTimeKeys = olmAccount->oneTimeKeys();
-    OneTimeKeys oneTimeKeysHash;
-    const auto signedKey = olmAccount->signOneTimeKeys(oneTimeKeys);
-    for (const auto &[keyId, key] : asKeyValueRange(signedKey)) {
-        oneTimeKeysHash[keyId] = key;
-    }
+    auto oneTimeKeysHash = olmAccount->signOneTimeKeys(oneTimeKeys);
     auto request = new UploadKeysJob(none, oneTimeKeysHash);
     connect(request, &BaseJob::result, this, [request, nKeys] {
         if (!request->status().good())


### PR DESCRIPTION
Since it is intended to be used with Qt containers which are implicitly-shared, asKeyValueRange can copy-construct an internal snapshot for cheap, for the sake of lifetime extension. However, any changes on that copy would not propagate to the original container rvalue. To avoid surprises, non-const begin/end adaptors are only enabled with (non-const) lvalues.