### PR TITLE
More modernisation, cleanup, deprecation

### DIFF
--- a/Quotient/accountregistry.cpp
+++ b/Quotient/accountregistry.cpp
@@ -10,10 +10,6 @@
 
 #include <QtCore/QCoreApplication>
 
-// TODO: remove in 0.9
-QT_IGNORE_DEPRECATIONS(
-    QUOTIENT_API Quotient::AccountRegistry Quotient::Accounts{};)
-
 using namespace Quotient;
 
 struct Q_DECL_HIDDEN AccountRegistry::Private {

--- a/Quotient/accountregistry.h
+++ b/Quotient/accountregistry.h
@@ -79,7 +79,4 @@ private:
     struct Private;
     ImplPtr<Private> d;
 };
-
-[[deprecated("Make and use an application-scope instance instead of a singleton")]]
-extern QUOTIENT_API AccountRegistry Accounts;
 } // namespace Quotient

--- a/Quotient/connection.cpp
+++ b/Quotient/connection.cpp
@@ -1829,8 +1829,7 @@ Database* Connection::database() const
     return d->encryptionData ? &d->encryptionData->database : nullptr;
 }
 
-UnorderedMap<QByteArray, QOlmInboundGroupSession>
-Connection::loadRoomMegolmSessions(const Room* room) const
+std::unordered_map<QByteArray, QOlmInboundGroupSession> Connection::loadRoomMegolmSessions(const Room* room) const
 {
     return database()->loadMegolmSessions(room->id());
 }

--- a/Quotient/connection.cpp
+++ b/Quotient/connection.cpp
@@ -1911,8 +1911,8 @@ void Connection::saveCurrentOutboundMegolmSession(
             "Check encryptionData() or database() before calling this method");
 }
 
-KeyVerificationSession* Connection::startKeyVerificationSession(
-    const QString& userId, const QString& deviceId)
+KeyVerificationSession* Connection::startKeyVerificationSession(const QString& userId,
+                                                                const QString& deviceId)
 {
     if (!d->encryptionData) {
         qWarning(E2EE) << "E2EE is switched off on" << objectName()

--- a/Quotient/connection.cpp
+++ b/Quotient/connection.cpp
@@ -1353,18 +1353,6 @@ IgnoredUsersList Connection::ignoredUsers() const
     return event ? event->ignoredUsers() : IgnoredUsersList();
 }
 
-void Connection::addToIgnoredUsers(const User* user)
-{
-    Q_ASSERT(user != nullptr);
-
-    auto ignoreList = ignoredUsers();
-    if (!ignoreList.contains(user->id())) {
-        ignoreList.insert(user->id());
-        d->packAndSendAccountData<IgnoredUsersEvent>(ignoreList);
-        emit ignoredUsersListChanged({ { user->id() } }, {});
-    }
-}
-
 void Connection::addToIgnoredUsers(const QString& userId)
 {
     auto ignoreList = ignoredUsers();
@@ -1372,17 +1360,6 @@ void Connection::addToIgnoredUsers(const QString& userId)
         ignoreList.insert(userId);
         d->packAndSendAccountData<IgnoredUsersEvent>(ignoreList);
         emit ignoredUsersListChanged({ { userId } }, {});
-    }
-}
-
-void Connection::removeFromIgnoredUsers(const User* user)
-{
-    Q_ASSERT(user != nullptr);
-
-    auto ignoreList = ignoredUsers();
-    if (ignoreList.remove(user->id()) != 0) {
-        d->packAndSendAccountData<IgnoredUsersEvent>(ignoreList);
-        emit ignoredUsersListChanged({}, { { user->id() } });
     }
 }
 
