### PR TITLE
GHA: Fix Clang pipelines by using Clang 15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,10 +61,7 @@ jobs:
       if: startsWith(matrix.os, 'ubuntu')
       run: |
         COMMON_PKGS="libolm-dev ninja-build valgrind gnome-keyring"
-        # Workaround for https://github.com/actions/runner-images/issues/8659
-        sudo rm -f /etc/apt/sources.list.d/ubuntu-toolchain-r-ubuntu-test-jammy.list
-        COMMON_PKGS="--allow-downgrades libc6=2.35-0ubuntu3.5 libc6-dev=2.35-0ubuntu3.5 libstdc++6=12.3.0-1ubuntu1~22.04 libgcc-s1=12.3.0-1ubuntu1~22.04 $COMMON_PKGS"
-        # End of workaround
+        COMMON_PKGS="$COMMON_PKGS clang-15" # Workaround for https://github.com/actions/runner-images/issues/8659
         sudo apt-get -qq update
         sudo apt-get -qq install $COMMON_PKGS \
             ${{ startsWith(matrix.qt-version, '5')
@@ -88,9 +85,10 @@ jobs:
             echo "CC=gcc" >>$GITHUB_ENV
             echo "CXX=g++" >>$GITHUB_ENV
             echo "VALGRIND=valgrind --tool=memcheck --leak-check=yes --gen-suppressions=all --suppressions=$GITHUB_WORKSPACE/quotest/.valgrind.supp" >>$GITHUB_ENV
-        elif [[ '${{ runner.os }}' != 'Windows' ]]; then
-            echo "CC=clang" >>$GITHUB_ENV
-            echo "CXX=clang++" >>$GITHUB_ENV
+        elif [[ '${{ runner.os }}' == 'Linux' ]]; then
+            # Workaround for https://github.com/actions/runner-images/issues/8659
+            echo "CC=clang-15" >>$GITHUB_ENV
+            echo "CXX=clang++-15" >>$GITHUB_ENV
         fi
         if grep -q 'refs/tags' <<<'${{ github.ref }}'; then
             VERSION="$(git describe --tags)"


### PR DESCRIPTION
It's still considered a workaround for https://github.com/actions/runner-images/issues/8659 - normally we should check on an older Clang version.