### PR TITLE
cryptoutils: more type safety with compile-time-sized spans

### DIFF
--- a/Quotient/database.cpp
+++ b/Quotient/database.cpp
@@ -492,7 +492,8 @@ void Database::storeEncrypted(const QString& name, const QByteArray& key)
 {
     auto iv = getRandom<AesBlockSize>();
     auto result =
-        aesCtr256Encrypt(key, asCBytes(m_picklingKey).first<AesKeySize>(), iv);
+        aesCtr256Encrypt(key, asCBytes(m_picklingKey).first<Aes256KeySize>(),
+                         iv);
     if (!result.has_value())
         return;
 
@@ -519,7 +520,7 @@ QByteArray Database::loadEncrypted(const QString& name)
     }
     auto cipher = QByteArray::fromBase64(query.value("cipher"_ls).toString().toLatin1());
     auto iv = QByteArray::fromBase64(query.value("iv"_ls).toString().toLatin1());
-    return aesCtr256Decrypt(cipher, asCBytes(m_picklingKey).first<AesKeySize>(),
+    return aesCtr256Decrypt(cipher, asCBytes(m_picklingKey).first<Aes256KeySize>(),
                             asCBytes<AesBlockSize>(iv))
         .move_value_or({});
 }

--- a/Quotient/database.cpp
+++ b/Quotient/database.cpp
@@ -520,6 +520,11 @@ QByteArray Database::loadEncrypted(const QString& name)
     }
     auto cipher = QByteArray::fromBase64(query.value("cipher"_ls).toString().toLatin1());
     auto iv = QByteArray::fromBase64(query.value("iv"_ls).toString().toLatin1());
+    if (iv.size() < AesBlockSize) {
+        qCWarning(E2EE) << "Corrupt iv at the database record for" << name;
+        return {};
+    }
+
     return aesCtr256Decrypt(cipher, asCBytes(m_picklingKey).first<Aes256KeySize>(),
                             asCBytes<AesBlockSize>(iv))
         .move_value_or({});

--- a/Quotient/database.cpp
+++ b/Quotient/database.cpp
@@ -490,18 +490,19 @@ QString Database::edKeyForKeyId(const QString& userId, const QString& edKeyId)
 
 void Database::storeEncrypted(const QString& name, const QByteArray& key)
 {
-    auto iv = getRandom<16>();
-    auto result = aesCtr256Encrypt(key, m_picklingKey.viewAsByteArray().left(32), iv.viewAsByteArray());
-    if (!result.has_value()) {
-        //TODO: Error
-    }
+    auto iv = getRandom<AesBlockSize>();
+    auto result =
+        aesCtr256Encrypt(key, asCBytes(m_picklingKey).first<AesKeySize>(), iv);
+    if (!result.has_value())
+        return;
+
     auto cipher = result.value().toBase64();
     auto query = prepareQuery(QStringLiteral("INSERT INTO encrypted(name, cipher, iv) VALUES(:name, :cipher, :iv);"));
     auto deleteQuery = prepareQuery(QStringLiteral("DELETE FROM encrypted WHERE name=:name;"));
     deleteQuery.bindValue(":name"_ls, name);
     query.bindValue(":name"_ls, name);
     query.bindValue(":cipher"_ls, cipher);
-    query.bindValue(":iv"_ls, iv.viewAsByteArray().toBase64());
+    query.bindValue(":iv"_ls, iv.toBase64());
     transaction();
     execute(deleteQuery);
     execute(query);
@@ -518,9 +519,7 @@ QByteArray Database::loadEncrypted(const QString& name)
     }
     auto cipher = QByteArray::fromBase64(query.value("cipher"_ls).toString().toLatin1());
     auto iv = QByteArray::fromBase64(query.value("iv"_ls).toString().toLatin1());
-    auto result = aesCtr256Decrypt(cipher, m_picklingKey.viewAsByteArray().left(32), iv);
-    if (!result.has_value()) {
-        //TODO: Error
-    }
-    return result.value();
+    return aesCtr256Decrypt(cipher, asCBytes(m_picklingKey).first<AesKeySize>(),
+                            asCBytes<AesBlockSize>(iv))
+        .move_value_or({});
 }