@@ -1888,27 +1865,6 @@ void Connection::sendSessionKeyToDevices(
 {
     Q_ASSERT(d->encryptionData != nullptr);
     d->encryptionData->sendSessionKeyToDevices(roomId, outboundSession, devices);
-}
-
-std::optional<QOlmOutboundGroupSession> Connection::loadCurrentOutboundMegolmSession(
-    const QString& roomId) const
-{
-    const auto& db = database();
-    Q_ASSERT_X(
-        db, __FUNCTION__,
-        "Check encryptionData() or database() before calling this method");
-    return db ? db->loadCurrentOutboundMegolmSession(roomId) : std::nullopt;
-}
-
-void Connection::saveCurrentOutboundMegolmSession(
-    const QString& roomId, const QOlmOutboundGroupSession& session) const
-{
-    if (const auto& db = database())
-        db->saveCurrentOutboundMegolmSession(roomId, session);
-    else
-        Q_ASSERT_X(
-            false, __FUNCTION__,
-            "Check encryptionData() or database() before calling this method");
 }
 
 KeyVerificationSession* Connection::startKeyVerificationSession(const QString& userId,

--- a/Quotient/connection.cpp
+++ b/Quotient/connection.cpp
@@ -39,8 +39,6 @@
 #include "jobs/mediathumbnailjob.h"
 #include "jobs/syncjob.h"
 
-#include <qt6keychain/keychain.h>
-
 #include <QtCore/QCoreApplication>
 #include <QtCore/QDir>
 #include <QtCore/QElapsedTimer>
@@ -50,6 +48,7 @@
 #include <QtCore/QStandardPaths>
 #include <QtCore/QStringBuilder>
 #include <QtNetwork/QDnsLookup>
+#include <qt6keychain/keychain.h>
 
 using namespace Quotient;
 
@@ -1770,20 +1769,9 @@ bool Connection::isQueryingKeys() const
            && d->encryptionData->currentQueryKeysJob != nullptr;
 }
 
-void Connection::encryptionUpdate(const Room* room, const QList<QString>& invitedIds)
+void Connection::encryptionUpdate(const Room* room, const QStringList& invitedIds)
 {
     if (d->encryptionData) {
-        d->encryptionData->encryptionUpdate(room->joinedMemberIds() + invitedIds);
-    }
-}
-
-void Connection::encryptionUpdate(const Room* room, const QList<User*>& invited)
-{
-    if (d->encryptionData) {
-        QList<QString> invitedIds;
-        for (const auto& u : invited) {
-            invitedIds.append(u->id());
-        }
         d->encryptionData->encryptionUpdate(room->joinedMemberIds() + invitedIds);
     }
 }

--- a/Quotient/connection.h
+++ b/Quotient/connection.h
@@ -769,8 +769,7 @@ public Q_SLOTS:
     Quotient::KeyVerificationSession* startKeyVerificationSession(const QString& userId,
                                                                   const QString& deviceId);
 
-    void encryptionUpdate(const Room* room, const QList<QString>& invitedIds);
-    void encryptionUpdate(const Room* room, const QList<User*>& invited = {});
+    void encryptionUpdate(const Room* room, const QStringList& invitedIds = {});
 
     static Connection* makeMockConnection(const QString& mxId,
                                           bool enableEncryption = true);

--- a/Quotient/connection.h
+++ b/Quotient/connection.h
@@ -295,22 +295,7 @@ public:
     //! to complete synchronisation with the server.
     //!
     //! \sa ignoredUsersListChanged
-    [[deprecated("Use the overload that accepts a user id instead")]] //
-    Q_INVOKABLE void addToIgnoredUsers(const Quotient::User* user);
-
-    //! \brief Add the user to the ignore list
-    //! The change signal is emitted synchronously, without waiting
-    //! to complete synchronisation with the server.
-    //!
-    //! \sa ignoredUsersListChanged
     Q_INVOKABLE void addToIgnoredUsers(const QString& userId);
-
-    //! \brief Remove the user from the ignore list
-    //!
-    //! Similar to adding, the change signal is emitted synchronously.
-    //! \sa ignoredUsersListChanged
-    [[deprecated("Use the overload that accepts a user id instead")]] //
-    Q_INVOKABLE void removeFromIgnoredUsers(const Quotient::User* user);
 
     //! \brief Remove the user from the ignore list
     //!
@@ -371,12 +356,6 @@ public:
         const Room* room) const;
     void saveMegolmSession(const Room* room,
                            const QOlmInboundGroupSession& session) const;
-    [[deprecated("Use database()->loadCurrentOutboundMegolmSession()")]] //
-    std::optional<QOlmOutboundGroupSession>
-    loadCurrentOutboundMegolmSession(const QString& roomId) const;
-    [[deprecated("Use database()->saveCurrentOutboundMegolmSession()")]]
-    void saveCurrentOutboundMegolmSession(
-        const QString& roomId, const QOlmOutboundGroupSession& session) const;
 
     QString edKeyForUserDevice(const QString& userId,
                                const QString& deviceId) const;

--- a/Quotient/connection.h
+++ b/Quotient/connection.h
@@ -786,8 +786,8 @@ public Q_SLOTS:
     //! \deprecated Do not use this directly, use Room::leaveRoom() instead
     virtual LeaveRoomJob* leaveRoom(Room* room);
 
-    KeyVerificationSession* startKeyVerificationSession(const QString& userId,
-                                                        const QString& deviceId);
+    Quotient::KeyVerificationSession* startKeyVerificationSession(const QString& userId,
+                                                                  const QString& deviceId);
 
     void encryptionUpdate(const Room* room, const QList<QString>& invitedIds);
     void encryptionUpdate(const Room* room, const QList<User*>& invited = {});
@@ -954,7 +954,7 @@ Q_SIGNALS:
         const Quotient::KeyVerificationSession* session,
         Quotient::KeyVerificationSession::State state);
     void sessionVerified(const QString& userId, const QString& deviceId);
-    bool finishedQueryingKeys();
+    void finishedQueryingKeys();
     void secretReceived(const QString& requestId, const QString& secret);
 
 protected:
@@ -972,14 +972,14 @@ protected:
     //! will be deleted and a new room object with Join state created.
     //! In contrast, switching between Join and Leave happens within
     //! the same object.
-    //! \param roomId room id (not alias!)
+    //! \param id room id (not alias!)
     //! \param joinState desired (target) join state of the room; if
     //! omitted, any state will be found and return unchanged, or a
     //! new Join room created.
     //! \return a pointer to a Room object with the specified id and the
     //! specified state; nullptr if roomId is empty or if roomFactory()
     //! failed to create a Room object.
-    Room* provideRoom(const QString& roomId, std::optional<JoinState> joinState = {});
+    Room* provideRoom(const QString& id, std::optional<JoinState> joinState = {});
 
     //! Process sync data from a successful sync request
     void onSyncSuccess(SyncData&& data, bool fromCache = false);

--- a/Quotient/connection.h
+++ b/Quotient/connection.h
@@ -285,6 +285,7 @@ public:
     Q_INVOKABLE bool isIgnored(const QString& userId) const;
 
     //! Check whether a particular user is in the ignore list
+    [[deprecated("Use the overload accepting UserId instead")]]
     Q_INVOKABLE bool isIgnored(const Quotient::User* user) const;
 
     //! Get the whole list of ignored users
@@ -352,7 +353,7 @@ public:
     QOlmAccount* olmAccount() const;
     Database* database() const;
 
