### PR TITLE
Clean up the rest of the User stuff around connection

### DIFF
--- a/Quotient/connection.h
+++ b/Quotient/connection.h
@@ -105,7 +105,6 @@ auto defaultUserFactory(Connection* c, const QString& id)
 // rooms in Join and Leave state; and direct chats in account data
 // are stored with no regard to their state.
 using DirectChatsMap = QMultiHash<const User*, QString>;
-using DirectChatUsersMap = QMultiHash<QString, User*>;
 using IgnoredUsersList = IgnoredUsersEvent::value_type;
 
 class QUOTIENT_API Connection : public QObject {
@@ -234,14 +233,6 @@ public:
     //! \sa directChatsListChanged
     void addToDirectChats(const Room* room, const QString& userId);
 
-    //! \brief Mark the room as a direct chat with the user
-    //!
-    //! This function marks \p room as a direct chat with \p user.
-    //! Emits the signal synchronously, without waiting to complete
-    //! synchronisation with the server.
-    //! \sa directChatsListChanged
-    void addToDirectChats(const Room* room, User* user);
-
     //! \brief Unmark the room from direct chats
     //!
     //! This function removes the room id from direct chats either for
@@ -252,17 +243,6 @@ public:
     //! the server.
     //! \sa directChatsListChanged
     void removeFromDirectChats(const QString& roomId, const QString& userId = {});
-
-    //! \brief Unmark the room from direct chats
-    //!
-    //! This function removes the room id from direct chats either for
-    //! a specific \p user or for all users if \p user in nullptr.
-    //! The room id is used to allow removal of, e.g., ids of forgotten
-    //! rooms; a Room object need not exist. Emits the signal
-    //! immediately, without waiting to complete synchronisation with
-    //! the server.
-    //! \sa directChatsListChanged
-    void removeFromDirectChats(const QString& roomId, User* user = nullptr);
 
     //! Check whether the room id corresponds to a direct chat
     bool isDirectChat(const QString& roomId) const;
@@ -275,11 +255,6 @@ public:
     //! \return The list of member IDs for which this room is marked as
     //!         a direct chat; an empty list if the room is not a direct chat
     QList<QString> directChatMemberIds(const Room* room) const;
-
-    //! \brief Retrieve the list of users the room is a direct chat with
-    //! \return The list of users for which this room is marked as
-    //!         a direct chat; an empty list if the room is not a direct chat
-    QList<User*> directChatUsers(const Room* room) const;
 
     //! Check whether a particular user id is in the ignore list
     Q_INVOKABLE bool isIgnored(const QString& userId) const;
@@ -303,9 +278,6 @@ public:
     //! Similar to adding, the change signal is emitted synchronously.
     //! \sa ignoredUsersListChanged
     Q_INVOKABLE void removeFromIgnoredUsers(const QString& userId);
-
-    //! Get the full list of users known to this account
-    QMap<QString, User*> users() const;
 
     //! Get the base URL of the homeserver to connect to
     QUrl homeserver() const;
@@ -705,14 +677,6 @@ public Q_SLOTS:
     //! \sa directChatAvailable
     void requestDirectChat(const QString& userId);
 
-    //! \brief Get a direct chat with a single user
-    //!
-    //! This method may return synchronously or asynchoronously depending
-    //! on whether a direct chat room with the respective person exists
-    //! already.
-    //! \sa directChatAvailable
-    void requestDirectChat(User* u);
-
     //! \brief Run an operation in a direct chat with the user
     //!
     //! This method may return synchronously or asynchoronously depending
@@ -721,14 +685,6 @@ public Q_SLOTS:
     //! function object with the direct chat room as its parameter.
     void doInDirectChat(const QString& userId,
                         const std::function<void(Room*)>& operation);
-
-    //! \brief Run an operation in a direct chat with the user
-    //!
-    //! This method may return synchronously or asynchoronously depending
-    //! on whether a direct chat room with the respective person exists
-    //! already. Instead of emitting a signal it executes the passed
-    //! function object with the direct chat room as its parameter.
-    void doInDirectChat(User* u, const std::function<void(Room*)>& operation);
 
     //! Create a direct chat with a single user, optional name and topic
     //!

--- a/Quotient/connection.h
+++ b/Quotient/connection.h
@@ -683,7 +683,7 @@ public Q_SLOTS:
     //! on whether a direct chat room with the respective person exists
     //! already. Instead of emitting a signal it executes the passed
     //! function object with the direct chat room as its parameter.
-    void doInDirectChat(const QString& userId,
+    void doInDirectChat(const QString& otherUserId,
                         const std::function<void(Room*)>& operation);
 
     //! Create a direct chat with a single user, optional name and topic

--- a/Quotient/connection_p.h
+++ b/Quotient/connection_p.h
@@ -44,7 +44,6 @@ public:
     std::unordered_map<QString, Avatar> userAvatarMap;
     DirectChatsMap directChats;
     QMultiHash<QString, QString> directChatMemberIds;
-    DirectChatUsersMap directChatUsers;
     // The below two variables track local changes between sync completions.
     // See https://github.com/quotient-im/libQuotient/wiki/Handling-direct-chat-events
     DirectChatsMap dcLocalAdditions;

--- a/Quotient/user.cpp
+++ b/Quotient/user.cpp
@@ -158,7 +158,7 @@ void User::removeAvatar() const
     connection()->callApi<SetAvatarUrlJob>(id(), QUrl());
 }
 
-void User::requestDirectChat() { connection()->requestDirectChat(this); }
+void User::requestDirectChat() { connection()->requestDirectChat(d->id); }
 
 void User::ignore() const { connection()->addToIgnoredUsers(d->id); }
 

--- a/quotest/quotest.cpp
+++ b/quotest/quotest.cpp
@@ -685,7 +685,7 @@ TEST_IMPL(markDirectChat)
 {
     if (checkDirectChat())
         connection()->removeFromDirectChats(targetRoom->id(),
-                                            connection()->user());
+                                            connection()->user()->id());
 
     const auto id = qRegisterMetaType<DirectChatsMap>(); // For QSignalSpy
     Q_ASSERT(id != -1);
@@ -694,7 +694,7 @@ TEST_IMPL(markDirectChat)
     // operations are synchronous.
     const QSignalSpy spy(connection(), &Connection::directChatsListChanged);
     clog << "Marking the room as a direct chat" << endl;
-    connection()->addToDirectChats(targetRoom, connection()->user());
+    connection()->addToDirectChats(targetRoom, connection()->user()->id());
     if (spy.count() != 1 || !checkDirectChat())
         FAIL_TEST();
 
@@ -707,7 +707,7 @@ TEST_IMPL(markDirectChat)
     }
 
     clog << "Unmarking the direct chat" << endl;
-    connection()->removeFromDirectChats(targetRoom->id(), connection()->user());
+    connection()->removeFromDirectChats(targetRoom->id(), connection()->user()->id());
     if (spy.count() != 2 && checkDirectChat())
         FAIL_TEST();
 


### PR DESCRIPTION
This finishes the cleanup from moving to `RoomMember`. All direct chat interfaces are now using userId rather than `User`.

`DirectChatUsers` is completely removed as it's replaced by `DirectChatMembers`.