### PR TITLE
Make RoomMember usage more convenient

### DIFF
--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -3379,22 +3379,7 @@ QJsonObject Room::Private::toJson() const
 
 QJsonObject Room::toJson() const { return d->toJson(); }
 
-MemberSorter Room::memberSorter() const { return MemberSorter(this); }
-
-bool MemberSorter::operator()(const RoomMember& u1, const RoomMember& u2) const
-{
-    return operator()(u1, u2.displayName());
-}
-
-bool MemberSorter::operator()(const RoomMember& u1, QStringView u2name) const
-{
-    auto n1 = u1.displayName();
-    if (n1.startsWith(u'@'))
-        n1.remove(0, 1);
-    const auto n2 = u2name.mid(u2name.startsWith(u'@') ? 1 : 0);
-
-    return n1.localeAwareCompare(n2) < 0;
-}
+MemberSorter Room::memberSorter() const { return MemberSorter(); }
 
 void Room::activateEncryption()
 {

--- a/Quotient/roommember.cpp
+++ b/Quotient/roommember.cpp
@@ -77,6 +77,11 @@ QString RoomMember::disambiguatedName() const { return _room->needsDisambiguatio
 
 QString RoomMember::htmlSafeDisambiguatedName() const { return disambiguatedName().toHtmlEscaped(); }
 
+bool RoomMember::matches(QStringView substr, Qt::CaseSensitivity cs) const
+{
+    return name().contains(substr, cs) || id().contains(substr, cs);
+}
+
 int RoomMember::hue() const { return static_cast<int>(hueF() * 359); }
 
 qreal RoomMember::hueF() const { return _hueF; }

--- a/Quotient/roommember.cpp
+++ b/Quotient/roommember.cpp
@@ -15,7 +15,7 @@ using namespace Quotient;
 RoomMember::RoomMember(const Room* room, const RoomMemberEvent* member)
     : _room(room)
     , _member(member)
-    , _hueF(_member == nullptr ? 0.0 : stringToHueF(member->userId()))
+    , _hueF(member == nullptr ? 0.0 : stringToHueF(member->userId()))
 {
 }
 

--- a/Quotient/roommember.cpp
+++ b/Quotient/roommember.cpp
@@ -127,3 +127,12 @@ QUrl RoomMember::avatarUrl() const {
     }
     return {};
 }
+
+namespace {
+inline QStringView removeLeadingAt(QStringView sv) { return sv.mid(sv.startsWith(u'@') ? 1 : 0); }
+}
+
+bool MemberSorter::operator()(QStringView u1name, QStringView u2name) const
+{
+    return removeLeadingAt(u1name).localeAwareCompare(removeLeadingAt(u2name)) < 0;
+}

--- a/Quotient/roommember.h
+++ b/Quotient/roommember.h
@@ -157,6 +157,12 @@ public:
     //! \sa disambiguatedName(), htmlSafeFullName(), htmlSafeDisplayName()
     QString htmlSafeDisambiguatedName() const;
 
+    //! \brief Check whether the name or id of the member contains a substring
+    //!
+    //! This is useful for a predicate to filter room members.
+    //! \sa MemberMatcher
+    Q_INVOKABLE bool matches(QStringView substr, Qt::CaseSensitivity cs = Qt::CaseSensitive) const;
+
     //! \brief Hue color component of this user based on the user's Matrix ID
     //!
     //! The implementation is based on XEP-0392:
@@ -195,6 +201,18 @@ private:
 
     qreal _hueF = 0;
 };
+
+//! \brief A factory to get a functional object matching room members against a substring
+//!
+//! This is a convenience wrapper to use RoomMember::matches() in standard algorithms.
+inline auto memberMatcher(auto substr, Qt::CaseSensitivity cs = Qt::CaseSensitive)
+{
+#ifdef __cpp_lib_bind_back
+    return std::bind_back(&RoomMember::matches, substr, cs);
+#else
+    return [substr, cs](const RoomMember& m) { return m.matches(substr, cs); };
+#endif
+}
 
 struct QUOTIENT_API MemberSorter {
     bool operator()(const RoomMember& u1, const RoomMember& u2) const

--- a/Quotient/roommember.h
+++ b/Quotient/roommember.h
@@ -195,4 +195,29 @@ private:
 
     qreal _hueF = 0;
 };
+
+struct QUOTIENT_API MemberSorter {
+    bool operator()(const RoomMember& u1, const RoomMember& u2) const
+    {
+        return operator()(u1.displayName(), u2.displayName());
+    }
+    bool operator()(const RoomMember& u1, QStringView u2name) const
+    {
+        return operator()(u1.displayName(), u2name);
+    }
+    bool operator()(QStringView u1name, const RoomMember& u2) const
+    {
+        return operator()(u1name, u2.displayName());
+    }
+    bool operator()(QStringView u1name, QStringView u2name) const;
+
+    template <template <class> class ContT>
+    [[deprecated("Use Quotient::lowerBoundIndex() or std::ranges::lower_bound() instead")]] //
+    typename ContT<RoomMember>::size_type
+    lowerBoundIndex(const ContT<RoomMember>& c, const auto& v) const
+    {
+        return std::ranges::lower_bound(c, v, *this) - c.begin();
+    }
+};
+
 } // namespace Quotient

--- a/Quotient/roommember.h
+++ b/Quotient/roommember.h
@@ -28,6 +28,7 @@ class RoomMemberEvent;
 //! \sa Quotient::User
 class QUOTIENT_API RoomMember {
     Q_GADGET
+    Q_PROPERTY(bool isEmpty READ isEmpty CONSTANT)
     Q_PROPERTY(QString id READ id CONSTANT)
     Q_PROPERTY(Uri uri READ uri CONSTANT)
     Q_PROPERTY(bool isLocalMember READ isLocalMember CONSTANT)
@@ -46,6 +47,8 @@ public:
     RoomMember() = default;
 
     explicit RoomMember(const Room* room, const RoomMemberEvent* member);
+
+    bool isEmpty() const { return _member == nullptr; }
 
     bool operator==(const RoomMember& other) const;
 
@@ -187,9 +190,9 @@ public:
     QUrl avatarUrl() const;
 
 private:
-    const Room* _room;
-    const RoomMemberEvent* _member;
+    const Room* _room = nullptr;
+    const RoomMemberEvent* _member = nullptr;
 
-    qreal _hueF;
+    qreal _hueF = 0;
 };
 } // namespace Quotient


### PR DESCRIPTION
This is a bunch of things made while porting Quaternion from `User` to `RoomMember` API:
1. `RoomMember::isEmpty()` ('nuff said)
2. `MemberSorter` doesn't need `Room` anymore because room pointers come with compared `RoomMember` objects already
3. `MemberSorter` is compatible with standard range algorithms now
4. `Quotient::lowerBoundMemberIndex()` comes to replace `MemberSorter::lowerBoundIndex()`
5. `RoomMember::matches()` and `memberMatcher()` to help with member filtering
6. ~~TODO: reinstate `RoomMember::avatar()`~~ will go to a separate PR.

If something is missing to make these useful for NeoChat, I'm happy to learn.