-    UnorderedMap<QByteArray, QOlmInboundGroupSession> loadRoomMegolmSessions(
+    std::unordered_map<QByteArray, QOlmInboundGroupSession> loadRoomMegolmSessions(
         const Room* room) const;
     void saveMegolmSession(const Room* room,
                            const QOlmInboundGroupSession& session) const;

--- a/Quotient/connection_p.h
+++ b/Quotient/connection_p.h
@@ -41,7 +41,7 @@ public:
     QVector<QString> roomIdsToForget;
     QVector<QString> pendingStateRoomIds;
     QMap<QString, User*> userMap;
-    UnorderedMap<QString, Avatar> userAvatarMap;
+    std::unordered_map<QString, Avatar> userAvatarMap;
     DirectChatsMap directChats;
     QMultiHash<QString, QString> directChatMemberIds;
     DirectChatUsersMap directChatUsers;
@@ -49,7 +49,7 @@ public:
     // See https://github.com/quotient-im/libQuotient/wiki/Handling-direct-chat-events
     DirectChatsMap dcLocalAdditions;
     DirectChatsMap dcLocalRemovals;
-    UnorderedMap<QString, EventPtr> accountData;
+    std::unordered_map<QString, EventPtr> accountData;
     QMetaObject::Connection syncLoopConnection {};
     int syncTimeout = -1;
 

--- a/Quotient/connectionencryptiondata_p.h
+++ b/Quotient/connectionencryptiondata_p.h
@@ -23,7 +23,7 @@ namespace _impl {
         QOlmAccount olmAccount;
         // No easy way in C++ to discern between SQL SELECT from UPDATE, too bad
         mutable Database database;
-        UnorderedMap<QByteArray, std::vector<QOlmSession>> olmSessions;
+        std::unordered_map<QByteArray, std::vector<QOlmSession>> olmSessions;
         //! A map from SenderKey to vector of InboundSession
         QHash<QString, KeyVerificationSession*> verificationSessions{};
         QSet<QString> trackedUsers{};

--- a/Quotient/converters.h
+++ b/Quotient/converters.h
@@ -477,7 +477,7 @@ namespace _impl {
     template <typename ValT>
     inline void addTo(QUrlQuery& q, const QString&, const QHash<QString, ValT>& fields)
     {
-        for (const auto& [k, v] : asKeyValueRange(fields))
+        for (const auto& [k, v] : fields.asKeyValueRange())
             addTo(q, k, v);
     }
 

--- a/Quotient/csapi/search.h
+++ b/Quotient/csapi/search.h
@@ -157,7 +157,7 @@ public:
         //!
         //! The `string` key is the room ID for which the `State
         //! Event` array belongs to.
-        UnorderedMap<QString, StateEvents> state{};
+        std::unordered_map<QString, StateEvents> state{};
 
         //! Any groups that were requested.
         //!

--- a/Quotient/database.cpp
+++ b/Quotient/database.cpp
@@ -64,12 +64,8 @@ int Database::version()
 
 QSqlQuery Database::execute(const QString& queryString)
 {
-    auto query = database().exec(queryString);
-    if (query.lastError().type() != QSqlError::NoError) {
-        qCritical(DATABASE) << "Failed to execute query";
-        qCritical(DATABASE) << query.lastQuery();
-        qCritical(DATABASE) << query.lastError();
-    }
+    QSqlQuery query(queryString, database());
+    execute(query);
     return query;
 }
 

--- a/Quotient/database.cpp
+++ b/Quotient/database.cpp
@@ -221,14 +221,14 @@ void Database::saveOlmSession(const QByteArray& senderKey,
     commit();
 }
 
-UnorderedMap<QByteArray, std::vector<QOlmSession>> Database::loadOlmSessions()
+std::unordered_map<QByteArray, std::vector<QOlmSession> > Database::loadOlmSessions()
 {
     auto query = prepareQuery(QStringLiteral(
         "SELECT * FROM olm_sessions ORDER BY lastReceived DESC;"));
     transaction();
     execute(query);
     commit();
-    UnorderedMap<QByteArray, std::vector<QOlmSession>> sessions;
+    std::unordered_map<QByteArray, std::vector<QOlmSession>> sessions;
     while (query.next()) {
         if (auto&& expectedSession =
                 QOlmSession::unpickle(query.value("pickle"_ls).toByteArray(),
@@ -242,7 +242,7 @@ UnorderedMap<QByteArray, std::vector<QOlmSession>> Database::loadOlmSessions()
     return sessions;
 }
 
-UnorderedMap<QByteArray, QOlmInboundGroupSession> Database::loadMegolmSessions(
+std::unordered_map<QByteArray, QOlmInboundGroupSession> Database::loadMegolmSessions(
     const QString& roomId)
 {
     auto query = prepareQuery(QStringLiteral("SELECT * FROM inbound_megolm_sessions WHERE roomId=:roomId;"));
@@ -250,7 +250,7 @@ UnorderedMap<QByteArray, QOlmInboundGroupSession> Database::loadMegolmSessions(
     transaction();
     execute(query);
     commit();
-    UnorderedMap<QByteArray, QOlmInboundGroupSession> sessions;
+    decltype(Database::loadMegolmSessions({})) sessions;
     while (query.next()) {
         if (auto&& expectedSession = QOlmInboundGroupSession::unpickle(
                 query.value("pickle"_ls).toByteArray(), m_picklingKey)) {

--- a/Quotient/database.h
+++ b/Quotient/database.h
@@ -37,8 +37,8 @@ public:
     void clear();
     void saveOlmSession(const QByteArray& senderKey, const QOlmSession& session,
                         const QDateTime& timestamp);
-    UnorderedMap<QByteArray, std::vector<QOlmSession>> loadOlmSessions();
-    UnorderedMap<QByteArray, QOlmInboundGroupSession> loadMegolmSessions(
+    std::unordered_map<QByteArray, std::vector<QOlmSession>> loadOlmSessions();
+    std::unordered_map<QByteArray, QOlmInboundGroupSession> loadMegolmSessions(
         const QString& roomId);
     void saveMegolmSession(const QString& roomId,
                            const QOlmInboundGroupSession& session);

--- a/Quotient/e2ee/qolmaccount.cpp
+++ b/Quotient/e2ee/qolmaccount.cpp
@@ -193,7 +193,7 @@ UnsignedOneTimeKeys QOlmAccount::oneTimeKeys() const
 OneTimeKeys QOlmAccount::signOneTimeKeys(const UnsignedOneTimeKeys &keys) const
 {
     OneTimeKeys signedOneTimeKeys;
-    for (const auto& [keyId, key] : asKeyValueRange(keys.curve25519()))
+    for (const auto& [keyId, key] : keys.curve25519().asKeyValueRange())
         signedOneTimeKeys.insert("signed_curve25519:"_ls % keyId,
                                  SignedOneTimeKey {
                                      key, m_userId, m_deviceId,

--- a/Quotient/e2ee/sssshandler.cpp
+++ b/Quotient/e2ee/sssshandler.cpp
@@ -194,11 +194,12 @@ void SSSSHandler::loadMegolmBackup(const QByteArray& megolmDecryptionKey)
         connect(keysJob, &BaseJob::finished, this, [this, keysJob, megolmDecryptionKey](){
             const auto &rooms = keysJob->rooms();
             qCDebug(E2EE) << rooms.size() << "rooms in the backup";
-            for (const auto& [roomId, roomKeyBackup] : asKeyValueRange(rooms)) {
+            for (const auto& [roomId, roomKeyBackup] : rooms.asKeyValueRange()) {
                 if (!m_connection->room(roomId))
                     continue;
 
-                for (const auto& [sessionId, backupData] : asKeyValueRange(roomKeyBackup.sessions)) {
+                for (const auto& [sessionId, backupData] :
+                     roomKeyBackup.sessions.asKeyValueRange()) {
                     const auto& sessionData = backupData.sessionData;
                     const auto result =
                         curve25519AesSha2Decrypt(sessionData["ciphertext"_ls].toString().toLatin1(),

--- a/Quotient/events/accountdataevents.h
+++ b/Quotient/events/accountdataevents.h
@@ -46,20 +46,8 @@ struct JsonObjectConverter<TagRecord> {
 using TagsMap = QHash<QString, TagRecord>;
 
 DEFINE_SIMPLE_EVENT(TagEvent, Event, "m.tag", TagsMap, tags, "tags")
-DEFINE_SIMPLE_EVENT(ReadMarkerEventImpl, Event, "m.fully_read", QString,
+DEFINE_SIMPLE_EVENT(ReadMarkerEvent, Event, "m.fully_read", QString,
                     eventId, "event_id")
-class ReadMarkerEvent : public ReadMarkerEventImpl {
-public:
-    using ReadMarkerEventImpl::ReadMarkerEventImpl;
-    [[deprecated("Use ReadMarkerEvent::eventId() instead")]]
-    auto event_id() const { return eventId(); }
-};
-DEFINE_SIMPLE_EVENT(IgnoredUsersEventImpl, Event, "m.ignored_user_list",
+DEFINE_SIMPLE_EVENT(IgnoredUsersEvent, Event, "m.ignored_user_list",
                     QSet<QString>, ignoredUsers, "ignored_users")
-class IgnoredUsersEvent : public IgnoredUsersEventImpl {
-public:
-    using IgnoredUsersEventImpl::IgnoredUsersEventImpl;
-    [[deprecated("Use IgnoredUsersEvent::ignoredUsers() instead")]]
-    auto ignored_users() const { return ignoredUsers(); }
-};
 } // namespace Quotient

--- a/Quotient/events/event.h
+++ b/Quotient/events/event.h
@@ -13,14 +13,6 @@ namespace Quotient {
 template <typename EventT>
 using event_ptr_tt = std::unique_ptr<EventT>;
 
-/// Unwrap a plain pointer and downcast it to the specified type
-template <typename TargetEventT, typename EventT>
-[[deprecated("Use eventCast() instead")]] // Remove after 0.9
-inline TargetEventT* weakPtrCast(const event_ptr_tt<EventT>& ptr)
-{
-    return static_cast<TargetEventT*>(std::to_address(ptr));
-}
-
 // === Standard Matrix key names ===
 
 constexpr inline auto TypeKey = "type"_ls;
@@ -596,19 +588,6 @@ inline auto Event::switchOnType(VisitorTs&&... visitors) const
 {
     return Quotient::switchOnType(*this,
                                   std::forward<VisitorTs>(visitors)...);
-}
-
-// A facility overload that calls void-returning switchOnType() on each event
-// over a range of event pointers
-// TODO: remove after 0.9
-template <typename RangeT, typename... FnTs>
-[[deprecated("Make a range-for and call switchOnType() from it directly")]]
-inline auto visitEach(RangeT&& events, FnTs&&... fns)
-    requires std::is_void_v<
-        decltype(switchOnType(**begin(events), std::forward<FnTs>(fns)...))>
-{
-    for (auto&& evtPtr: events)
-        switchOnType(*evtPtr, std::forward<FnTs>(fns)...);
 }
 
 } // namespace Quotient

--- a/Quotient/events/event.h
+++ b/Quotient/events/event.h
@@ -41,7 +41,7 @@ using event_type_t = QLatin1String;
 class Event;
 
 template <typename EventT, typename BaseEventT = Event>
-concept EventClass = std::is_base_of_v<BaseEventT, EventT>;
+concept EventClass = std::derived_from<EventT, BaseEventT>;
 
 template <EventClass EventT>
 bool is(const Event& e);

--- a/Quotient/events/eventcontent.h
+++ b/Quotient/events/eventcontent.h
@@ -7,7 +7,8 @@
 // message events as well as other events (e.g., avatars).
 
 #include "filesourceinfo.h"
-#include <Quotient/quotient_export.h>
+
+#include "../util.h"
 
 #include <QtCore/QJsonObject>
 #include <QtCore/QMetaType>

--- a/Quotient/events/filesourceinfo.cpp
+++ b/Quotient/events/filesourceinfo.cpp
@@ -12,8 +12,6 @@
 #include <QtCore/QReadWriteLock>
 #include <QtCore/QCryptographicHash>
 
-
-
 using namespace Quotient;
 
 QByteArray Quotient::decryptFile(const QByteArray& ciphertext,

--- a/Quotient/events/reactionevent.h
+++ b/Quotient/events/reactionevent.h
@@ -24,8 +24,6 @@ public:
         : EventTemplate(EventRelation::annotate(eventId, reactionKey))
     {}
 
-    [[deprecated("Use eventId(), key(), or content().value instead")]]
-    EventRelation relation() const { return content().value; }
     QString eventId() const { return content().value.eventId; }
     QString key() const { return content().value.key; }
 

--- a/Quotient/events/roomevent.h
+++ b/Quotient/events/roomevent.h
@@ -68,7 +68,7 @@ private:
 };
 using RoomEventPtr = event_ptr_tt<RoomEvent>;
 using RoomEvents = EventsArray<RoomEvent>;
-using RoomEventsRange = Range<RoomEvents>;
+using RoomEventsRange = std::ranges::subrange<RoomEvents::iterator>;
 
 } // namespace Quotient
 Q_DECLARE_METATYPE(Quotient::RoomEvent*)

--- a/Quotient/events/roommessageevent.h
+++ b/Quotient/events/roommessageevent.h
@@ -12,8 +12,6 @@
 class QFileInfo;
 
 namespace Quotient {
-//! \deprecated Use namespace EventContent instead
-namespace MessageEventContent = EventContent; // REMOVE after 0.9
 
 /**
  * The event class corresponding to m.room.message events

--- a/Quotient/events/single_key_value.h
+++ b/Quotient/events/single_key_value.h
@@ -7,14 +7,9 @@ namespace Quotient {
 namespace EventContent {
     template <typename T, const QLatin1String& KeyStr>
     struct SingleKeyValue {
-        // NOLINTBEGIN(google-explicit-constructor): that check should learn
-        //                                           about explicit(false)
-        QUO_IMPLICIT SingleKeyValue(const T& v = {})
-            : value { v }
-        {}
-        QUO_IMPLICIT SingleKeyValue(T&& v)
-            : value { std::move(v) }
-        {}
+        // NOLINTBEGIN(google-explicit-constructor): that check should learn about explicit(false)
+        QUO_IMPLICIT SingleKeyValue(const T& v = {}) : value(v) {}
+        QUO_IMPLICIT SingleKeyValue(T&& v) : value(std::move(v)) {}
         // NOLINTEND(google-explicit-constructor)
         T value;
     };
@@ -25,7 +20,7 @@ struct JsonConverter<EventContent::SingleKeyValue<ValueT, KeyStr>> {
     using content_type = EventContent::SingleKeyValue<ValueT, KeyStr>;
     static content_type load(const QJsonValue& jv)
     {
-        return { fromJson<ValueT>(jv.toObject().value(JsonKey)) };
+        return fromJson<ValueT>(jv.toObject().value(JsonKey));
     }
     static QJsonObject dump(const content_type& c)
     {

--- a/Quotient/events/stateevent.h
+++ b/Quotient/events/stateevent.h
@@ -138,3 +138,12 @@ concept Keyless_State_Event = !EvT::needsStateKey;
 } // namespace Quotient
 Q_DECLARE_METATYPE(Quotient::StateEvent*)
 Q_DECLARE_METATYPE(const Quotient::StateEvent*)
+
+// https://stackoverflow.com/questions/68320024/why-did-the-c-standards-committee-not-include-stdhash-for-pair-and-tuple
+template <>
+struct std::hash<Quotient::StateEventKey> {
+    size_t operator()(const Quotient::StateEventKey& k) const
+    {
+        return qHash(k, QHashSeed::globalSeed());
+    }
+};

--- a/Quotient/jobs/basejob.h
+++ b/Quotient/jobs/basejob.h
@@ -36,9 +36,6 @@ class QUOTIENT_API BaseJob : public QObject {
     }
 
 public:
-#define WITH_DEPRECATED_ERROR_VERSION(Recommended) \
-    Recommended, DECL_DEPRECATED_ENUMERATOR(Recommended##Error, Recommended)
-
     /*! The status code of a job
      *
      * Every job is created in Unprepared status; upon calling prepare()
@@ -58,18 +55,18 @@ public:
         Abandoned = 50, //!< A tiny period between abandoning and object deletion
         ErrorLevel = 100, //!< Errors have codes starting from this
         NetworkError = 101,
-        WITH_DEPRECATED_ERROR_VERSION(Timeout),
+        Timeout,
         Unauthorised,
         ContentAccessError,
-        WITH_DEPRECATED_ERROR_VERSION(NotFound),
-        WITH_DEPRECATED_ERROR_VERSION(IncorrectRequest),
-        WITH_DEPRECATED_ERROR_VERSION(IncorrectResponse),
-        WITH_DEPRECATED_ERROR_VERSION(TooManyRequests),
+        NotFound,
+        IncorrectRequest,
+        IncorrectResponse,
+        TooManyRequests,
         RateLimited = TooManyRequests,
-        WITH_DEPRECATED_ERROR_VERSION(RequestNotImplemented),
-        WITH_DEPRECATED_ERROR_VERSION(UnsupportedRoomVersion),
-        WITH_DEPRECATED_ERROR_VERSION(NetworkAuthRequired),
-        WITH_DEPRECATED_ERROR_VERSION(UserConsentRequired),
+        RequestNotImplemented,
+        UnsupportedRoomVersion,
+        NetworkAuthRequired,
+        UserConsentRequired,
         CannotLeaveRoom,
         UserDeactivated,
         FileError,
@@ -77,19 +74,11 @@ public:
     };
     Q_ENUM(StatusCode)
 
-#undef WITH_DEPRECATED_ERROR_VERSION
-
     template <typename... StrTs>
     static QByteArray makePath(StrTs&&... parts)
     {
         return (QByteArray() % ... % encodeIfParam(parts));
     }
-
-    using Data
-#ifndef Q_CC_MSVC
-        Q_DECL_DEPRECATED_X("Use Quotient::RequestData instead")
-#endif
-        = RequestData;
 
     /*!
      * This structure stores the status of a server call job. The status

--- a/Quotient/mxcreply.h
+++ b/Quotient/mxcreply.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "util.h"
+
 #include "events/filesourceinfo.h"
 
 #include <QtNetwork/QNetworkReply>

--- a/Quotient/qt_connection_util.h
+++ b/Quotient/qt_connection_util.h
@@ -29,7 +29,7 @@ inline auto connectUntil(auto* sender, auto signal, QObject* context, SmartSlotT
         sender, signal, cHolder,
         [sl = std::forward<SmartSlotT>(smartSlot), cHolder]<typename... Ts>
             requires std::invocable<SmartSlotT, Ts...>
-        (const Ts&... args) {
+        (const Ts&... args) mutable {
             static_assert(std::is_same_v<decltype(sl(args...)), bool>);
             if (sl(args...))
                 delete cHolder; // break the connection

--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -96,7 +96,7 @@ public:
     JoinState joinState;
     RoomSummary summary = { {}, 0, {} };
     /// The state of the room at timeline position before-0
-    UnorderedMap<StateEventKey, StateEventPtr> baseState;
+    std::unordered_map<StateEventKey, StateEventPtr> baseState;
     /// The state of the room at syncEdge()
     /// \sa syncEdge
     RoomStateView currentState;
@@ -132,7 +132,7 @@ public:
     QHash<QString, ReadReceipt> lastReadReceipts;
     QString fullyReadUntilEventId;
     TagsMap tags;
-    UnorderedMap<QString, EventPtr> accountData;
+    std::unordered_map<QString, EventPtr> accountData;
     //! \brief Previous (i.e. next towards the room beginning) batch token
     //!
     //! "Emptiness" of this can have two forms. If prevBatch.has_value() it means the library
@@ -145,7 +145,7 @@ public:
     QPointer<GetRoomEventsJob> eventsHistoryJob;
     QPointer<GetMembersByRoomJob> allMembersJob;
     //! Map from megolm sessionId to set of eventIds
-    UnorderedMap<QString, QSet<QString>> undecryptedEvents;
+    std::unordered_map<QString, QSet<QString>> undecryptedEvents;
 
     struct FileTransferPrivateInfo {
         FileTransferPrivateInfo() = default;
@@ -335,7 +335,7 @@ public:
 
     bool isLocalMember(const QString& memberId) const { return memberId == connection->userId(); }
 
-    UnorderedMap<QByteArray, QOlmInboundGroupSession> groupSessions;
+    std::unordered_map<QByteArray, QOlmInboundGroupSession> groupSessions;
     std::optional<QOlmOutboundGroupSession> currentOutboundMegolmSession = {};
 
     bool addInboundGroupSession(QByteArray sessionId, QByteArray sessionKey,
@@ -2744,7 +2744,7 @@ Room::Changes Room::Private::addNewMessageEvents(RoomEvents&& events)
         // NB: We have to store redacting/replacing events to the timeline too -
         // see #220.
         auto it = std::find_if(events.begin(), events.end(), isEditing);
-        for (const auto& eptr : RoomEventsRange(it, events.end())) {
+        for (const auto& eptr : std::ranges::subrange(it, events.end())) {
             if (auto* r = eventCast<RedactionEvent>(eptr)) {
                 // Try to find the target in the timeline, then in the batch.
                 if (processRedaction(*r))

--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -97,8 +97,6 @@ public:
     RoomSummary summary = { {}, 0, {} };
     /// The state of the room at timeline position before-0
     UnorderedMap<StateEventKey, StateEventPtr> baseState;
-    /// State event stubs - events without content, just type and state key
-    static decltype(baseState) stubbedState;
     /// The state of the room at syncEdge()
     /// \sa syncEdge
     RoomStateView currentState;
@@ -453,8 +451,6 @@ private:
     using users_shortlist_t = std::array<QString, 3>;
     users_shortlist_t buildShortlist(const QStringList& userIds) const;
 };
-
-decltype(Room::Private::baseState) Room::Private::stubbedState {};
 
 Room::Room(Connection* connection, QString id, JoinState initialJoinState)
     : QObject(connection), d(new Private(connection, id, initialJoinState))

--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -462,9 +462,8 @@ Room::Room(Connection* connection, QString id, JoinState initialJoinState)
     d->q = this;
     d->displayname = d->calculateDisplayname(); // Set initial "Empty room" name
     if (connection->encryptionEnabled()) {
-        connectSingleShot(this, &Room::encryption, this, [this, connection] {
-            connection->encryptionUpdate(this);
-        });
+        connect(this, &Room::encryption, this,
+                [this, connection] { connection->encryptionUpdate(this); });
         connect(this, &Room::memberListChanged, this, [this, connection] {
             if(usesEncryption()) {
                 connection->encryptionUpdate(this, d->membersInvited);

--- a/Quotient/room.h
+++ b/Quotient/room.h
@@ -161,8 +161,8 @@ class QUOTIENT_API Room : public QObject {
     Q_PROPERTY(bool isFavourite READ isFavourite NOTIFY tagsChanged STORED false)
     Q_PROPERTY(bool isLowPriority READ isLowPriority NOTIFY tagsChanged STORED false)
 
-    Q_PROPERTY(GetRoomEventsJob* eventsHistoryJob READ eventsHistoryJob NOTIFY
-                   eventsHistoryJobChanged)
+    Q_PROPERTY(GetRoomEventsJob* eventsHistoryJob READ eventsHistoryJob NOTIFY eventsHistoryJobChanged)
+    Q_PROPERTY(int requestedHistorySize READ requestedHistorySize NOTIFY eventsHistoryJobChanged)
 
     Q_PROPERTY(QStringList accountDataEventTypes READ accountDataEventTypes NOTIFY accountDataChanged)
 
@@ -330,12 +330,13 @@ public:
     const Timeline& messageEvents() const;
     const PendingEvents& pendingEvents() const;
 
-    /// Check whether all historical messages are already loaded
-    /**
-     * \return true if the "oldest" event in the timeline is
-     *         a room creation event and there's no further history
-     *         to load; false otherwise
-     */
+    //! \brief Get the number of requested historical events
+    //! \return The number of requested events if there's a pending request; 0 otherwise
+    int requestedHistorySize() const;
+
+    //! Check whether all historical messages are already loaded
+    //! \return true if the "oldest" event in the timeline is a room creation event and there's
+    //!         no further history to load; false otherwise
     bool allHistoryLoaded() const;
 
     //! \brief Get a reverse iterator at the position before the "oldest" event

--- a/Quotient/room.h
+++ b/Quotient/room.h
@@ -182,10 +182,7 @@ public:
     enum class Change : quint32 { // QFlags can't go more than 32-bit
         None = 0x0, //!< No changes occurred in the room
         RoomNames = 0x1, //!< \sa namesChanged, displaynameChanged
-        DECL_DEPRECATED_ENUMERATOR(Name, RoomNames),
-        DECL_DEPRECATED_ENUMERATOR(Aliases, RoomNames),
-        DECL_DEPRECATED_ENUMERATOR(CanonicalAlias, RoomNames),
-        // Aliases/CanonicalAlias pre-0.8 = 0x2 - open for reuse
+        // NotInUse = 0x2,
         Topic = 0x4, //!< \sa topicChanged
         PartiallyReadStats = 0x8, //!< \sa partiallyReadStatsChanged
         Avatar = 0x10, //!< \sa avatarChanged

--- a/Quotient/room.h
+++ b/Quotient/room.h
@@ -29,7 +29,6 @@
 #include <QtGui/QImage>
 
 #include <deque>
-#include <memory>
 #include <utility>
 
 namespace Quotient {
@@ -338,20 +337,18 @@ public:
      *         to load; false otherwise
      */
     bool allHistoryLoaded() const;
-    /**
-     * A convenience method returning the read marker to the position
-     * before the "oldest" event; same as messageEvents().crend()
-     */
+
+    //! \brief Get a reverse iterator at the position before the "oldest" event
+    //!
+    //! Same as messageEvents().crend()
     rev_iter_t historyEdge() const;
-    /**
-     * A convenience method returning the iterator beyond the latest
-     * arrived event; same as messageEvents().cend()
-     */
+    //! \brief Get an iterator for the position beyond the latest arrived event
+    //!
+    //! Same as messageEvents().cend()
     Timeline::const_iterator syncEdge() const;
     Q_INVOKABLE Quotient::TimelineItem::index_t minTimelineIndex() const;
     Q_INVOKABLE Quotient::TimelineItem::index_t maxTimelineIndex() const;
-    Q_INVOKABLE bool
-    isValidIndex(Quotient::TimelineItem::index_t timelineIndex) const;
+    Q_INVOKABLE bool isValidIndex(Quotient::TimelineItem::index_t timelineIndex) const;
 
     rev_iter_t findInTimeline(TimelineItem::index_t index) const;
     rev_iter_t findInTimeline(const QString& evtId) const;

--- a/Quotient/room.h
+++ b/Quotient/room.h
@@ -636,8 +636,10 @@ public:
      */
     Q_INVOKABLE QString prettyPrint(const QString& plainText) const;
 
+#if Quotient_VERSION_MAJOR == 0 && Quotient_VERSION_MINOR < 10
     [[deprecated("Create MemberSorter objects directly instead")]]
     MemberSorter memberSorter() const;
+#endif
 
     Q_INVOKABLE bool supportsCalls() const;
 

--- a/Quotient/roommember.cpp
+++ b/Quotient/roommember.cpp
@@ -68,7 +68,7 @@ QString RoomMember::fullName() const {
     if (name().isEmpty()) {
         return id();
     }
-    return displayName() % " ("_ls % id() % u')';
+    return name() % u" (" % id() % u')';
 }
 
 QString RoomMember::htmlSafeFullName() const { return fullName().toHtmlEscaped(); }

--- a/Quotient/roommember.h
+++ b/Quotient/roommember.h
@@ -229,6 +229,7 @@ struct QUOTIENT_API MemberSorter {
     }
     bool operator()(QStringView u1name, QStringView u2name) const;
 
+#if Quotient_VERSION_MAJOR == 0 && Quotient_VERSION_MINOR < 10
     template <template <class> class ContT>
     [[deprecated("Use Quotient::lowerBoundIndex() or std::ranges::lower_bound() instead")]] //
     typename ContT<RoomMember>::size_type
@@ -236,6 +237,7 @@ struct QUOTIENT_API MemberSorter {
     {
         return std::ranges::lower_bound(c, v, *this) - c.begin();
     }
+#endif
 };
 
 } // namespace Quotient

--- a/Quotient/settings.cpp
+++ b/Quotient/settings.cpp
@@ -108,7 +108,6 @@ QUO_DEFINE_SETTING(AccountSettings, bool, keepLoggedIn, "keep_logged_in", false,
 
 namespace {
 constexpr auto HomeserverKey = "homeserver"_ls;
-constexpr auto AccessTokenKey = "access_token"_ls;
 constexpr auto EncryptionAccountPickleKey = "encryption_account_pickle"_ls;
 }
 
@@ -123,14 +122,6 @@ void AccountSettings::setHomeserver(const QUrl& url)
 }
 
 QString AccountSettings::userId() const { return group().section(u'/', -1); }
-
-void AccountSettings::clearAccessToken()
-{
-    legacySettings.remove(AccessTokenKey);
-    legacySettings.remove(QStringLiteral("device_id")); // Force the server to
-                                                        // re-issue it
-    remove(AccessTokenKey);
-}
 
 QByteArray AccountSettings::encryptionAccountPickle()
 {

--- a/Quotient/settings.h
+++ b/Quotient/settings.h
@@ -145,9 +145,6 @@ public:
     QUrl homeserver() const;
     void setHomeserver(const QUrl& url);
 
-    Q_DECL_DEPRECATED_X("Access tokens are not stored in QSettings any more")
-    Q_INVOKABLE void clearAccessToken();
-
     QByteArray encryptionAccountPickle();
     void setEncryptionAccountPickle(const QByteArray& encryptionAccountPickle);
     Q_INVOKABLE void clearEncryptionAccountPickle();

--- a/Quotient/syncdata.h
+++ b/Quotient/syncdata.h
@@ -28,7 +28,7 @@ struct QUOTIENT_API RoomSummary {
 
     bool isEmpty() const;
 };
-QDebug operator<<(QDebug dbg, const RoomSummary& rs);
+QUOTIENT_API QDebug operator<<(QDebug dbg, const RoomSummary& rs);
 
 template <>
 struct JsonObjectConverter<RoomSummary> {

--- a/Quotient/user.cpp
+++ b/Quotient/user.cpp
@@ -164,7 +164,7 @@ void User::ignore() const { connection()->addToIgnoredUsers(d->id); }
 
 void User::unmarkIgnore() const { connection()->removeFromIgnoredUsers(d->id); }
 
-bool User::isIgnored() const { return connection()->isIgnored(this); }
+bool User::isIgnored() const { return connection()->isIgnored(d->id); }
 
 QString User::avatarMediaId() const
 {

--- a/autotests/testolmaccount.cpp
+++ b/autotests/testolmaccount.cpp
@@ -207,9 +207,9 @@ void TestOlmAccount::uploadOneTimeKeys()
     const auto oneTimeKeys = olmAccount->oneTimeKeys();
 
     OneTimeKeys oneTimeKeysHash;
-    for (const auto& [keyId, key] : asKeyValueRange(oneTimeKeys.curve25519())) {
+    for (const auto& [keyId, key] : oneTimeKeys.curve25519().asKeyValueRange())
         oneTimeKeysHash["curve25519:"_ls + keyId] = key;
-    }
+
     auto request = new UploadKeysJob({}, oneTimeKeysHash);
     connect(request, &BaseJob::result, this, [request] {
         if (!request->status().good())
@@ -377,7 +377,7 @@ void TestOlmAccount::claimKeys()
 
     // The key is the one bob sent.
     const auto& claimedDeviceKeys = allClaimedKeys.value(bob->deviceId());
-    for (const auto& claimedKey : asKeyValueRange(claimedDeviceKeys)) {
+    for (const auto& claimedKey : claimedDeviceKeys.asKeyValueRange()) {
         if (!claimedKey.first.startsWith(SignedCurve25519Key))
             continue;
         QVERIFY(std::holds_alternative<SignedOneTimeKey>(claimedKey.second));

--- a/autotests/utiltests.cpp
+++ b/autotests/utiltests.cpp
@@ -27,8 +27,7 @@ private Q_SLOTS:
     void testLinkifyUrl();
 
 private:
-    void testLinkified(QString original, const QString& expected,
-                       const int sourceLine) const
+    void testLinkified(QString original, const QString& expected, const int sourceLine) const
     {
         linkifyUrls(original);
         QTest::qCompare(original, expected, "", "", __FILE__, sourceLine);

--- a/gtad/gtad.yaml
+++ b/gtad/gtad.yaml
@@ -124,7 +124,7 @@ analyzer:
       - //: "QVector<{{1}}>"
     - map: # `additionalProperties` in OpenAPI
       - RoomState:
-          type: "UnorderedMap<QString, {{1}}>"
+          type: "std::unordered_map<QString, {{1}}>"
           moveOnly:
       - /.+/: "QHash<QString, {{1}}>"
       - //: QVariantHash # QJsonObject?..


### PR DESCRIPTION
Best reviewed commit by commit (see the Commits tab, as force-pushes made a mess of the commits list here below). Most notable stuff:
- (f360a85) Getting rid of things previously deprecated: `Quotient::Accounts` variable, `visitEach()`, `MessageEventContent` namespace alias, old job status and room change codes
- (995c246) Deprecate things that can be done with standard library and Qt now, in particular `UnorderedMap`, `Range` (`RoomEventsRange` stays but is now a specialisation of `std::ranges::subrange`) and `asKeyValueRange`
- Removed (or deprecated, where not yet) overloads accepting `User*` or a collection of `User*`s, passing user MXIDs instead.