### PR TITLE
Fix database query executing

### DIFF
--- a/Quotient/database.cpp
+++ b/Quotient/database.cpp
@@ -65,7 +65,11 @@ int Database::version()
 QSqlQuery Database::execute(const QString& queryString)
 {
     QSqlQuery query(queryString, database());
-    execute(query);
+    if (query.lastError().type() != QSqlError::NoError) {
+        qCritical(DATABASE) << "Failed to execute query";
+        qCritical(DATABASE) << query.lastQuery();
+        qCritical(DATABASE) << query.lastError();
+    }
     return query;
 }
 


### PR DESCRIPTION
This constructor for QSqlQuery automatically executes the query, meaning that we effectively executed all queries twice