### PR TITLE
Make userIdsAtEvent const

### DIFF
--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -1218,7 +1218,7 @@ Room::rev_iter_t Room::fullyReadMarker() const
     return findInTimeline(d->fullyReadUntilEventId);
 }
 
-QSet<QString> Room::userIdsAtEvent(const QString& eventId)
+QSet<QString> Room::userIdsAtEvent(const QString& eventId) const
 {
     return d->eventIdReadUsers.value(eventId);
 }

--- a/Quotient/room.h
+++ b/Quotient/room.h
@@ -512,7 +512,7 @@ public:
     //!       it's recommended to ensure that all room members are loaded
     //!       before operating on the result of this function.
     //! \sa lastReadReceipt, allMembersLoaded
-    QSet<QString> userIdsAtEvent(const QString& eventId);
+    QSet<QString> userIdsAtEvent(const QString& eventId) const;
 
     [[deprecated("Use userIdsAtEvent instead")]]
     QSet<User*> usersAtEventId(const QString& eventId);


### PR DESCRIPTION
Make userIdsAtEvent const as it doesn't modify anything and I'd like to call it from a const NeoChatRoom* reference.