### PR TITLE
Change "room has loaded all history" to qCDebug

### DIFF
--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -2437,7 +2437,7 @@ void Room::Private::getPreviousContent(int limit, const QString& filter)
         {
             *prevBatch = newPrevBatch;
         } else {
-            qInfo(MESSAGES)
+            qCDebug(MESSAGES)
                 << "Room" << q->objectName() << "has loaded all history";
             prevBatch.reset();
         }


### PR DESCRIPTION
This message isn't very interesting in normal scenarios, so not showing it when debug messages are disabled makes sense