### PR TITLE
More CI fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,10 @@ jobs:
       if: startsWith(matrix.os, 'ubuntu')
       run: |
         COMMON_PKGS="libolm-dev ninja-build valgrind gnome-keyring"
+        # Workaround for https://github.com/actions/runner-images/issues/8659
+        sudo rm -f /etc/apt/sources.list.d/ubuntu-toolchain-r-ubuntu-test-jammy.list
+        COMMON_PKGS="--allow-downgrades libc6=2.35-0ubuntu3.4 libc6-dev=2.35-0ubuntu3.4 libstdc++6=12.3.0-1ubuntu1~22.04 libgcc-s1=12.3.0-1ubuntu1~22.04 $COMMON_PKGS"
+        # End of workaround
         sudo apt-get -qq update
         sudo apt-get -qq install $COMMON_PKGS \
             ${{ startsWith(matrix.qt-version, '5')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
     - name: Set up Sonar Cloud tools
       id: sonar
       if: matrix.static-analysis == 'sonar'
-      uses: sonarsource/sonarcloud-github-c-cpp@v1
+      uses: sonarsource/sonarcloud-github-c-cpp@v2
 
     - name: Build and install QtKeychain
       run: |


### PR DESCRIPTION
1. Upgrade SonarCloud GitHub Action to the next version that chooses Java 17 instead of Java 11 they are about to stop supporting.
2. Fix build failures with Clang by working around https://github.com/actions/runner-images/issues/8659

There's one more, sporadic, failure that started happening recently and this PR doesn't address it: sometimes `sendFile` test in Quotest fails to download the files in several threads. Either something is loose in the multithreaded `Quotient::NetworkAccessManager` code or the failure is due to the server responding 429 and `Quotient::NAM` not knowing what to do with it - I haven't checked yet.