--- a/Quotient/e2ee/cryptoutils.cpp
+++ b/Quotient/e2ee/cryptoutils.cpp
@@ -99,7 +99,7 @@ SslExpected<QByteArray> Quotient::pbkdf2HmacSha512(const QByteArray& password,
 }
 
 SslExpected<QByteArray> Quotient::aesCtr256Encrypt(const QByteArray& plaintext,
-                                                   byte_view_t<AesKeySize> key,
+                                                   byte_view_t<Aes256KeySize> key,
                                                    byte_view_t<AesBlockSize> iv)
 {
     CLAMP_SIZE(plaintextSize, plaintext,
@@ -185,7 +185,7 @@ SslExpected<QByteArray> Quotient::hmacSha256(byte_view_t<HmacKeySize> hmacKey,
 }
 
 SslExpected<QByteArray> Quotient::aesCtr256Decrypt(const QByteArray& ciphertext,
-                                                   byte_view_t<AesKeySize> key,
+                                                   byte_view_t<Aes256KeySize> key,
                                                    byte_view_t<AesBlockSize> iv)
 {
     const ContextHolder context(EVP_CIPHER_CTX_new(), &EVP_CIPHER_CTX_free);

--- a/Quotient/e2ee/cryptoutils.cpp
+++ b/Quotient/e2ee/cryptoutils.cpp
@@ -226,7 +226,8 @@ QOlmExpected<QByteArray> Quotient::curve25519AesSha2Decrypt(
     auto context = makeCStruct(olm_pk_decryption, olm_pk_decryption_size, olm_clear_pk_decryption);
     Q_ASSERT(context);
 
-    // NB: The produced public key is not actually used, it's only a check
+    // NB: The produced public key is not actually used, the call is only
+    //     to fill the context with the private key for olm_pk_decrypt()
     if (std::vector<uint8_t> publicKey(olm_pk_key_length());
         olm_pk_key_from_private(context.get(), publicKey.data(),
                                 publicKey.size(), privateKey.data(),

--- a/Quotient/e2ee/cryptoutils.h
+++ b/Quotient/e2ee/cryptoutils.h
@@ -12,11 +12,23 @@
 #include <QtCore/QString>
 
 namespace Quotient {
-struct QUOTIENT_API HkdfKeys {
-    //! @brief Key to be used for AES encryption / decryption
-    QByteArray aes;
-    //! @brief Key to be used for MAC creation / verification
-    QByteArray mac;
+
+// Common remark: OpenSSL is a private dependency of libQuotient, meaning that
+// headers of libQuotient can't include OpenSSL headers. Instead, alias
+// the value or type along with a comment (see SslErrorCode e.g.) and add
+// static_assert in the .cpp file to check it against the OpenSSL definition.
+
+constexpr auto DefaultPbkdf2KeyLength = 32u;
+constexpr auto AesKeySize = 32u;
+constexpr auto AesBlockSize = 16u; // AES_BLOCK_SIZE
+constexpr auto HmacKeySize = 32u;
+
+struct QUOTIENT_API HkdfKeys
+    : public FixedBuffer<AesKeySize + HmacKeySize> {
+    //! \brief Key to be used for AES encryption / decryption
+    auto aes() const { return asCBytes(*this).first<AesKeySize>(); }
+    //! \brief Key to be used for MAC creation / verification
+    auto mac() const { return asCBytes(*this).last<HmacKeySize>(); }
 };
 
 struct QUOTIENT_API Curve25519Encrypted {
@@ -25,17 +37,14 @@ struct QUOTIENT_API Curve25519Encrypted {
     QByteArray ephemeral;
 };
 
-// OpenSSL is a private dependency; can't refer to OpenSSL symbols from here
-
-constexpr auto DefaultPbkdf2KeyLength = 32u;
-constexpr auto AesBlockSize = 16u; // AES_BLOCK_SIZE
-
 // NOLINTNEXTLINE(google-runtime-int): the type is copied from OpenSSL
 using SslErrorCode = unsigned long; // decltype(ERR_get_error())
 
-constexpr SslErrorCode SslErrorUserOffset = 128; // ERR_LIB_USER
-[[maybe_unused]] constexpr SslErrorCode WrongDerivedKeyLength =
-    SslErrorUserOffset + 1;
+enum SslErrorCodes : SslErrorCode {
+    SslErrorUserOffset = 128, // ERR_LIB_USER; never use this bare
+    WrongDerivedKeyLength = SslErrorUserOffset + 1,
+    SslPayloadTooLong = SslErrorUserOffset + 2
+};
 
 //! Same as QOlmExpected but for wrapping OpenSSL instead of Olm calls
 template <typename T>
@@ -59,8 +68,9 @@ QUOTIENT_API SslExpected<HkdfKeys> hkdfSha256(const QByteArray& key,
                                               const QByteArray& info);
 
 //! Calculate a MAC from the given key and data
-QUOTIENT_API SslExpected<QByteArray> hmacSha256(const QByteArray& hmacKey,
-                                                const QByteArray& data);
+QUOTIENT_API SslExpected<QByteArray> hmacSha256(
+    byte_view_t<HmacKeySize> hmacKey,
+    const QByteArray& data);
 
 //! \brief Decrypt the data using Curve25519-AES-Sha256
 //! \note ciphertext must be given as base64
@@ -77,13 +87,15 @@ QUOTIENT_API QOlmExpected<Curve25519Encrypted> curve25519AesSha2Encrypt(
 //!
 //! key and iv have a length of 32 bytes
 QUOTIENT_API SslExpected<QByteArray> aesCtr256Encrypt(
-    const QByteArray& plaintext, const QByteArray& key, const QByteArray& iv);
+    const QByteArray& plaintext, byte_view_t<AesKeySize> key,
+    byte_view_t<AesBlockSize> iv);
 
 //! \brief Decrypt data using AES-CTR-256
 //!
 //! key and iv have a length of 32 bytes
 QUOTIENT_API SslExpected<QByteArray> aesCtr256Decrypt(
-    const QByteArray& ciphertext, const QByteArray& key, const QByteArray& iv);
+    const QByteArray& ciphertext, byte_view_t<AesKeySize> key,
+    byte_view_t<AesBlockSize> iv);
 
 QUOTIENT_API QByteArray base58Decode(const QByteArray& encoded);
 

--- a/Quotient/e2ee/cryptoutils.h
+++ b/Quotient/e2ee/cryptoutils.h
@@ -19,14 +19,14 @@ namespace Quotient {
 // static_assert in the .cpp file to check it against the OpenSSL definition.
 
 constexpr auto DefaultPbkdf2KeyLength = 32u;
-constexpr auto AesKeySize = 32u;
+constexpr auto Aes256KeySize = 32u;
 constexpr auto AesBlockSize = 16u; // AES_BLOCK_SIZE
 constexpr auto HmacKeySize = 32u;
 
 struct QUOTIENT_API HkdfKeys
-    : public FixedBuffer<AesKeySize + HmacKeySize> {
+    : public FixedBuffer<Aes256KeySize + HmacKeySize> {
     //! \brief Key to be used for AES encryption / decryption
-    auto aes() const { return asCBytes(*this).first<AesKeySize>(); }
+    auto aes() const { return asCBytes(*this).first<Aes256KeySize>(); }
     //! \brief Key to be used for MAC creation / verification
     auto mac() const { return asCBytes(*this).last<HmacKeySize>(); }
 };
@@ -87,14 +87,14 @@ QUOTIENT_API QOlmExpected<Curve25519Encrypted> curve25519AesSha2Encrypt(
 //!
 //! key and iv have a length of 32 bytes
 QUOTIENT_API SslExpected<QByteArray> aesCtr256Encrypt(
-    const QByteArray& plaintext, byte_view_t<AesKeySize> key,
+    const QByteArray& plaintext, byte_view_t<Aes256KeySize> key,
     byte_view_t<AesBlockSize> iv);
 
 //! \brief Decrypt data using AES-CTR-256
 //!
 //! key and iv have a length of 32 bytes
 QUOTIENT_API SslExpected<QByteArray> aesCtr256Decrypt(
-    const QByteArray& ciphertext, byte_view_t<AesKeySize> key,
+    const QByteArray& ciphertext, byte_view_t<Aes256KeySize> key,
     byte_view_t<AesBlockSize> iv);
 
 QUOTIENT_API QByteArray base58Decode(const QByteArray& encoded);

--- a/Quotient/e2ee/e2ee_common.cpp
+++ b/Quotient/e2ee/e2ee_common.cpp
@@ -23,6 +23,13 @@ QByteArray Quotient::byteArrayForOlm(size_t bufferSize)
     return {};
 }
 
+void Quotient::_impl::reportSpanShortfall(QByteArray::size_type inputSize,
+                                          size_t neededSize)
+{
+    qCCritical(E2EE) << "Not enough bytes to create a valid span: " << inputSize
+                     << '<' << neededSize << "- undefined behaviour imminent";
+}
+
 void Quotient::fillFromSecureRng(std::span<byte_t> bytes)
 {
     // Discussion of QRandomGenerator::system() vs. OpenSSL's RAND_bytes

--- a/Quotient/e2ee/e2ee_common.cpp
+++ b/Quotient/e2ee/e2ee_common.cpp
@@ -14,6 +14,8 @@ using namespace Quotient;
 
 QByteArray Quotient::byteArrayForOlm(size_t bufferSize)
 {
+    // TODO: remove the check and inline the function once we move over to Qt 6
+    //       with its 64-bit qsizetype
     if (bufferSize < std::numeric_limits<QByteArray::size_type>::max())
         return { static_cast<QByteArray::size_type>(bufferSize), '\0' };
 

--- a/Quotient/e2ee/e2ee_common.cpp
+++ b/Quotient/e2ee/e2ee_common.cpp
@@ -23,11 +23,17 @@ QByteArray Quotient::byteArrayForOlm(size_t bufferSize)
     return {};
 }
 
-void Quotient::_impl::reportSpanShortfall(QByteArray::size_type inputSize,
+void Quotient::_impl::checkForSpanShortfall(QByteArray::size_type inputSize,
                                           size_t neededSize)
 {
-    qCCritical(E2EE) << "Not enough bytes to create a valid span: " << inputSize
-                     << '<' << neededSize << "- undefined behaviour imminent";
+    if (inputSize < static_cast<qsizetype>(neededSize)) {
+        qCCritical(E2EE) << "Not enough bytes to create a valid span: "
+                         << inputSize << '<' << neededSize
+                         << "- undefined behaviour imminent";
+        Q_ASSERT(false);
+        // Can't help it in Release builds; a span of the given size has
+        // to be returned regardless, so UB
+    }
 }
 
 void Quotient::fillFromSecureRng(std::span<byte_t> bytes)

--- a/Quotient/e2ee/e2ee_common.h
+++ b/Quotient/e2ee/e2ee_common.h
@@ -103,7 +103,7 @@ namespace _impl {
                                           size_t neededSize);
 } // namespace _impl
 
-//! \brief Obtain an std::span<const byte_t> looking into the passed QByteArray
+//! \brief Obtain a std::span<const byte_t> looking into the passed QByteArray
 //!
 //! This function returns an adaptor object that is suitable for OpenSSL/Olm
 //! invocations (via std::span<>::data() accessor) so that you don't have

--- a/Quotient/e2ee/sssshandler.cpp
+++ b/Quotient/e2ee/sssshandler.cpp
@@ -35,10 +35,10 @@ QByteArray SSSSHandler::decryptKey(const QString& name, const QByteArray& decryp
     if (!hkdfResult.has_value()) {
         //TODO: Error
     }
-    auto keys = hkdfResult.value();
+    auto&& keys = hkdfResult.value();
 
     auto rawCipher = QByteArray::fromBase64(encrypted["ciphertext"_ls].toString().toLatin1());
-    auto result = hmacSha256(keys.mac, rawCipher);
+    auto result = hmacSha256(keys.mac(), rawCipher);
     if (!result.has_value()) {
         //TODO: Error
     }
@@ -46,7 +46,10 @@ QByteArray SSSSHandler::decryptKey(const QString& name, const QByteArray& decryp
         qCWarning(E2EE) << "MAC mismatch for" << name;
         return {};
     }
-    auto decryptResult = aesCtr256Decrypt(rawCipher, keys.aes, QByteArray::fromBase64(encrypted["iv"_ls].toString().toLatin1()));
+    auto decryptResult =
+        aesCtr256Decrypt(rawCipher, keys.aes(),
+                         asCBytes<AesBlockSize>(QByteArray::fromBase64(
+                             encrypted["iv"_ls].toString().toLatin1())));
     if (!decryptResult.has_value()) {
         //TODO: Error
     }
@@ -188,11 +191,14 @@ void SSSSHandler::calculateDefaultKey(const QByteArray& secret,
     if (!testKeys.has_value()) {
         //TODO: Error
     }
-    const auto &encrypted = aesCtr256Encrypt(QByteArray(32, u'\0'), testKeys.value().aes, QByteArray::fromBase64(keyEvent->contentPart<QString>("iv"_ls).toLatin1()));
+    const auto& encrypted = aesCtr256Encrypt(
+        QByteArray(32, u'\0'), testKeys.value().aes(),
+        asCBytes<AesBlockSize>(QByteArray::fromBase64(
+            keyEvent->contentPart<QString>("iv"_ls).toLatin1())));
     if (!encrypted.has_value()) {
         //TODO: Error
     }
-    const auto &result = hmacSha256(testKeys.value().mac, encrypted.value());
+    const auto &result = hmacSha256(testKeys.value().mac(), encrypted.value());
     if (!result.has_value()) {
         //TODO: Error
     }

--- a/Quotient/events/filesourceinfo.cpp
+++ b/Quotient/events/filesourceinfo.cpp
@@ -23,12 +23,16 @@ using namespace Quotient;
 QByteArray Quotient::decryptFile(const QByteArray& ciphertext,
                                  const EncryptedFileMetadata& metadata)
 {
+    if (QByteArray::fromBase64(metadata.hashes["sha256"_ls].toLatin1())
+        != QCryptographicHash::hash(ciphertext, QCryptographicHash::Sha256)) {
+        qCWarning(E2EE) << "Hash verification failed for file";
+        return {};
+    }
     const auto key = QByteArray::fromBase64(metadata.key.k.toLatin1(),
                                             QByteArray::Base64UrlEncoding);
     if (key.size() < Aes256KeySize) {
-        qCWarning(E2EE)
-            << "Decoded key is too short for AES, need 32 bytes, got"
-            << key.size();
+        qCWarning(E2EE) << "Decoded key is too short for AES, need"
+                        << Aes256KeySize << "bytes, got" << key.size();
         return {};
     }
     const auto iv = QByteArray::fromBase64(metadata.iv.toLatin1());

--- a/Quotient/events/filesourceinfo.cpp
+++ b/Quotient/events/filesourceinfo.cpp
@@ -25,7 +25,7 @@ QByteArray Quotient::decryptFile(const QByteArray& ciphertext,
 {
     const auto key = QByteArray::fromBase64(metadata.key.k.toLatin1(),
                                             QByteArray::Base64UrlEncoding);
-    if (key.size() < AesKeySize) {
+    if (key.size() < Aes256KeySize) {
         qCWarning(E2EE)
             << "Decoded key is too short for AES, need 32 bytes, got"
             << key.size();
@@ -45,7 +45,7 @@ QByteArray Quotient::decryptFile(const QByteArray& ciphertext,
 std::pair<EncryptedFileMetadata, QByteArray> Quotient::encryptFile(
     const QByteArray& plainText)
 {
-    auto k = getRandom<AesKeySize>();
+    auto k = getRandom<Aes256KeySize>();
     auto kBase64 = k.toBase64(QByteArray::Base64UrlEncoding
                               | QByteArray::OmitTrailingEquals);
     auto iv = getRandom<AesBlockSize>();

--- a/Quotient/events/filesourceinfo.cpp
+++ b/Quotient/events/filesourceinfo.cpp
@@ -57,15 +57,15 @@ std::pair<EncryptedFileMetadata, QByteArray> Quotient::encryptFile(
         "oct"_ls, { "encrypt"_ls, "decrypt"_ls }, "A256CTR"_ls, QString::fromLatin1(kBase64), true
     };
     auto result = aesCtr256Encrypt(plainText, k, iv);
+    if (!result.has_value())
+        return {};
 
-    if (!result.has_value()) {
-        //TODO: Error
-    }
     auto hash = QCryptographicHash::hash(result.value(), QCryptographicHash::Sha256)
                     .toBase64(QByteArray::OmitTrailingEquals);
     auto ivBase64 = iv.toBase64(QByteArray::OmitTrailingEquals);
     const EncryptedFileMetadata efm = {
-        {}, key, QString::fromLatin1(ivBase64), { { QStringLiteral("sha256"), QString::fromLatin1(hash) } }, "v2"_ls
+        {}, key, QString::fromLatin1(ivBase64),
+        { { "sha256"_ls, QString::fromLatin1(hash) } }, "v2"_ls
     };
     return { efm, result.value() };
 }

--- a/autotests/testcryptoutils.cpp
+++ b/autotests/testcryptoutils.cpp
@@ -32,7 +32,7 @@ using namespace Quotient;
 void TestCryptoUtils::aesCtrEncryptDecryptData()
 {
     const QByteArray plain = "ABCDEF";
-    const FixedBuffer<AesKeySize> key{};
+    const FixedBuffer<Aes256KeySize> key{};
     const FixedBuffer<AesBlockSize> iv{};
     auto cipher = aesCtr256Encrypt(plain, key, iv);
     QVERIFY(cipher.has_value());

--- a/autotests/testcryptoutils.cpp
+++ b/autotests/testcryptoutils.cpp
@@ -32,8 +32,8 @@ using namespace Quotient;
 void TestCryptoUtils::aesCtrEncryptDecryptData()
 {
     const QByteArray plain = "ABCDEF";
-    const auto key = zeroedByteArray();
-    const auto iv = zeroedByteArray();
+    const FixedBuffer<AesKeySize> key{};
+    const FixedBuffer<AesBlockSize> iv{};
     auto cipher = aesCtr256Encrypt(plain, key, iv);
     QVERIFY(cipher.has_value());
     auto decrypted = aesCtr256Decrypt(cipher.value(), key, iv);
@@ -56,9 +56,9 @@ void TestCryptoUtils::hkdfSha256ExpandKeys()
 {
     auto result = hkdfSha256(zeroedByteArray(), zeroedByteArray(), zeroedByteArray());
     QVERIFY(result.has_value());
-    auto keys = result.value();
-    QCOMPARE(keys.aes, QByteArray::fromBase64("WQvd7OvHEaSFkO5nPBLDHK9F0UW5r11S6MS83AjhHx8="));
-    QCOMPARE(keys.mac, QByteArray::fromBase64("hZhUYGZQRYj4src+HzLcKRruQQ0wSr9kC/g105lej+s="));
+    auto&& keys = result.value();
+    QCOMPARE(viewAsByteArray(keys.aes()), QByteArray::fromBase64("WQvd7OvHEaSFkO5nPBLDHK9F0UW5r11S6MS83AjhHx8="));
+    QCOMPARE(viewAsByteArray(keys.mac()), QByteArray::fromBase64("hZhUYGZQRYj4src+HzLcKRruQQ0wSr9kC/g105lej+s="));
 }
 
 void TestCryptoUtils::pbkdfGenerateKey()
@@ -70,7 +70,7 @@ void TestCryptoUtils::pbkdfGenerateKey()
 
 void TestCryptoUtils::hmac()
 {
-    auto result = hmacSha256(zeroedByteArray(),  QByteArray(64, 1));
+    auto result = hmacSha256(FixedBuffer<HmacKeySize>{}, QByteArray(64, 1));
     QVERIFY(result.has_value());
     QCOMPARE(result.value(), QByteArray::fromBase64("GfJTpEMByWSMA/NXBYH/KHW2qlKxSZu4r//jRsUuz24="));
 }


### PR DESCRIPTION
This can be seen as rather controversial so I'm making it a PR-on-PR. Given the amount and the kind of changes, it can look either beautiful or hideous. I tried to use a bit of ideomatic C++20 here - ideally, I would use ranges but unfortunately I can't, until version 0.9 at least. If that doesn't look too terrifying, I'll merge it and continue with the original PR.