### PR TITLE
Expose 3PID request fields

### DIFF
--- a/Quotient/csapi/definitions/request_email_validation.h
+++ b/Quotient/csapi/definitions/request_email_validation.h
@@ -9,7 +9,7 @@
 
 namespace Quotient {
 
-struct EmailValidationData : RequestEmailValidation {
+struct EmailValidationData : public RequestEmailValidation {
     /// The hostname of the identity server to communicate with. May optionally
     /// include a port. This parameter is ignored when the homeserver handles
     /// 3PID verification.

--- a/Quotient/csapi/definitions/request_msisdn_validation.h
+++ b/Quotient/csapi/definitions/request_msisdn_validation.h
@@ -9,7 +9,7 @@
 
 namespace Quotient {
 
-struct MsisdnValidationData : RequestMsisdnValidation {
+struct MsisdnValidationData : public RequestMsisdnValidation {
     /// The hostname of the identity server to communicate with. May optionally
     /// include a port. This parameter is ignored when the homeserver handles
     /// 3PID verification.


### PR DESCRIPTION
Mandatory fields are now exposed, make it impossible to send `RequestTokenTo3PIDEmailJob` and `RequestTokenTo3PIDMSISDNJob`