### PR TITLE
Matrix 1.11 support

### DIFF
--- a/Quotient/csapi/administrative_contact.h
+++ b/Quotient/csapi/administrative_contact.h
@@ -84,7 +84,8 @@ struct QUOTIENT_API JsonObjectConverter<GetAccount3PIDsJob::ThirdPartyIdentifier
 //! has been removed, making this endpoint behave as though it was `false`.
 //! This results in this endpoint being an equivalent to `/3pid/bind` rather
 //! than dual-purpose.
-class QUOTIENT_API Post3PIDsJob : public BaseJob {
+class [[deprecated("Check the documentation for details")]] QUOTIENT_API Post3PIDsJob
+    : public BaseJob {
 public:
     // Inner data structures
 

--- a/Quotient/csapi/appservice_room_directory.cpp
+++ b/Quotient/csapi/appservice_room_directory.cpp
@@ -7,7 +7,8 @@ using namespace Quotient;
 UpdateAppserviceRoomDirectoryVisibilityJob::UpdateAppserviceRoomDirectoryVisibilityJob(
     const QString& networkId, const QString& roomId, const QString& visibility)
     : BaseJob(HttpVerb::Put, QStringLiteral("UpdateAppserviceRoomDirectoryVisibilityJob"),
-              makePath("/_matrix/client/v3", "/directory/list/appservice/", networkId, "/", roomId))
+              makePath("/_matrix/client/v3", "/directory/list/appservice/", networkId, "/", roomId),
+              false)
 {
     QJsonObject _dataJson;
     addParam<>(_dataJson, QStringLiteral("visibility"), visibility);

--- a/Quotient/csapi/authed-content-repo.cpp
+++ b/Quotient/csapi/authed-content-repo.cpp
@@ -1,0 +1,126 @@
+// THIS FILE IS GENERATED - ANY EDITS WILL BE OVERWRITTEN
+
+#include "authed-content-repo.h"
+
+using namespace Quotient;
+
+auto queryToGetContentAuthed(qint64 timeoutMs)
+{
+    QUrlQuery _q;
+    addParam<IfNotEmpty>(_q, QStringLiteral("timeout_ms"), timeoutMs);
+    return _q;
+}
+
+QUrl GetContentAuthedJob::makeRequestUrl(QUrl baseUrl, const QString& serverName,
+                                         const QString& mediaId, qint64 timeoutMs)
+{
+    return BaseJob::makeRequestUrl(std::move(baseUrl),
+                                   makePath("/_matrix/client/v1", "/media/download/", serverName,
+                                            "/", mediaId),
+                                   queryToGetContentAuthed(timeoutMs));
+}
+
+GetContentAuthedJob::GetContentAuthedJob(const QString& serverName, const QString& mediaId,
+                                         qint64 timeoutMs)
+    : BaseJob(HttpVerb::Get, QStringLiteral("GetContentAuthedJob"),
+              makePath("/_matrix/client/v1", "/media/download/", serverName, "/", mediaId),
+              queryToGetContentAuthed(timeoutMs))
+{
+    setExpectedContentTypes({ "application/octet-stream" });
+}
+
+auto queryToGetContentOverrideNameAuthed(qint64 timeoutMs)
+{
+    QUrlQuery _q;
+    addParam<IfNotEmpty>(_q, QStringLiteral("timeout_ms"), timeoutMs);
+    return _q;
+}
+
+QUrl GetContentOverrideNameAuthedJob::makeRequestUrl(QUrl baseUrl, const QString& serverName,
+                                                     const QString& mediaId,
+                                                     const QString& fileName, qint64 timeoutMs)
+{
+    return BaseJob::makeRequestUrl(std::move(baseUrl),
+                                   makePath("/_matrix/client/v1", "/media/download/", serverName,
+                                            "/", mediaId, "/", fileName),
+                                   queryToGetContentOverrideNameAuthed(timeoutMs));
+}
+
+GetContentOverrideNameAuthedJob::GetContentOverrideNameAuthedJob(const QString& serverName,
+                                                                 const QString& mediaId,
+                                                                 const QString& fileName,
+                                                                 qint64 timeoutMs)
+    : BaseJob(HttpVerb::Get, QStringLiteral("GetContentOverrideNameAuthedJob"),
+              makePath("/_matrix/client/v1", "/media/download/", serverName, "/", mediaId, "/",
+                       fileName),
+              queryToGetContentOverrideNameAuthed(timeoutMs))
+{
+    setExpectedContentTypes({ "application/octet-stream" });
+}
+
+auto queryToGetContentThumbnailAuthed(int width, int height, const QString& method,
+                                      qint64 timeoutMs, std::optional<bool> animated)
+{
+    QUrlQuery _q;
+    addParam<>(_q, QStringLiteral("width"), width);
+    addParam<>(_q, QStringLiteral("height"), height);
+    addParam<IfNotEmpty>(_q, QStringLiteral("method"), method);
+    addParam<IfNotEmpty>(_q, QStringLiteral("timeout_ms"), timeoutMs);
+    addParam<IfNotEmpty>(_q, QStringLiteral("animated"), animated);
+    return _q;
+}
+
+QUrl GetContentThumbnailAuthedJob::makeRequestUrl(QUrl baseUrl, const QString& serverName,
+                                                  const QString& mediaId, int width, int height,
+                                                  const QString& method, qint64 timeoutMs,
+                                                  std::optional<bool> animated)
+{
+    return BaseJob::makeRequestUrl(
+        std::move(baseUrl),
+        makePath("/_matrix/client/v1", "/media/thumbnail/", serverName, "/", mediaId),
+        queryToGetContentThumbnailAuthed(width, height, method, timeoutMs, animated));
+}
+
+GetContentThumbnailAuthedJob::GetContentThumbnailAuthedJob(const QString& serverName,
+                                                           const QString& mediaId, int width,
+                                                           int height, const QString& method,
+                                                           qint64 timeoutMs,
+                                                           std::optional<bool> animated)
+    : BaseJob(HttpVerb::Get, QStringLiteral("GetContentThumbnailAuthedJob"),
+              makePath("/_matrix/client/v1", "/media/thumbnail/", serverName, "/", mediaId),
+              queryToGetContentThumbnailAuthed(width, height, method, timeoutMs, animated))
+{
+    setExpectedContentTypes({ "image/jpeg", "image/png", "image/apng", "image/gif", "image/webp" });
+}
+
+auto queryToGetUrlPreviewAuthed(const QUrl& url, std::optional<qint64> ts)
+{
+    QUrlQuery _q;
+    addParam<>(_q, QStringLiteral("url"), url);
+    addParam<IfNotEmpty>(_q, QStringLiteral("ts"), ts);
+    return _q;
+}
+
+QUrl GetUrlPreviewAuthedJob::makeRequestUrl(QUrl baseUrl, const QUrl& url, std::optional<qint64> ts)
+{
+    return BaseJob::makeRequestUrl(std::move(baseUrl),
+                                   makePath("/_matrix/client/v1", "/media/preview_url"),
+                                   queryToGetUrlPreviewAuthed(url, ts));
+}
+
+GetUrlPreviewAuthedJob::GetUrlPreviewAuthedJob(const QUrl& url, std::optional<qint64> ts)
+    : BaseJob(HttpVerb::Get, QStringLiteral("GetUrlPreviewAuthedJob"),
+              makePath("/_matrix/client/v1", "/media/preview_url"),
+              queryToGetUrlPreviewAuthed(url, ts))
+{}
+
+QUrl GetConfigAuthedJob::makeRequestUrl(QUrl baseUrl)
+{
+    return BaseJob::makeRequestUrl(std::move(baseUrl),
+                                   makePath("/_matrix/client/v1", "/media/config"));
+}
+
+GetConfigAuthedJob::GetConfigAuthedJob()
+    : BaseJob(HttpVerb::Get, QStringLiteral("GetConfigAuthedJob"),
+              makePath("/_matrix/client/v1", "/media/config"))
+{}

--- a/Quotient/csapi/authed-content-repo.h
+++ b/Quotient/csapi/authed-content-repo.h
@@ -1,0 +1,287 @@
+// THIS FILE IS GENERATED - ANY EDITS WILL BE OVERWRITTEN
+
+#pragma once
+
+#include <Quotient/jobs/basejob.h>
+
+#include <QtCore/QIODevice>
+#include <QtNetwork/QNetworkReply>
+
+namespace Quotient {
+
+//! \brief Download content from the content repository.
+//!
+//! \note
+//! Clients SHOULD NOT generate or use URLs which supply the access token in
+//! the query string. These URLs may be copied by users verbatim and provided
+//! in a chat message to another user, disclosing the sender's access token.
+//!
+//! Clients MAY be redirected using the 307/308 responses below to download
+//! the request object. This is typical when the homeserver uses a Content
+//! Delivery Network (CDN).
+class QUOTIENT_API GetContentAuthedJob : public BaseJob {
+public:
+    //! \param serverName
+    //!   The server name from the `mxc://` URI (the authority component).
+    //!
+    //! \param mediaId
+    //!   The media ID from the `mxc://` URI (the path component).
+    //!
+    //! \param timeoutMs
+    //!   The maximum number of milliseconds that the client is willing to wait to
+    //!   start receiving data, in the case that the content has not yet been
+    //!   uploaded. The default value is 20000 (20 seconds). The content
+    //!   repository SHOULD impose a maximum value for this parameter. The
+    //!   content repository MAY respond before the timeout.
+    explicit GetContentAuthedJob(const QString& serverName, const QString& mediaId,
+                                 qint64 timeoutMs = 20000);
+
+    //! \brief Construct a URL without creating a full-fledged job object
+    //!
+    //! This function can be used when a URL for GetContentAuthedJob
+    //! is necessary but the job itself isn't.
+    static QUrl makeRequestUrl(QUrl baseUrl, const QString& serverName, const QString& mediaId,
+                               qint64 timeoutMs = 20000);
+
+    // Result properties
+
+    //! The content type of the file that was previously uploaded.
+    QString contentType() const { return QString::fromUtf8(reply()->rawHeader("Content-Type")); }
+
+    //! The name of the file that was previously uploaded, if set.
+    QString contentDisposition() const
+    {
+        return QString::fromUtf8(reply()->rawHeader("Content-Disposition"));
+    }
+
+    //! The content that was previously uploaded.
+    QIODevice* data() { return reply(); }
+};
+
+//! \brief Download content from the content repository overriding the file name.
+//!
+//! This will download content from the content repository (same as
+//! the previous endpoint) but replaces the target file name with the one
+//! provided by the caller.
+//!
+//! \note
+//! Clients SHOULD NOT generate or use URLs which supply the access token in
+//! the query string. These URLs may be copied by users verbatim and provided
+//! in a chat message to another user, disclosing the sender's access token.
+//!
+//! Clients MAY be redirected using the 307/308 responses below to download
+//! the request object. This is typical when the homeserver uses a Content
+//! Delivery Network (CDN).
+class QUOTIENT_API GetContentOverrideNameAuthedJob : public BaseJob {
+public:
+    //! \param serverName
+    //!   The server name from the `mxc://` URI (the authority component).
+    //!
+    //! \param mediaId
+    //!   The media ID from the `mxc://` URI (the path component).
+    //!
+    //! \param fileName
+    //!   A filename to give in the `Content-Disposition` header.
+    //!
+    //! \param timeoutMs
+    //!   The maximum number of milliseconds that the client is willing to wait to
+    //!   start receiving data, in the case that the content has not yet been
+    //!   uploaded. The default value is 20000 (20 seconds). The content
+    //!   repository SHOULD impose a maximum value for this parameter. The
+    //!   content repository MAY respond before the timeout.
+    explicit GetContentOverrideNameAuthedJob(const QString& serverName, const QString& mediaId,
+                                             const QString& fileName, qint64 timeoutMs = 20000);
+
+    //! \brief Construct a URL without creating a full-fledged job object
+    //!
+    //! This function can be used when a URL for GetContentOverrideNameAuthedJob
+    //! is necessary but the job itself isn't.
+    static QUrl makeRequestUrl(QUrl baseUrl, const QString& serverName, const QString& mediaId,
+                               const QString& fileName, qint64 timeoutMs = 20000);
+
+    // Result properties
+
+    //! The content type of the file that was previously uploaded.
+    QString contentType() const { return QString::fromUtf8(reply()->rawHeader("Content-Type")); }
+
+    //! The `fileName` requested or the name of the file that was previously
+    //! uploaded, if set.
+    QString contentDisposition() const
+    {
+        return QString::fromUtf8(reply()->rawHeader("Content-Disposition"));
+    }
+
+    //! The content that was previously uploaded.
+    QIODevice* data() { return reply(); }
+};
+
+//! \brief Download a thumbnail of content from the content repository
+//!
+//! Download a thumbnail of content from the content repository.
+//! See the [Thumbnails](/client-server-api/#thumbnails) section for more information.
+//!
+//! \note
+//! Clients SHOULD NOT generate or use URLs which supply the access token in
+//! the query string. These URLs may be copied by users verbatim and provided
+//! in a chat message to another user, disclosing the sender's access token.
+//!
+//! Clients MAY be redirected using the 307/308 responses below to download
+//! the request object. This is typical when the homeserver uses a Content
+//! Delivery Network (CDN).
+class QUOTIENT_API GetContentThumbnailAuthedJob : public BaseJob {
+public:
+    //! \param serverName
+    //!   The server name from the `mxc://` URI (the authority component).
+    //!
+    //! \param mediaId
+    //!   The media ID from the `mxc://` URI (the path component).
+    //!
+    //! \param width
+    //!   The *desired* width of the thumbnail. The actual thumbnail may be
+    //!   larger than the size specified.
+    //!
+    //! \param height
+    //!   The *desired* height of the thumbnail. The actual thumbnail may be
+    //!   larger than the size specified.
+    //!
+    //! \param method
+    //!   The desired resizing method. See the [Thumbnails](/client-server-api/#thumbnails)
+    //!   section for more information.
+    //!
+    //! \param timeoutMs
+    //!   The maximum number of milliseconds that the client is willing to wait to
+    //!   start receiving data, in the case that the content has not yet been
+    //!   uploaded. The default value is 20000 (20 seconds). The content
+    //!   repository SHOULD impose a maximum value for this parameter. The
+    //!   content repository MAY respond before the timeout.
+    //!
+    //! \param animated
+    //!   Indicates preference for an animated thumbnail from the server, if possible. Animated
+    //!   thumbnails typically use the content types `image/gif`, `image/png` (with APNG format),
+    //!   `image/apng`, and `image/webp` instead of the common static `image/png` or `image/jpeg`
+    //!   content types.
+    //!
+    //!   When `true`, the server SHOULD return an animated thumbnail if possible and supported.
+    //!   When `false`, the server MUST NOT return an animated thumbnail. For example, returning a
+    //!   static `image/png` or `image/jpeg` thumbnail. When not provided, the server SHOULD NOT
+    //!   return an animated thumbnail.
+    //!
+    //!   Servers SHOULD prefer to return `image/webp` thumbnails when supporting animation.
+    //!
+    //!   When `true` and the media cannot be animated, such as in the case of a JPEG or PDF, the
+    //!   server SHOULD behave as though `animated` is `false`.
+    explicit GetContentThumbnailAuthedJob(const QString& serverName, const QString& mediaId,
+                                          int width, int height, const QString& method = {},
+                                          qint64 timeoutMs = 20000,
+                                          std::optional<bool> animated = std::nullopt);
+
+    //! \brief Construct a URL without creating a full-fledged job object
+    //!
+    //! This function can be used when a URL for GetContentThumbnailAuthedJob
+    //! is necessary but the job itself isn't.
+    static QUrl makeRequestUrl(QUrl baseUrl, const QString& serverName, const QString& mediaId,
+                               int width, int height, const QString& method = {},
+                               qint64 timeoutMs = 20000,
+                               std::optional<bool> animated = std::nullopt);
+
+    // Result properties
+
+    //! The content type of the thumbnail.
+    QString contentType() const { return QString::fromUtf8(reply()->rawHeader("Content-Type")); }
+
+    //! A thumbnail of the requested content.
+    QIODevice* data() { return reply(); }
+};
+
+//! \brief Get information about a URL for a client
+//!
+//! Get information about a URL for the client. Typically this is called when a
+//! client sees a URL in a message and wants to render a preview for the user.
+//!
+//! \note
+//! Clients should consider avoiding this endpoint for URLs posted in encrypted
+//! rooms. Encrypted rooms often contain more sensitive information the users
+//! do not want to share with the homeserver, and this can mean that the URLs
+//! being shared should also not be shared with the homeserver.
+class QUOTIENT_API GetUrlPreviewAuthedJob : public BaseJob {
+public:
+    //! \param url
+    //!   The URL to get a preview of.
+    //!
+    //! \param ts
+    //!   The preferred point in time to return a preview for. The server may
+    //!   return a newer version if it does not have the requested version
+    //!   available.
+    explicit GetUrlPreviewAuthedJob(const QUrl& url, std::optional<qint64> ts = std::nullopt);
+
+    //! \brief Construct a URL without creating a full-fledged job object
+    //!
+    //! This function can be used when a URL for GetUrlPreviewAuthedJob
+    //! is necessary but the job itself isn't.
+    static QUrl makeRequestUrl(QUrl baseUrl, const QUrl& url,
+                               std::optional<qint64> ts = std::nullopt);
+
+    // Result properties
+
+    //! The byte-size of the image. Omitted if there is no image attached.
+    std::optional<qint64> matrixImageSize() const
+    {
+        return loadFromJson<std::optional<qint64>>("matrix:image:size"_ls);
+    }
+
+    //! An [`mxc://` URI](/client-server-api/#matrix-content-mxc-uris) to the image. Omitted if
+    //! there is no image.
+    QUrl ogImage() const { return loadFromJson<QUrl>("og:image"_ls); }
+
+    struct Response {
+        //! The byte-size of the image. Omitted if there is no image attached.
+        std::optional<qint64> matrixImageSize{};
+
+        //! An [`mxc://` URI](/client-server-api/#matrix-content-mxc-uris) to the image. Omitted if
+        //! there is no image.
+        QUrl ogImage{};
+    };
+};
+
+template <std::derived_from<GetUrlPreviewAuthedJob> JobT>
+constexpr inline auto doCollectResponse<JobT> = [](JobT* j) -> GetUrlPreviewAuthedJob::Response {
+    return { j->matrixImageSize(), j->ogImage() };
+};
+
+//! \brief Get the configuration for the content repository.
+//!
+//! This endpoint allows clients to retrieve the configuration of the content
+//! repository, such as upload limitations.
+//! Clients SHOULD use this as a guide when using content repository endpoints.
+//! All values are intentionally left optional. Clients SHOULD follow
+//! the advice given in the field description when the field is not available.
+//!
+//! \note
+//! Both clients and server administrators should be aware that proxies
+//! between the client and the server may affect the apparent behaviour of content
+//! repository APIs, for example, proxies may enforce a lower upload size limit
+//! than is advertised by the server on this endpoint.
+class QUOTIENT_API GetConfigAuthedJob : public BaseJob {
+public:
+    explicit GetConfigAuthedJob();
+
+    //! \brief Construct a URL without creating a full-fledged job object
+    //!
+    //! This function can be used when a URL for GetConfigAuthedJob
+    //! is necessary but the job itself isn't.
+    static QUrl makeRequestUrl(QUrl baseUrl);
+
+    // Result properties
+
+    //! The maximum size an upload can be in bytes.
+    //! Clients SHOULD use this as a guide when uploading content.
+    //! If not listed or null, the size limit should be treated as unknown.
+    std::optional<qint64> uploadSize() const
+    {
+        return loadFromJson<std::optional<qint64>>("m.upload.size"_ls);
+    }
+};
+
+inline auto collectResponse(const GetConfigAuthedJob* job) { return job->uploadSize(); }
+
+} // namespace Quotient

--- a/Quotient/csapi/content-repo.h
+++ b/Quotient/csapi/content-repo.h
@@ -12,8 +12,6 @@ namespace Quotient {
 //! \brief Upload some content to the content repository.
 class QUOTIENT_API UploadContentJob : public BaseJob {
 public:
-    //! \param content
-    //!   The content to be uploaded.
     //!
     //! \param filename
     //!   The name of the file being uploaded
@@ -38,15 +36,11 @@ inline auto collectResponse(const UploadContentJob* job) { return job->contentUr
 class QUOTIENT_API UploadContentToMXCJob : public BaseJob {
 public:
     //! \param serverName
-    //!   The server name from the `mxc://` URI returned by `POST /_matrix/media/v1/create` (the
-    //!   authoritory component).
+    //!   The server name from the `mxc://` URI (the authority component).
     //!
     //! \param mediaId
-    //!   The media ID from the `mxc://` URI returned by `POST /_matrix/media/v1/create` (the path
-    //!   component).
+    //!   The media ID from the `mxc://` URI (the path component).
     //!
-    //! \param content
-    //!   The content to be uploaded.
     //!
     //! \param filename
     //!   The name of the file being uploaded
@@ -119,31 +113,44 @@ constexpr inline auto doCollectResponse<JobT> =
     [](JobT* j) -> CreateContentJob::Response { return { j->contentUri(), j->unusedExpiresAt() }; };
 
 //! \brief Download content from the content repository.
-class QUOTIENT_API GetContentJob : public BaseJob {
+//!
+//! \note
+//! Replaced by [`GET
+//! /_matrix/client/v1/media/download/{serverName}/{mediaId}`](/client-server-api/#get_matrixclientv1mediadownloadservernamemediaid)
+//! (requires authentication).
+//!
+//! \warning
+//! **(Changed in v1.11)** This endpoint MAY return `404 M_NOT_FOUND`
+//! for media which exists, but is after the server froze unauthenticated
+//! media access. See [Client Behaviour](/client-server-api/#content-repo-client-behaviour) for more
+//! information.
+class [[deprecated("Check the documentation for details")]] QUOTIENT_API GetContentJob
+    : public BaseJob {
 public:
     //! \param serverName
-    //!   The server name from the `mxc://` URI (the authoritory component)
+    //!   The server name from the `mxc://` URI (the authority component).
     //!
     //! \param mediaId
-    //!   The media ID from the `mxc://` URI (the path component)
+    //!   The media ID from the `mxc://` URI (the path component).
     //!
     //! \param allowRemote
-    //!   Indicates to the server that it should not attempt to fetch the media if it is deemed
-    //!   remote. This is to prevent routing loops where the server contacts itself. Defaults to
-    //!   true if not provided.
+    //!   Indicates to the server that it should not attempt to fetch the media if
+    //!   it is deemed remote. This is to prevent routing loops where the server
+    //!   contacts itself.
+    //!
+    //!   Defaults to `true` if not provided.
     //!
     //! \param timeoutMs
-    //!   The maximum number of milliseconds that the client is willing to
-    //!   wait to start receiving data, in the case that the content has not
-    //!   yet been uploaded. The default value is 20000 (20 seconds). The
-    //!   content repository can and should impose a maximum value for this
-    //!   parameter. The content repository may also choose to respond before
-    //!   the timeout.
+    //!   The maximum number of milliseconds that the client is willing to wait to
+    //!   start receiving data, in the case that the content has not yet been
+    //!   uploaded. The default value is 20000 (20 seconds). The content
+    //!   repository SHOULD impose a maximum value for this parameter. The
+    //!   content repository MAY respond before the timeout.
     //!
     //! \param allowRedirect
-    //!   Indicates to the server that it may return a 307 or 308 redirect response that points
-    //!   at the relevant media content. When not explicitly set to true the server must return
-    //!   the media content itself.
+    //!   Indicates to the server that it may return a 307 or 308 redirect
+    //!   response that points at the relevant media content. When not explicitly
+    //!   set to `true` the server must return the media content itself.
     explicit GetContentJob(const QString& serverName, const QString& mediaId,
                            bool allowRemote = true, qint64 timeoutMs = 20000,
                            bool allowRedirect = false);
@@ -173,37 +180,50 @@ public:
 
 //! \brief Download content from the content repository overriding the file name
 //!
+//! \note
+//! Replaced by [`GET
+//! /_matrix/client/v1/media/download/{serverName}/{mediaId}/{fileName}`](/client-server-api/#get_matrixclientv1mediadownloadservernamemediaidfilename)
+//! (requires authentication).
+//!
 //! This will download content from the content repository (same as
 //! the previous endpoint) but replace the target file name with the one
 //! provided by the caller.
-class QUOTIENT_API GetContentOverrideNameJob : public BaseJob {
+//!
+//! \warning
+//! **(Changed in v1.11)** This endpoint MAY return `404 M_NOT_FOUND`
+//! for media which exists, but is after the server froze unauthenticated
+//! media access. See [Client Behaviour](/client-server-api/#content-repo-client-behaviour) for more
+//! information.
+class [[deprecated("Check the documentation for details")]] QUOTIENT_API GetContentOverrideNameJob
+    : public BaseJob {
 public:
     //! \param serverName
-    //!   The server name from the `mxc://` URI (the authoritory component)
+    //!   The server name from the `mxc://` URI (the authority component).
     //!
     //! \param mediaId
-    //!   The media ID from the `mxc://` URI (the path component)
+    //!   The media ID from the `mxc://` URI (the path component).
     //!
     //! \param fileName
     //!   A filename to give in the `Content-Disposition` header.
     //!
     //! \param allowRemote
-    //!   Indicates to the server that it should not attempt to fetch the media if it is deemed
-    //!   remote. This is to prevent routing loops where the server contacts itself. Defaults to
-    //!   true if not provided.
+    //!   Indicates to the server that it should not attempt to fetch the media if
+    //!   it is deemed remote. This is to prevent routing loops where the server
+    //!   contacts itself.
+    //!
+    //!   Defaults to `true` if not provided.
     //!
     //! \param timeoutMs
-    //!   The maximum number of milliseconds that the client is willing to
-    //!   wait to start receiving data, in the case that the content has not
-    //!   yet been uploaded. The default value is 20000 (20 seconds). The
-    //!   content repository can and should impose a maximum value for this
-    //!   parameter. The content repository may also choose to respond before
-    //!   the timeout.
+    //!   The maximum number of milliseconds that the client is willing to wait to
+    //!   start receiving data, in the case that the content has not yet been
+    //!   uploaded. The default value is 20000 (20 seconds). The content
+    //!   repository SHOULD impose a maximum value for this parameter. The
+    //!   content repository MAY respond before the timeout.
     //!
     //! \param allowRedirect
-    //!   Indicates to the server that it may return a 307 or 308 redirect response that points
-    //!   at the relevant media content. When not explicitly set to true the server must return
-    //!   the media content itself.
+    //!   Indicates to the server that it may return a 307 or 308 redirect
+    //!   response that points at the relevant media content. When not explicitly
+    //!   set to `true` the server must return the media content itself.
     explicit GetContentOverrideNameJob(const QString& serverName, const QString& mediaId,
                                        const QString& fileName, bool allowRemote = true,
                                        qint64 timeoutMs = 20000, bool allowRedirect = false);
@@ -234,15 +254,27 @@ public:
 
 //! \brief Download a thumbnail of content from the content repository
 //!
+//! \note
+//! Replaced by [`GET
+//! /_matrix/client/v1/media/thumbnail/{serverName}/{mediaId}`](/client-server-api/#get_matrixclientv1mediathumbnailservernamemediaid)
+//! (requires authentication).
+//!
 //! Download a thumbnail of content from the content repository.
 //! See the [Thumbnails](/client-server-api/#thumbnails) section for more information.
-class QUOTIENT_API GetContentThumbnailJob : public BaseJob {
+//!
+//! \warning
+//! **(Changed in v1.11)** This endpoint MAY return `404 M_NOT_FOUND`
+//! for media which exists, but is after the server froze unauthenticated
+//! media access. See [Client Behaviour](/client-server-api/#content-repo-client-behaviour) for more
+//! information.
+class [[deprecated("Check the documentation for details")]] QUOTIENT_API GetContentThumbnailJob
+    : public BaseJob {
 public:
     //! \param serverName
-    //!   The server name from the `mxc://` URI (the authoritory component)
+    //!   The server name from the `mxc://` URI (the authority component).
     //!
     //! \param mediaId
-    //!   The media ID from the `mxc://` URI (the path component)
+    //!   The media ID from the `mxc://` URI (the path component).
     //!
     //! \param width
     //!   The *desired* width of the thumbnail. The actual thumbnail may be
@@ -257,25 +289,43 @@ public:
     //!   section for more information.
     //!
     //! \param allowRemote
-    //!   Indicates to the server that it should not attempt to fetch
-    //!   the media if it is deemed remote. This is to prevent routing loops
-    //!   where the server contacts itself. Defaults to true if not provided.
+    //!   Indicates to the server that it should not attempt to fetch the media if
+    //!   it is deemed remote. This is to prevent routing loops where the server
+    //!   contacts itself.
+    //!
+    //!   Defaults to `true` if not provided.
     //!
     //! \param timeoutMs
-    //!   The maximum number of milliseconds that the client is willing to
-    //!   wait to start receiving data, in the case that the content has not
-    //!   yet been uploaded. The default value is 20000 (20 seconds). The
-    //!   content repository can and should impose a maximum value for this
-    //!   parameter. The content repository may also choose to respond before
-    //!   the timeout.
+    //!   The maximum number of milliseconds that the client is willing to wait to
+    //!   start receiving data, in the case that the content has not yet been
+    //!   uploaded. The default value is 20000 (20 seconds). The content
+    //!   repository SHOULD impose a maximum value for this parameter. The
+    //!   content repository MAY respond before the timeout.
     //!
     //! \param allowRedirect
-    //!   Indicates to the server that it may return a 307 or 308 redirect response that points
-    //!   at the relevant media content. When not explicitly set to true the server must return
-    //!   the media content itself.
+    //!   Indicates to the server that it may return a 307 or 308 redirect
+    //!   response that points at the relevant media content. When not explicitly
+    //!   set to `true` the server must return the media content itself.
+    //!
+    //! \param animated
+    //!   Indicates preference for an animated thumbnail from the server, if possible. Animated
+    //!   thumbnails typically use the content types `image/gif`, `image/png` (with APNG format),
+    //!   `image/apng`, and `image/webp` instead of the common static `image/png` or `image/jpeg`
+    //!   content types.
+    //!
+    //!   When `true`, the server SHOULD return an animated thumbnail if possible and supported.
+    //!   When `false`, the server MUST NOT return an animated thumbnail. For example, returning a
+    //!   static `image/png` or `image/jpeg` thumbnail. When not provided, the server SHOULD NOT
+    //!   return an animated thumbnail.
+    //!
+    //!   Servers SHOULD prefer to return `image/webp` thumbnails when supporting animation.
+    //!
+    //!   When `true` and the media cannot be animated, such as in the case of a JPEG or PDF, the
+    //!   server SHOULD behave as though `animated` is `false`.
     explicit GetContentThumbnailJob(const QString& serverName, const QString& mediaId, int width,
                                     int height, const QString& method = {}, bool allowRemote = true,
-                                    qint64 timeoutMs = 20000, bool allowRedirect = false);
+                                    qint64 timeoutMs = 20000, bool allowRedirect = false,
+                                    std::optional<bool> animated = std::nullopt);
 
     //! \brief Construct a URL without creating a full-fledged job object
     //!
@@ -284,7 +334,8 @@ public:
     static QUrl makeRequestUrl(QUrl baseUrl, const QString& serverName, const QString& mediaId,
                                int width, int height, const QString& method = {},
                                bool allowRemote = true, qint64 timeoutMs = 20000,
-                               bool allowRedirect = false);
+                               bool allowRedirect = false,
+                               std::optional<bool> animated = std::nullopt);
 
     // Result properties
 
@@ -297,6 +348,10 @@ public:
 
 //! \brief Get information about a URL for a client
 //!
+//! \note
+//! Replaced by [`GET
+//! /_matrix/client/v1/media/preview_url`](/client-server-api/#get_matrixclientv1mediapreview_url).
+//!
 //! Get information about a URL for the client. Typically this is called when a
 //! client sees a URL in a message and wants to render a preview for the user.
 //!
@@ -305,7 +360,8 @@ public:
 //! rooms. Encrypted rooms often contain more sensitive information the users
 //! do not want to share with the homeserver, and this can mean that the URLs
 //! being shared should also not be shared with the homeserver.
-class QUOTIENT_API GetUrlPreviewJob : public BaseJob {
+class [[deprecated("Check the documentation for details")]] QUOTIENT_API GetUrlPreviewJob
+    : public BaseJob {
 public:
     //! \param url
     //!   The URL to get a preview of.
@@ -351,6 +407,10 @@ constexpr inline auto doCollectResponse<JobT> =
 
 //! \brief Get the configuration for the content repository.
 //!
+//! \note
+//! Replaced by [`GET
+//! /_matrix/client/v1/media/config`](/client-server-api/#get_matrixclientv1mediaconfig).
+//!
 //! This endpoint allows clients to retrieve the configuration of the content
 //! repository, such as upload limitations.
 //! Clients SHOULD use this as a guide when using content repository endpoints.
@@ -361,7 +421,8 @@ constexpr inline auto doCollectResponse<JobT> =
 //! between the client and the server may affect the apparent behaviour of content
 //! repository APIs, for example, proxies may enforce a lower upload size limit
 //! than is advertised by the server on this endpoint.
-class QUOTIENT_API GetConfigJob : public BaseJob {
+class [[deprecated("Check the documentation for details")]] QUOTIENT_API GetConfigJob
+    : public BaseJob {
 public:
     explicit GetConfigJob();
 

--- a/Quotient/csapi/cross_signing.cpp
+++ b/Quotient/csapi/cross_signing.cpp
@@ -21,7 +21,7 @@ UploadCrossSigningKeysJob::UploadCrossSigningKeysJob(
 }
 
 UploadCrossSigningSignaturesJob::UploadCrossSigningSignaturesJob(
-    const QHash<QString, QHash<QString, QJsonObject>>& signatures)
+    const QHash<UserId, QHash<QString, QJsonObject>>& signatures)
     : BaseJob(HttpVerb::Post, QStringLiteral("UploadCrossSigningSignaturesJob"),
               makePath("/_matrix/client/v3", "/keys/signatures/upload"))
 {

--- a/Quotient/csapi/cross_signing.h
+++ b/Quotient/csapi/cross_signing.h
@@ -15,6 +15,19 @@ namespace Quotient {
 //!
 //! This API endpoint uses the [User-Interactive Authentication
 //! API](/client-server-api/#user-interactive-authentication-api).
+//!
+//! User-Interactive Authentication MUST be performed, except in these cases:
+//! - there is no existing cross-signing master key uploaded to the homeserver, OR
+//! - there is an existing cross-signing master key and it exactly matches the
+//!   cross-signing master key provided in the request body. If there are any additional
+//!   keys provided in the request (self-signing key, user-signing key) they MUST also
+//!   match the existing keys stored on the server. In other words, the request contains
+//!   no new keys.
+//!
+//! This allows clients to freely upload one set of keys, but not modify/overwrite keys if
+//! they already exist. Allowing clients to upload the same set of keys more than once
+//! makes this endpoint idempotent in the case where the response is lost over the network,
+//! which would otherwise cause a UIA challenge upon retry.
 class QUOTIENT_API UploadCrossSigningKeysJob : public BaseJob {
 public:
     //! \param masterKey
@@ -55,16 +68,16 @@ public:
     //!   A map from user ID to key ID to signed JSON objects containing the
     //!   signatures to be published.
     explicit UploadCrossSigningSignaturesJob(
-        const QHash<QString, QHash<QString, QJsonObject>>& signatures);
+        const QHash<UserId, QHash<QString, QJsonObject>>& signatures);
 
     // Result properties
 
     //! A map from user ID to key ID to an error for any signatures
     //! that failed.  If a signature was invalid, the `errcode` will
     //! be set to `M_INVALID_SIGNATURE`.
-    QHash<QString, QHash<QString, QJsonObject>> failures() const
+    QHash<UserId, QHash<QString, QJsonObject>> failures() const
     {
-        return loadFromJson<QHash<QString, QHash<QString, QJsonObject>>>("failures"_ls);
+        return loadFromJson<QHash<UserId, QHash<QString, QJsonObject>>>("failures"_ls);
     }
 };
 

--- a/Quotient/csapi/definitions/device_keys.h
+++ b/Quotient/csapi/definitions/device_keys.h
@@ -28,7 +28,7 @@ struct QUOTIENT_API DeviceKeys {
     //!
     //! The signature is calculated using the process described at [Signing
     //! JSON](/appendices/#signing-json).
-    QHash<QString, QHash<QString, QString>> signatures;
+    QHash<UserId, QHash<QString, QString>> signatures;
 };
 
 template <>

--- a/Quotient/csapi/definitions/push_condition.h
+++ b/Quotient/csapi/definitions/push_condition.h
@@ -7,7 +7,7 @@
 namespace Quotient {
 
 struct QUOTIENT_API PushCondition {
-    //! The kind of condition to apply. See [conditions](/client-server-api/#conditions) for
+    //! The kind of condition to apply. See [conditions](/client-server-api/#conditions-1) for
     //! more information on the allowed kinds and how they work.
     QString kind;
 

--- a/Quotient/csapi/definitions/tag.h
+++ b/Quotient/csapi/definitions/tag.h
@@ -1,0 +1,27 @@
+// THIS FILE IS GENERATED - ANY EDITS WILL BE OVERWRITTEN
+
+#pragma once
+
+#include <Quotient/converters.h>
+
+namespace Quotient {
+
+struct QUOTIENT_API Tag {
+    //! A number in a range `[0,1]` describing a relative
+    //! position of the room under the given tag.
+    std::optional<float> order{};
+};
+
+template <>
+struct JsonObjectConverter<Tag> {
+    static void dumpTo(QJsonObject& jo, const Tag& pod)
+    {
+        addParam<IfNotEmpty>(jo, QStringLiteral("order"), pod.order);
+    }
+    static void fillFrom(const QJsonObject& jo, Tag& pod)
+    {
+        fillFromJson(jo.value("order"_ls), pod.order);
+    }
+};
+
+} // namespace Quotient

--- a/Quotient/csapi/key_backup.cpp
+++ b/Quotient/csapi/key_backup.cpp
@@ -209,7 +209,7 @@ auto queryToPutRoomKeys(const QString& version)
     return _q;
 }
 
-PutRoomKeysJob::PutRoomKeysJob(const QString& version, const QHash<QString, RoomKeyBackup>& rooms)
+PutRoomKeysJob::PutRoomKeysJob(const QString& version, const QHash<RoomId, RoomKeyBackup>& rooms)
     : BaseJob(HttpVerb::Put, QStringLiteral("PutRoomKeysJob"),
               makePath("/_matrix/client/v3", "/room_keys/keys"), queryToPutRoomKeys(version))
 {

--- a/Quotient/csapi/key_backup.h
+++ b/Quotient/csapi/key_backup.h
@@ -447,7 +447,7 @@ public:
     //!
     //! \param rooms
     //!   A map of room IDs to room key backup data.
-    explicit PutRoomKeysJob(const QString& version, const QHash<QString, RoomKeyBackup>& rooms);
+    explicit PutRoomKeysJob(const QString& version, const QHash<RoomId, RoomKeyBackup>& rooms);
 
     // Result properties
 
@@ -490,9 +490,9 @@ public:
     // Result properties
 
     //! A map of room IDs to room key backup data.
-    QHash<QString, RoomKeyBackup> rooms() const
+    QHash<RoomId, RoomKeyBackup> rooms() const
     {
-        return loadFromJson<QHash<QString, RoomKeyBackup>>("rooms"_ls);
+        return loadFromJson<QHash<RoomId, RoomKeyBackup>>("rooms"_ls);
     }
 };
 

--- a/Quotient/csapi/keys.cpp
+++ b/Quotient/csapi/keys.cpp
@@ -17,7 +17,7 @@ UploadKeysJob::UploadKeysJob(const std::optional<DeviceKeys>& deviceKeys,
     addExpectedKey("one_time_key_counts");
 }
 
-QueryKeysJob::QueryKeysJob(const QHash<QString, QStringList>& deviceKeys, std::optional<int> timeout)
+QueryKeysJob::QueryKeysJob(const QHash<UserId, QStringList>& deviceKeys, std::optional<int> timeout)
     : BaseJob(HttpVerb::Post, QStringLiteral("QueryKeysJob"),
               makePath("/_matrix/client/v3", "/keys/query"))
 {
@@ -27,7 +27,7 @@ QueryKeysJob::QueryKeysJob(const QHash<QString, QStringList>& deviceKeys, std::o
     setRequestData({ _dataJson });
 }
 
-ClaimKeysJob::ClaimKeysJob(const QHash<QString, QHash<QString, QString>>& oneTimeKeys,
+ClaimKeysJob::ClaimKeysJob(const QHash<UserId, QHash<QString, QString>>& oneTimeKeys,
                            std::optional<int> timeout)
     : BaseJob(HttpVerb::Post, QStringLiteral("ClaimKeysJob"),
               makePath("/_matrix/client/v3", "/keys/claim"))

--- a/Quotient/csapi/keys.h
+++ b/Quotient/csapi/keys.h
@@ -92,7 +92,7 @@ public:
     //! \param timeout
     //!   The time (in milliseconds) to wait when downloading keys from
     //!   remote servers. 10 seconds is the recommended default.
-    explicit QueryKeysJob(const QHash<QString, QStringList>& deviceKeys,
+    explicit QueryKeysJob(const QHash<UserId, QStringList>& deviceKeys,
                           std::optional<int> timeout = std::nullopt);
 
     // Result properties
@@ -114,9 +114,9 @@ public:
     //! the information returned will be the same as uploaded via
     //! `/keys/upload`, with the addition of an `unsigned`
     //! property.
-    QHash<QString, QHash<QString, DeviceInformation>> deviceKeys() const
+    QHash<UserId, QHash<QString, DeviceInformation>> deviceKeys() const
     {
-        return loadFromJson<QHash<QString, QHash<QString, DeviceInformation>>>("device_keys"_ls);
+        return loadFromJson<QHash<UserId, QHash<QString, DeviceInformation>>>("device_keys"_ls);
     }
 
     //! Information on the master cross-signing keys of the queried users.
@@ -125,18 +125,18 @@ public:
     //! `/keys/device_signing/upload`, along with the signatures
     //! uploaded via `/keys/signatures/upload` that the requesting user
     //! is allowed to see.
-    QHash<QString, CrossSigningKey> masterKeys() const
+    QHash<UserId, CrossSigningKey> masterKeys() const
     {
-        return loadFromJson<QHash<QString, CrossSigningKey>>("master_keys"_ls);
+        return loadFromJson<QHash<UserId, CrossSigningKey>>("master_keys"_ls);
     }
 
     //! Information on the self-signing keys of the queried users. A map
     //! from user ID, to self-signing key information.  For each key, the
     //! information returned will be the same as uploaded via
     //! `/keys/device_signing/upload`.
-    QHash<QString, CrossSigningKey> selfSigningKeys() const
+    QHash<UserId, CrossSigningKey> selfSigningKeys() const
     {
-        return loadFromJson<QHash<QString, CrossSigningKey>>("self_signing_keys"_ls);
+        return loadFromJson<QHash<UserId, CrossSigningKey>>("self_signing_keys"_ls);
     }
 
     //! Information on the user-signing key of the user making the
@@ -144,9 +144,9 @@ public:
     //! from user ID, to user-signing key information.  The
     //! information returned will be the same as uploaded via
     //! `/keys/device_signing/upload`.
-    QHash<QString, CrossSigningKey> userSigningKeys() const
+    QHash<UserId, CrossSigningKey> userSigningKeys() const
     {
-        return loadFromJson<QHash<QString, CrossSigningKey>>("user_signing_keys"_ls);
+        return loadFromJson<QHash<UserId, CrossSigningKey>>("user_signing_keys"_ls);
     }
 
     struct Response {
@@ -164,7 +164,7 @@ public:
         //! the information returned will be the same as uploaded via
         //! `/keys/upload`, with the addition of an `unsigned`
         //! property.
-        QHash<QString, QHash<QString, DeviceInformation>> deviceKeys{};
+        QHash<UserId, QHash<QString, DeviceInformation>> deviceKeys{};
 
         //! Information on the master cross-signing keys of the queried users.
         //! A map from user ID, to master key information.  For each key, the
@@ -172,20 +172,20 @@ public:
         //! `/keys/device_signing/upload`, along with the signatures
         //! uploaded via `/keys/signatures/upload` that the requesting user
         //! is allowed to see.
-        QHash<QString, CrossSigningKey> masterKeys{};
+        QHash<UserId, CrossSigningKey> masterKeys{};
 
         //! Information on the self-signing keys of the queried users. A map
         //! from user ID, to self-signing key information.  For each key, the
         //! information returned will be the same as uploaded via
         //! `/keys/device_signing/upload`.
-        QHash<QString, CrossSigningKey> selfSigningKeys{};
+        QHash<UserId, CrossSigningKey> selfSigningKeys{};
 
         //! Information on the user-signing key of the user making the
         //! request, if they queried their own device information. A map
         //! from user ID, to user-signing key information.  The
         //! information returned will be the same as uploaded via
         //! `/keys/device_signing/upload`.
-        QHash<QString, CrossSigningKey> userSigningKeys{};
+        QHash<UserId, CrossSigningKey> userSigningKeys{};
     };
 };
 
@@ -224,7 +224,7 @@ public:
     //! \param timeout
     //!   The time (in milliseconds) to wait when downloading keys from
     //!   remote servers. 10 seconds is the recommended default.
-    explicit ClaimKeysJob(const QHash<QString, QHash<QString, QString>>& oneTimeKeys,
+    explicit ClaimKeysJob(const QHash<UserId, QHash<QString, QString>>& oneTimeKeys,
                           std::optional<int> timeout = std::nullopt);
 
     // Result properties
@@ -249,9 +249,9 @@ public:
     //!
     //! If necessary, the claimed key might be a fallback key. Fallback
     //! keys are re-used by the server until replaced by the device.
-    QHash<QString, QHash<QString, OneTimeKeys>> oneTimeKeys() const
+    QHash<UserId, QHash<QString, OneTimeKeys>> oneTimeKeys() const
     {
-        return loadFromJson<QHash<QString, QHash<QString, OneTimeKeys>>>("one_time_keys"_ls);
+        return loadFromJson<QHash<UserId, QHash<QString, OneTimeKeys>>>("one_time_keys"_ls);
     }
 
     struct Response {
@@ -272,7 +272,7 @@ public:
         //!
         //! If necessary, the claimed key might be a fallback key. Fallback
         //! keys are re-used by the server until replaced by the device.
-        QHash<QString, QHash<QString, OneTimeKeys>> oneTimeKeys{};
+        QHash<UserId, QHash<QString, OneTimeKeys>> oneTimeKeys{};
     };
 };
 

--- a/Quotient/csapi/login.h
+++ b/Quotient/csapi/login.h
@@ -76,6 +76,10 @@ public:
     //! \param type
     //!   The login type being used.
     //!
+    //!   This must be a type returned in one of the flows of the
+    //!   response of the [`GET /login`](/client-server-api/#get_matrixclientv3login)
+    //!   endpoint, like `m.login.password` or `m.login.token`.
+    //!
     //!
     //! \param password
     //!   Required when `type` is `m.login.password`. The user's

--- a/Quotient/csapi/login_token.h
+++ b/Quotient/csapi/login_token.h
@@ -37,7 +37,7 @@ namespace Quotient {
 //! intend to log in multiple devices must generate a token for each.
 //!
 //! With other User-Interactive Authentication (UIA)-supporting endpoints, servers sometimes do not
-//! re-prompt for verification if the session recently passed UIA. For this endpoint, servers should
+//! re-prompt for verification if the session recently passed UIA. For this endpoint, servers MUST
 //! always re-prompt the user for verification to ensure explicit consent is gained for each
 //! additional client.
 //!

--- a/Quotient/csapi/relations.h
+++ b/Quotient/csapi/relations.h
@@ -58,14 +58,13 @@ public:
     //!   Whether to additionally include events which only relate indirectly to the
     //!   given event, i.e. events related to the given event via two or more direct relationships.
     //!
-    //!   If set to `false`, only events which have direct a relation with the given
+    //!   If set to `false`, only events which have a direct relation with the given
     //!   event will be included.
     //!
-    //!   If set to `true`, all events which relate to the given event, or relate to
-    //!   events that relate to the given event, will be included.
-    //!
-    //!   It is recommended that homeservers traverse at least 3 levels of relationships.
-    //!   Implementations may perform more but should be careful to not infinitely recurse.
+    //!   If set to `true`, events which have an indirect relation with the given event
+    //!   will be included additionally up to a certain depth level. Homeservers SHOULD traverse
+    //!   at least 3 levels of relationships. Implementations MAY perform more but MUST be careful
+    //!   to not infinitely recurse.
     //!
     //!   The default value is `false`.
     explicit GetRelatingEventsJob(const QString& roomId, const QString& eventId,
@@ -182,14 +181,13 @@ public:
     //!   Whether to additionally include events which only relate indirectly to the
     //!   given event, i.e. events related to the given event via two or more direct relationships.
     //!
-    //!   If set to `false`, only events which have direct a relation with the given
+    //!   If set to `false`, only events which have a direct relation with the given
     //!   event will be included.
     //!
-    //!   If set to `true`, all events which relate to the given event, or relate to
-    //!   events that relate to the given event, will be included.
-    //!
-    //!   It is recommended that homeservers traverse at least 3 levels of relationships.
-    //!   Implementations may perform more but should be careful to not infinitely recurse.
+    //!   If set to `true`, events which have an indirect relation with the given event
+    //!   will be included additionally up to a certain depth level. Homeservers SHOULD traverse
+    //!   at least 3 levels of relationships. Implementations MAY perform more but MUST be careful
+    //!   to not infinitely recurse.
     //!
     //!   The default value is `false`.
     explicit GetRelatingEventsWithRelTypeJob(const QString& roomId, const QString& eventId,
@@ -319,14 +317,13 @@ public:
     //!   Whether to additionally include events which only relate indirectly to the
     //!   given event, i.e. events related to the given event via two or more direct relationships.
     //!
-    //!   If set to `false`, only events which have direct a relation with the given
+    //!   If set to `false`, only events which have a direct relation with the given
     //!   event will be included.
     //!
-    //!   If set to `true`, all events which relate to the given event, or relate to
-    //!   events that relate to the given event, will be included.
-    //!
-    //!   It is recommended that homeservers traverse at least 3 levels of relationships.
-    //!   Implementations may perform more but should be careful to not infinitely recurse.
+    //!   If set to `true`, events which have an indirect relation with the given event
+    //!   will be included additionally up to a certain depth level. Homeservers SHOULD traverse
+    //!   at least 3 levels of relationships. Implementations MAY perform more but MUST be careful
+    //!   to not infinitely recurse.
     //!
     //!   The default value is `false`.
     explicit GetRelatingEventsWithRelTypeAndEventTypeJob(

--- a/Quotient/csapi/rooms.h
+++ b/Quotient/csapi/rooms.h
@@ -167,9 +167,9 @@ public:
     // Result properties
 
     //! A map from user ID to a RoomMember object.
-    QHash<QString, RoomMember> joined() const
+    QHash<UserId, RoomMember> joined() const
     {
-        return loadFromJson<QHash<QString, RoomMember>>("joined"_ls);
+        return loadFromJson<QHash<UserId, RoomMember>>("joined"_ls);
     }
 };
 

--- a/Quotient/csapi/search.h
+++ b/Quotient/csapi/search.h
@@ -99,9 +99,9 @@ public:
         //! The historic profile information of the
         //! users that sent the events returned.
         //!
-        //! The `string` key is the user ID for which
+        //! The key is the user ID for which
         //! the profile belongs to.
-        QHash<QString, UserProfile> profileInfo{};
+        QHash<UserId, UserProfile> profileInfo{};
 
         //! Events just before the result.
         RoomEvents eventsBefore{};
@@ -155,9 +155,9 @@ public:
         //! This is included if the request had the
         //! `include_state` key set with a value of `true`.
         //!
-        //! The `string` key is the room ID for which the `State
+        //! The key is the room ID for which the `State
         //! Event` array belongs to.
-        std::unordered_map<QString, StateEvents> state{};
+        std::unordered_map<RoomId, StateEvents> state{};
 
         //! Any groups that were requested.
         //!

--- a/Quotient/csapi/tags.cpp
+++ b/Quotient/csapi/tags.cpp
@@ -16,14 +16,11 @@ GetRoomTagsJob::GetRoomTagsJob(const QString& userId, const QString& roomId)
 {}
 
 SetRoomTagJob::SetRoomTagJob(const QString& userId, const QString& roomId, const QString& tag,
-                             std::optional<float> order, const QVariantHash& additionalProperties)
+                             const Tag& data)
     : BaseJob(HttpVerb::Put, QStringLiteral("SetRoomTagJob"),
               makePath("/_matrix/client/v3", "/user/", userId, "/rooms/", roomId, "/tags/", tag))
 {
-    QJsonObject _dataJson;
-    fillJson(_dataJson, additionalProperties);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("order"), order);
-    setRequestData({ _dataJson });
+    setRequestData({ toJson(data) });
 }
 
 QUrl DeleteRoomTagJob::makeRequestUrl(QUrl baseUrl, const QString& userId, const QString& roomId,

--- a/Quotient/csapi/tags.h
+++ b/Quotient/csapi/tags.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include <Quotient/csapi/definitions/tag.h>
+
 #include <Quotient/jobs/basejob.h>
 
 namespace Quotient {
@@ -11,18 +13,6 @@ namespace Quotient {
 //! List the tags set by a user on a room.
 class QUOTIENT_API GetRoomTagsJob : public BaseJob {
 public:
-    // Inner data structures
-
-    struct QUOTIENT_API Tag {
-        //! A number in a range `[0,1]` describing a relative
-        //! position of the room under the given tag.
-        std::optional<float> order{};
-
-        QVariantHash additionalProperties{};
-    };
-
-    // Construction/destruction
-
     //! \param userId
     //!   The id of the user to get tags for. The access token must be
     //!   authorized to make requests for this user ID.
@@ -44,15 +34,6 @@ public:
 
 inline auto collectResponse(const GetRoomTagsJob* job) { return job->tags(); }
 
-template <>
-struct QUOTIENT_API JsonObjectConverter<GetRoomTagsJob::Tag> {
-    static void fillFrom(QJsonObject jo, GetRoomTagsJob::Tag& result)
-    {
-        fillFromJson(jo.take("order"_ls), result.order);
-        fromJson(jo, result.additionalProperties);
-    }
-};
-
 //! \brief Add a tag to a room.
 //!
 //! Add a tag to the room.
@@ -68,13 +49,10 @@ public:
     //! \param tag
     //!   The tag to add.
     //!
-    //! \param order
-    //!   A number in a range `[0,1]` describing a relative
-    //!   position of the room under the given tag.
-    //!
+    //! \param data
+    //!   Extra data for the tag, e.g. ordering.
     explicit SetRoomTagJob(const QString& userId, const QString& roomId, const QString& tag,
-                           std::optional<float> order = std::nullopt,
-                           const QVariantHash& additionalProperties = {});
+                           const Tag& data);
 };
 
 //! \brief Remove a tag from the room.

--- a/Quotient/csapi/to_device.cpp
+++ b/Quotient/csapi/to_device.cpp
@@ -5,7 +5,7 @@
 using namespace Quotient;
 
 SendToDeviceJob::SendToDeviceJob(const QString& eventType, const QString& txnId,
-                                 const QHash<QString, QHash<QString, QJsonObject>>& messages)
+                                 const QHash<UserId, QHash<QString, QJsonObject>>& messages)
     : BaseJob(HttpVerb::Put, QStringLiteral("SendToDeviceJob"),
               makePath("/_matrix/client/v3", "/sendToDevice/", eventType, "/", txnId))
 {

--- a/Quotient/csapi/to_device.h
+++ b/Quotient/csapi/to_device.h
@@ -25,7 +25,7 @@ public:
     //!   device ID to message body. The device ID may also be `*`,
     //!   meaning all known devices for the user.
     explicit SendToDeviceJob(const QString& eventType, const QString& txnId,
-                             const QHash<QString, QHash<QString, QJsonObject>>& messages);
+                             const QHash<UserId, QHash<QString, QJsonObject>>& messages);
 };
 
 } // namespace Quotient

--- a/Quotient/csapi/versions.cpp
+++ b/Quotient/csapi/versions.cpp
@@ -11,7 +11,7 @@ QUrl GetVersionsJob::makeRequestUrl(QUrl baseUrl)
 
 GetVersionsJob::GetVersionsJob()
     : BaseJob(HttpVerb::Get, QStringLiteral("GetVersionsJob"),
-              makePath("/_matrix/client", "/versions"), false)
+              makePath("/_matrix/client", "/versions"))
 {
     addExpectedKey("versions");
 }

--- a/Quotient/events/accountdataevents.h
+++ b/Quotient/events/accountdataevents.h
@@ -5,45 +5,23 @@
 
 #include "event.h"
 
+#include "../csapi/definitions/tag.h"
+
 namespace Quotient {
 constexpr inline auto FavouriteTag = "m.favourite"_ls;
 constexpr inline auto LowPriorityTag = "m.lowpriority"_ls;
 constexpr inline auto ServerNoticeTag = "m.server_notice"_ls;
 
-struct TagRecord {
-    std::optional<float> order = std::nullopt;
-};
+using TagRecord [[deprecated("Use Tag from csapi/definitions/tag.h instead")]] = Tag;
 
-inline bool operator<(TagRecord lhs, TagRecord rhs)
+inline bool operator<(Tag lhs, Tag rhs)
 {
     // Per The Spec, rooms with no order should be after those with order,
     // against std::optional<>::operator<() convention.
     return lhs.order && (!rhs.order || *lhs.order < *rhs.order);
 }
 
-template <>
-struct JsonObjectConverter<TagRecord> {
-    static void fillFrom(const QJsonObject& jo, TagRecord& rec)
-    {
-        // Parse a float both from JSON double and JSON string because
-        // the library previously used to use strings to store order.
-        const auto orderJv = jo.value("order"_ls);
-        if (orderJv.isDouble())
-            rec.order = fromJson<float>(orderJv);
-        if (orderJv.isString()) {
-            bool ok = false;
-            rec.order = orderJv.toString().toFloat(&ok);
-            if (!ok)
-                rec.order = std::nullopt;
-        }
-    }
-    static void dumpTo(QJsonObject& jo, TagRecord rec)
-    {
-        addParam<IfNotEmpty>(jo, QStringLiteral("order"), rec.order);
-    }
-};
-
-using TagsMap = QHash<QString, TagRecord>;
+using TagsMap = QHash<QString, Tag>;
 
 DEFINE_SIMPLE_EVENT(TagEvent, Event, "m.tag", TagsMap, tags, "tags")
 DEFINE_SIMPLE_EVENT(ReadMarkerEvent, Event, "m.fully_read", QString,

--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -1313,8 +1313,8 @@ void Room::addTag(const QString& name, const TagRecord& record)
     emit tagsAboutToChange();
     d->tags.insert(checkRes.second, record);
     emit tagsChanged();
-    connection()->callApi<SetRoomTagJob>(localMember().id(), id(),
-                                         checkRes.second, record.order);
+    connection()->callApi<SetRoomTagJob>(localMember().id(), id(), checkRes.second,
+                                         Tag { record.order });
 }
 
 void Room::addTag(const QString& name, float order)

--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -1288,7 +1288,7 @@ QStringList Room::tagNames() const { return d->tags.keys(); }
 
 TagsMap Room::tags() const { return d->tags; }
 
-TagRecord Room::tag(const QString& name) const { return d->tags.value(name); }
+Tag Room::tag(const QString& name) const { return d->tags.value(name); }
 
 std::pair<bool, QString> validatedTag(QString name)
 {
@@ -1303,7 +1303,7 @@ std::pair<bool, QString> validatedTag(QString name)
     return { true, name };
 }
 
-void Room::addTag(const QString& name, const TagRecord& record)
+void Room::addTag(const QString& name, const Tag& tagData)
 {
     const auto& checkRes = validatedTag(name);
     if (d->tags.contains(name)
@@ -1311,15 +1311,14 @@ void Room::addTag(const QString& name, const TagRecord& record)
         return;
 
     emit tagsAboutToChange();
-    d->tags.insert(checkRes.second, record);
+    d->tags.insert(checkRes.second, tagData);
     emit tagsChanged();
-    connection()->callApi<SetRoomTagJob>(localMember().id(), id(), checkRes.second,
-                                         Tag { record.order });
+    connection()->callApi<SetRoomTagJob>(localMember().id(), id(), checkRes.second, tagData);
 }
 
 void Room::addTag(const QString& name, float order)
 {
-    addTag(name, TagRecord { order });
+    addTag(name, Tag { order });
 }
 
 void Room::removeTag(const QString& name)

--- a/Quotient/room.h
+++ b/Quotient/room.h
@@ -554,7 +554,7 @@ public:
 
     QStringList tagNames() const;
     TagsMap tags() const;
-    TagRecord tag(const QString& name) const;
+    Tag tag(const QString& name) const;
 
     /** Add a new tag to this room
      * If this room already has this tag, nothing happens. If it's a new
@@ -562,7 +562,7 @@ public:
      * of tags and the new set is sent to the server to update other
      * clients.
      */
-    void addTag(const QString& name, const TagRecord& record = {});
+    void addTag(const QString& name, const Tag& tagData = {});
     Q_INVOKABLE void addTag(const QString& name, float order);
 
     /// Remove a tag from the room

--- a/Quotient/util.h
+++ b/Quotient/util.h
@@ -421,3 +421,11 @@ constexpr inline size_t mergeStruct(StructT& lhs, const StructT& rhs, const auto
 {
     return ((... + static_cast<size_t>(merge(lhs.*fields, rhs.*fields))));
 }
+
+// These are meant to eventually become separate classes derived from QString (or perhaps
+// QByteArray?), with their own construction and validation logic; for now they are just aliases
+// for QString to make numerous IDs at least semantically different in the code.
+
+using UserId = QString;
+using RoomId = QString;
+using EventId = QString;

--- a/gtad/gtad.yaml
+++ b/gtad/gtad.yaml
@@ -1,7 +1,10 @@
 analyzer:
   subst:
-    "%CLIENT_RELEASE_LABEL%": r0
-    "%CLIENT_MAJOR_VERSION%": r0
+    # Escaping open braces because GTAD always treats subst keys as regexes, unlike other places
+    '\{\{% boxes/note %}}': '\note'
+    '\{\{% boxes/warning %}}': '\warning'
+    '\{\{< changed-in v="([^ ]+)" >}}': '**(Changed in v$1)**'
+    '( +)\{\{% /boxes/[a-z]+ %}}\n': '' # Delete lines with the closing handlebar entirely
   identifiers:
     signed: signedData
     unsigned: unsignedData
@@ -84,13 +87,16 @@ analyzer:
       - dateTime:
           type: QDateTime
           initializer: QDateTime::fromString("{{defaultValue}}")
-      - uri:
+      - uri: &Url
           type: QUrl
           initializer: QUrl::fromEncoded("{{defaultValue}}")
+      - mx-mxc-uri: *Url
+      - mx-user-id: UserId
+      - mx-room-id: RoomId
+      - mx-event-id: EventId
       - //: &QString
           type: QString
           initializer: QStringLiteral("{{defaultValue}}")
-          isString:
   - file: *ByteStream
   - +set: { avoidCopy: }
     +on:
@@ -122,11 +128,11 @@ analyzer:
         - /(room|client)_event.yaml$/: RoomEvents
         - /event(_without_room_id)?.yaml$/: Events
       - //: "QVector<{{1}}>"
-    - map: # `additionalProperties` in OpenAPI
+    - map: # `patternProperties` and `additionalProperties` in OpenAPI
       - RoomState:
-          type: "std::unordered_map<QString, {{1}}>"
+          type: "std::unordered_map<{{1}}, {{2}}>"
           moveOnly:
-      - /.+/: "QHash<QString, {{1}}>"
+      - /.+/: "QHash<{{1}}, {{2}}>"
       - //: QVariantHash # QJsonObject?..
     - variant: # A sequence `type` or a 'oneOf' group in OpenAPI
       - /^string,null|null,string$/: *QString
@@ -182,6 +188,9 @@ mustache:
     omittedValue: '{}' # default value to initialize omitted parameters with
     initializer: '{{defaultValue}}'
     cjoin: '{{#hasMore}}, {{/hasMore}}'
+
+    maybeDeprecated:
+      '{{#deprecated?}}[[deprecated("Check the documentation for details")]] {{/deprecated?}}'
 
     openOptional:
       "{{^required?}}{{#useOptional}}\

--- a/gtad/operation.h.mustache
+++ b/gtad/operation.h.mustache
@@ -18,7 +18,7 @@ namespace Quotient {
 //! \brief {{summary}}{{#description?}}
 //!{{#description}}
 //! {{_}}{{/description}}{{/description?}}
-class QUOTIENT_API {{>titleCaseOperationId}}Job : public BaseJob {
+class {{>maybeDeprecated}} QUOTIENT_API {{>titleCaseOperationId}}Job : public BaseJob {
 public:
     {{#models}}{{#model?}}
     // Inner data structures


### PR DESCRIPTION
With recent changes API description files started using `patternProperties` (coming from standard JSON Schema and therefore OpenAPI) and `x-pattern-format` (our extension). This PR updates GTAD to the revision supporting these, and introduces a few aliases corresponding to x-pattern-formats already in use. This may eventually help to attach certain logic to specific id types, e.g. validating user ids, or only allowing certain ids in a certain context.

This PR will not build with `update-api` flag in CI (the Linux/GCC pipeline atm) because the signature of `SetRoomTagJob` constructor changes in a backwards-incompatible way and our soft fork of `matrix-spec` stays on an older commit for now (so that other branches and PRs could still build). When Matrix 1.11 is released (expected in second half of June) the soft-fork will be updated to it, together with merging this PR.