### PR TITLE
Fix two small issue found by clazy

### DIFF
--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -623,7 +623,8 @@ QStringList Room::pinnedEventIds() const {
 QVector<const Quotient::RoomEvent*> Quotient::Room::pinnedEvents() const
 {
     QVector<const RoomEvent*> pinnedEvents;
-    for (const auto& evtId : pinnedEventIds())
+    const auto eventIds = pinnedEventIds();
+    for (const auto& evtId : eventIds)
         if (const auto& it = findInTimeline(evtId); it != historyEdge())
             pinnedEvents.append(it->event());
 
@@ -1397,7 +1398,8 @@ QUrl Room::makeMediaUrl(const QString& eventId, const QUrl& mxcUrl) const
 
 QString safeFileName(QString rawName)
 {
-    return rawName.replace(QRegularExpression("[/\\<>|\"*?:]"_ls), "_"_ls);
+    static auto safeFileNameRegex = QRegularExpression("[/\\<>|\"*?:]"_ls);
+    return rawName.replace(safeFileNameRegex, "_"_ls);
 }
 
 const RoomMessageEvent*


### PR DESCRIPTION
- QRegularExpression are expensive to create and should ideally be static so that they are created only once
- Potential detach found in a for loop with a QStringList