### PR TITLE
Direct Chat Encryption Default

### DIFF
--- a/Quotient/connection.cpp
+++ b/Quotient/connection.cpp
@@ -30,6 +30,7 @@
 #include "csapi/whoami.h"
 
 #include "events/directchatevent.h"
+#include "events/encryptionevent.h"
 #include "jobs/downloadfilejob.h"
 #include "jobs/mediathumbnailjob.h"
 #include "jobs/syncjob.h"
@@ -925,8 +926,20 @@ CreateRoomJob* Connection::createDirectChat(const QString& userId,
                                             const QString& topic,
                                             const QString& name)
 {
+    QList<CreateRoomJob::StateEvent> initialStateEvents;
+
+    if (d->encryptDirectChats) {
+        const auto encryptionContent = EncryptionEventContent(EncryptionType::MegolmV1AesSha2);
+        initialStateEvents.append(CreateRoomJob::StateEvent{
+            "m.room.encryption"_ls,
+            encryptionContent.toJson(),
+            {},
+        });
+    }
+
     return createRoom(UnpublishRoom, {}, name, topic, { userId },
-                      QStringLiteral("trusted_private_chat"), {}, true);
+                      QStringLiteral("trusted_private_chat"), {}, true,
+                      initialStateEvents);
 }
 
 ForgetRoomJob* Connection::forgetRoom(const QString& id)
@@ -1504,6 +1517,11 @@ void Connection::setEncryptionDefault(bool useByDefault)
 {
     Private::encryptionDefault = useByDefault;
 }
+
+void Connection::setDirectChatEncryptionDefault(bool useByDefault)
+{
+    Private::directChatEncryptionDefault = useByDefault;
+}
 #endif
 
 void Connection::setRoomFactory(room_factory_t f)
@@ -1769,11 +1787,32 @@ void Connection::enableEncryption(bool enable)
 
 #ifdef Quotient_E2EE_ENABLED
     d->useEncryption = enable;
-    emit encryptionChanged(enable);
+    emit directChatsEncryptionChanged(enable);
 #else
     Q_UNUSED(enable)
     qWarning(E2EE) << "The library is compiled without E2EE support, "
                       "enabling encryption has no effect";
+#endif
+}
+
+bool Connection::directChatEncryptionEnabled() const
+{
+    return d->encryptDirectChats;
+}
+
+void Connection::enableDirectChatEncryption(bool enable)
+{
+    if (enable == d->encryptDirectChats) {
+        return;
+    }
+
+#ifdef Quotient_E2EE_ENABLED
+    d->encryptDirectChats = enable;
+    emit encryptionChanged(enable);
+#else
+    Q_UNUSED(enable)
+    qWarning(E2EE) << "The library is compiled without E2EE support, "
+                      "enabling encryption for direct chats has no effect";
 #endif
 }
 

--- a/Quotient/connection.cpp
+++ b/Quotient/connection.cpp
@@ -930,11 +930,7 @@ CreateRoomJob* Connection::createDirectChat(const QString& userId,
 
     if (d->encryptDirectChats) {
         const auto encryptionContent = EncryptionEventContent(EncryptionType::MegolmV1AesSha2);
-        initialStateEvents.append(CreateRoomJob::StateEvent{
-            "m.room.encryption"_ls,
-            encryptionContent.toJson(),
-            {},
-        });
+        initialStateEvents.append({ EncryptionEvent::TypeId, encryptionContent.toJson() });
     }
 
     return createRoom(UnpublishRoom, {}, name, topic, { userId },
@@ -1808,7 +1804,7 @@ void Connection::enableDirectChatEncryption(bool enable)
 
 #ifdef Quotient_E2EE_ENABLED
     d->encryptDirectChats = enable;
-    emit encryptionChanged(enable);
+    emit directChatsEncryptionChanged(enable);
 #else
     Q_UNUSED(enable)
     qWarning(E2EE) << "The library is compiled without E2EE support, "

--- a/Quotient/connection.cpp
+++ b/Quotient/connection.cpp
@@ -1783,7 +1783,7 @@ void Connection::enableEncryption(bool enable)
 
 #ifdef Quotient_E2EE_ENABLED
     d->useEncryption = enable;
-    emit directChatsEncryptionChanged(enable);
+    emit encryptionChanged(enable);
 #else
     Q_UNUSED(enable)
     qWarning(E2EE) << "The library is compiled without E2EE support, "

--- a/Quotient/connection.h
+++ b/Quotient/connection.h
@@ -131,6 +131,7 @@ class QUOTIENT_API Connection : public QObject {
     Q_PROPERTY(bool lazyLoading READ lazyLoading WRITE setLazyLoading NOTIFY lazyLoadingChanged)
     Q_PROPERTY(bool canChangePassword READ canChangePassword NOTIFY capabilitiesLoaded)
     Q_PROPERTY(bool encryptionEnabled READ encryptionEnabled WRITE enableEncryption NOTIFY encryptionChanged)
+    Q_PROPERTY(bool directChatEncryptionEnabled READ directChatEncryptionEnabled WRITE enableDirectChatEncryption NOTIFY directChatsEncryptionChanged)
     Q_PROPERTY(QStringList accountDataEventTypes READ accountDataEventTypes NOTIFY accountDataChanged)
 
 public:
@@ -478,6 +479,20 @@ public:
     //! \sa encryptionEnabled
     void enableEncryption(bool enable);
 
+    //! \brief Check whether encryption is enabled for new direct chats on this connection
+    //!
+    //! \note This has no effect if the library is compiled without E2EE support
+    //!
+    //! \sa enableDirectChatEncryption
+    bool directChatEncryptionEnabled() const;
+
+    //! \brief Enable or disable whether new direct chats are encrypted on this connection
+    //!
+    //! \note This has no effect if the library is compiled without E2EE support
+    //!
+    //! \sa directChatEncryptionEnabled
+    void enableDirectChatEncryption(bool enable);
+
     //! \brief Load room state from a previously saved file
     //!
     //! Call this before first sync.
@@ -591,6 +606,9 @@ public:
 #ifdef Quotient_E2EE_ENABLED
     //! Set the E2EE default state for any Connection created further
     static void setEncryptionDefault(bool useByDefault);
+
+    //! Set the direct chat E2EE default state for any Connection created further
+    static void setDirectChatEncryptionDefault(bool useByDefault);
 #endif
 
     //! Set a room factory function
@@ -959,6 +977,7 @@ Q_SIGNALS:
 
     //! Encryption has been enabled or disabled
     void encryptionChanged(bool enabled);
+    void directChatsEncryptionChanged(bool enabled);
 
 #ifdef Quotient_E2EE_ENABLED
     void newKeyVerificationSession(Quotient::KeyVerificationSession* session);

--- a/Quotient/connection_p.h
+++ b/Quotient/connection_p.h
@@ -66,9 +66,12 @@ public:
 #ifdef Quotient_E2EE_ENABLED
     static inline bool encryptionDefault = false;
     bool useEncryption = encryptionDefault;
+    static inline bool directChatEncryptionDefault = false;
+    bool encryptDirectChats = directChatEncryptionDefault;
     std::unique_ptr<_impl::ConnectionEncryptionData> encryptionData;
 #else
     static constexpr bool useEncryption = false;
+    static constexpr bool encryptDirectChats = false;
 #endif
 
     QPointer<GetWellknownJob> resolverJob = nullptr;


### PR DESCRIPTION
Add the ability to both set whether connections will try to encrypt direct chats by default and change the setting for individual connections