### PR TITLE
Store senderkey for inbound megolm sessions

### DIFF
--- a/Quotient/connection.cpp
+++ b/Quotient/connection.cpp
@@ -1734,9 +1734,9 @@ std::unordered_map<QByteArray, QOlmInboundGroupSession> Connection::loadRoomMego
 }
 
 void Connection::saveMegolmSession(const Room* room,
-                                   const QOlmInboundGroupSession& session) const
+                                   const QOlmInboundGroupSession& session, const QByteArray& senderKey) const
 {
-    database()->saveMegolmSession(room->id(), session);
+    database()->saveMegolmSession(room->id(), session, senderKey);
 }
 
 QStringList Connection::devicesForUser(const QString& userId) const

--- a/Quotient/connection.h
+++ b/Quotient/connection.h
@@ -333,7 +333,7 @@ public:
     std::unordered_map<QByteArray, QOlmInboundGroupSession> loadRoomMegolmSessions(
         const Room* room) const;
     void saveMegolmSession(const Room* room,
-                           const QOlmInboundGroupSession& session) const;
+                           const QOlmInboundGroupSession& session, const QByteArray &senderKey) const;
 
     QString edKeyForUserDevice(const QString& userId,
                                const QString& deviceId) const;

--- a/Quotient/connectionencryptiondata_p.cpp
+++ b/Quotient/connectionencryptiondata_p.cpp
@@ -380,7 +380,7 @@ void ConnectionEncryptionData::handleEncryptedToDeviceEvent(
          olmSessionId = olmSessionId](const RoomKeyEvent& roomKeyEvent) {
             if (auto* detectedRoom = q->room(roomKeyEvent.roomId())) {
                 detectedRoom->handleRoomKeyEvent(roomKeyEvent, event.senderId(),
-                                                 olmSessionId);
+                                                 olmSessionId, event.senderKey().toLatin1());
             } else {
                 qCDebug(E2EE)
                     << "Encrypted event room id" << roomKeyEvent.roomId()

--- a/Quotient/database.h
+++ b/Quotient/database.h
@@ -41,7 +41,8 @@ public:
     std::unordered_map<QByteArray, QOlmInboundGroupSession> loadMegolmSessions(
         const QString& roomId);
     void saveMegolmSession(const QString& roomId,
-                           const QOlmInboundGroupSession& session);
+                           const QOlmInboundGroupSession& session,
+                           const QByteArray& senderKey);
     void addGroupSessionIndexRecord(const QString& roomId,
                                     const QString& sessionId, uint32_t index,
                                     const QString& eventId, qint64 ts);
@@ -86,6 +87,7 @@ private:
     void migrateTo5();
     void migrateTo6();
     void migrateTo7();
+    void migrateTo8();
 
     QString m_userId;
     QString m_deviceId;

--- a/Quotient/e2ee/sssshandler.cpp
+++ b/Quotient/e2ee/sssshandler.cpp
@@ -214,7 +214,7 @@ void SSSSHandler::loadMegolmBackup(const QByteArray& megolmDecryptionKey)
                     const auto data = QJsonDocument::fromJson(result.value()).object();
                     m_connection->room(roomId)->addMegolmSessionFromBackup(
                         sessionId.toLatin1(), data["session_key"_ls].toString().toLatin1(),
-                        static_cast<uint32_t>(backupData.firstMessageIndex));
+                        static_cast<uint32_t>(backupData.firstMessageIndex), data["sender_key"_ls].toVariant().toByteArray());
                 }
             }
             emit finished();

--- a/Quotient/room.h
+++ b/Quotient/room.h
@@ -264,7 +264,8 @@ public:
     RoomEventPtr decryptMessage(const EncryptedEvent& encryptedEvent);
     void handleRoomKeyEvent(const RoomKeyEvent& roomKeyEvent,
                             const QString& senderId,
-                            const QByteArray& olmSessionId);
+                            const QByteArray& olmSessionId,
+                            const QByteArray& senderKey);
     int joinedCount() const;
     int invitedCount() const;
     int totalMemberCount() const;
@@ -678,7 +679,7 @@ public:
         return setState(EvT(std::forward<ArgTs>(args)...));
     }
 
-    void addMegolmSessionFromBackup(const QByteArray &sessionId, const QByteArray &sessionKey, uint32_t index);
+    void addMegolmSessionFromBackup(const QByteArray &sessionId, const QByteArray &sessionKey, uint32_t index, const QByteArray& senderKey);
 
     Q_INVOKABLE void startVerification();
 


### PR DESCRIPTION
I don't know of any case where we actually need those locally, but for creating correct key backups (or exports), we need to fill it in. For sessions we have received locally from olm, we can reconstruct it (as this patch does during database migration), but for key backup, we have to store it.