### PR TITLE
Add connections in AccountRegistry::invokeLogin()

### DIFF
--- a/Quotient/accountregistry.cpp
+++ b/Quotient/accountregistry.cpp
@@ -149,6 +149,7 @@ void AccountRegistry::invokeLogin()
                     connection->assumeIdentity(
                         account.userId(),
                         QString::fromUtf8(accessTokenLoadingJob->binaryData()));
+                    add(connection);
                 });
         accessTokenLoadingJob->start();
     }


### PR DESCRIPTION
Connection was previously adding itself to the AccountRegistry singleton, but that has been removed in c2c9bf420eb4e.