### PR TITLE
Allow auth data to have non-objects

### DIFF
--- a/Quotient/csapi/definitions/auth_data.h
+++ b/Quotient/csapi/definitions/auth_data.h
@@ -17,7 +17,7 @@ struct QUOTIENT_API AuthenticationData {
     QString session{};
 
     //! Keys dependent on the login type
-    QHash<QString, QJsonObject> authInfo{};
+    QVariantHash authInfo{};
 };
 
 template <>


### PR DESCRIPTION
The actual fix is in GTAD.