### PR TITLE
Quality-of-life improvements around jobs and job handles

### DIFF
--- a/Quotient/connectionencryptiondata_p.cpp
+++ b/Quotient/connectionencryptiondata_p.cpp
@@ -935,8 +935,7 @@ void ConnectionEncryptionData::doSendSessionKeyToDevices(
         return;
     }
 
-    auto job = q->callApi<ClaimKeysJob>(hash);
-    QObject::connect(job, &BaseJob::success, q, [job, this, sendKey] {
+    q->callApi<ClaimKeysJob>(hash).then(q, [this, sendKey](const ClaimKeysJob* job) {
         for (const auto& [userId, userDevices] : job->oneTimeKeys().asKeyValueRange())
             for (const auto& [deviceId, keys] : userDevices.asKeyValueRange())
                 createOlmSession(userId, deviceId, keys);

--- a/Quotient/connectionencryptiondata_p.h
+++ b/Quotient/connectionencryptiondata_p.h
@@ -29,7 +29,7 @@ namespace _impl {
         QSet<QString> trackedUsers{};
         QSet<QString> outdatedUsers{};
         QHash<QString, QHash<QString, DeviceKeys>> deviceKeys{};
-        QueryKeysJob* currentQueryKeysJob = nullptr;
+        JobHandle<QueryKeysJob> currentQueryKeysJob{};
         QSet<std::pair<QString, QString>> triedDevices{};
         //! An update of internal tracking structures (trackedUsers, e.g.) is
         //! needed
@@ -100,7 +100,7 @@ namespace _impl {
                                  PicklingKey&& picklingKey);
         bool hasConflictingDeviceIdsAndCrossSigningKeys(const QString& userId);
 
-        void handleQueryKeys(const QJsonObject& keysJson);
+        void handleQueryKeys(const QueryKeysJob::Response& keys);
 
         void handleMasterKeys(const QHash<QString, CrossSigningKey>& masterKeys);
         void handleSelfSigningKeys(const QHash<QString, CrossSigningKey>& selfSigningKeys);

--- a/Quotient/csapi/account-data.h
+++ b/Quotient/csapi/account-data.h
@@ -55,6 +55,8 @@ public:
     QJsonObject data() const { return fromJson<QJsonObject>(jsonData()); }
 };
 
+inline auto collectResponse(const GetAccountDataJob* job) { return job->data(); }
+
 //! \brief Set some account data for the user that is specific to a room.
 //!
 //! Set some account data for the client on a given room. This config is only
@@ -110,5 +112,7 @@ public:
     //! The account data content for the given type.
     QJsonObject data() const { return fromJson<QJsonObject>(jsonData()); }
 };
+
+inline auto collectResponse(const GetAccountDataPerRoomJob* job) { return job->data(); }
 
 } // namespace Quotient

--- a/Quotient/csapi/admin.h
+++ b/Quotient/csapi/admin.h
@@ -60,7 +60,19 @@ public:
     {
         return loadFromJson<QHash<QString, DeviceInfo>>("devices"_ls);
     }
+
+    struct Response {
+        //! The Matrix user ID of the user.
+        QString userId{};
+
+        //! Each key is an identifier for one of the user's devices.
+        QHash<QString, DeviceInfo> devices{};
+    };
 };
+
+template <std::derived_from<GetWhoIsJob> JobT>
+constexpr inline auto doCollectResponse<JobT> =
+    [](JobT* j) -> GetWhoIsJob::Response { return { j->userId(), j->devices() }; };
 
 template <>
 struct QUOTIENT_API JsonObjectConverter<GetWhoIsJob::ConnectionInfo> {

--- a/Quotient/csapi/administrative_contact.h
+++ b/Quotient/csapi/administrative_contact.h
@@ -59,6 +59,8 @@ public:
     }
 };
 
+inline auto collectResponse(const GetAccount3PIDsJob* job) { return job->threepids(); }
+
 template <>
 struct QUOTIENT_API JsonObjectConverter<GetAccount3PIDsJob::ThirdPartyIdentifier> {
     static void fillFrom(const QJsonObject& jo, GetAccount3PIDsJob::ThirdPartyIdentifier& result)
@@ -125,6 +127,8 @@ public:
     //! in the `/versions` response (ie: r0.5.0).
     QUrl submitUrl() const { return loadFromJson<QUrl>("submit_url"_ls); }
 };
+
+inline auto collectResponse(const Post3PIDsJob* job) { return job->submitUrl(); }
 
 template <>
 struct QUOTIENT_API JsonObjectConverter<Post3PIDsJob::ThreePidCredentials> {
@@ -226,6 +230,11 @@ public:
     }
 };
 
+inline auto collectResponse(const Delete3pidFromAccountJob* job)
+{
+    return job->idServerUnbindResult();
+}
+
 //! \brief Removes a user's third-party identifier from an identity server.
 //!
 //! Removes a user's third-party identifier from the provided identity server
@@ -263,6 +272,11 @@ public:
     }
 };
 
+inline auto collectResponse(const Unbind3pidFromAccountJob* job)
+{
+    return job->idServerUnbindResult();
+}
+
 //! \brief Begins the validation process for an email address for association with the user's
 //! account.
 //!
@@ -287,6 +301,8 @@ public:
     RequestTokenResponse response() const { return fromJson<RequestTokenResponse>(jsonData()); }
 };
 
+inline auto collectResponse(const RequestTokenTo3PIDEmailJob* job) { return job->response(); }
+
 //! \brief Begins the validation process for a phone number for association with the user's account.
 //!
 //! The homeserver must check that the given phone number is **not**
@@ -307,5 +323,7 @@ public:
     //! An SMS message was sent to the given phone number.
     RequestTokenResponse response() const { return fromJson<RequestTokenResponse>(jsonData()); }
 };
+
+inline auto collectResponse(const RequestTokenTo3PIDMSISDNJob* job) { return job->response(); }
 
 } // namespace Quotient

--- a/Quotient/csapi/capabilities.h
+++ b/Quotient/csapi/capabilities.h
@@ -58,6 +58,8 @@ public:
     Capabilities capabilities() const { return loadFromJson<Capabilities>("capabilities"_ls); }
 };
 
+inline auto collectResponse(const GetCapabilitiesJob* job) { return job->capabilities(); }
+
 template <>
 struct QUOTIENT_API JsonObjectConverter<GetCapabilitiesJob::ChangePasswordCapability> {
     static void fillFrom(const QJsonObject& jo, GetCapabilitiesJob::ChangePasswordCapability& result)

--- a/Quotient/csapi/create_room.h
+++ b/Quotient/csapi/create_room.h
@@ -180,6 +180,8 @@ public:
     QString roomId() const { return loadFromJson<QString>("room_id"_ls); }
 };
 
+inline auto collectResponse(const CreateRoomJob* job) { return job->roomId(); }
+
 template <>
 struct QUOTIENT_API JsonObjectConverter<CreateRoomJob::Invite3pid> {
     static void dumpTo(QJsonObject& jo, const CreateRoomJob::Invite3pid& pod)

--- a/Quotient/csapi/cross_signing.h
+++ b/Quotient/csapi/cross_signing.h
@@ -68,4 +68,6 @@ public:
     }
 };
 
+inline auto collectResponse(const UploadCrossSigningSignaturesJob* job) { return job->failures(); }
+
 } // namespace Quotient

--- a/Quotient/csapi/device_management.h
+++ b/Quotient/csapi/device_management.h
@@ -28,6 +28,8 @@ public:
     QVector<Device> devices() const { return loadFromJson<QVector<Device>>("devices"_ls); }
 };
 
+inline auto collectResponse(const GetDevicesJob* job) { return job->devices(); }
+
 //! \brief Get a single device
 //!
 //! Gets information on a single device, by device id.
@@ -48,6 +50,8 @@ public:
     //! Device information
     Device device() const { return fromJson<Device>(jsonData()); }
 };
+
+inline auto collectResponse(const GetDeviceJob* job) { return job->device(); }
 
 //! \brief Update a device
 //!

--- a/Quotient/csapi/directory.h
+++ b/Quotient/csapi/directory.h
@@ -45,7 +45,19 @@ public:
 
     //! A list of servers that are aware of this room alias.
     QStringList servers() const { return loadFromJson<QStringList>("servers"_ls); }
+
+    struct Response {
+        //! The room ID for this room alias.
+        QString roomId{};
+
+        //! A list of servers that are aware of this room alias.
+        QStringList servers{};
+    };
 };
+
+template <std::derived_from<GetRoomIdByAliasJob> JobT>
+constexpr inline auto doCollectResponse<JobT> =
+    [](JobT* j) -> GetRoomIdByAliasJob::Response { return { j->roomId(), j->servers() }; };
 
 //! \brief Remove a mapping of room alias to room ID.
 //!
@@ -109,5 +121,7 @@ public:
     //! The server's local aliases on the room. Can be empty.
     QStringList aliases() const { return loadFromJson<QStringList>("aliases"_ls); }
 };
+
+inline auto collectResponse(const GetLocalAliasesJob* job) { return job->aliases(); }
 
 } // namespace Quotient

--- a/Quotient/csapi/event_context.h
+++ b/Quotient/csapi/event_context.h
@@ -69,6 +69,33 @@ public:
 
     //! The state of the room at the last event returned.
     StateEvents state() { return takeFromJson<StateEvents>("state"_ls); }
+
+    struct Response {
+        //! A token that can be used to paginate backwards with.
+        QString begin{};
+
+        //! A token that can be used to paginate forwards with.
+        QString end{};
+
+        //! A list of room events that happened just before the
+        //! requested event, in reverse-chronological order.
+        RoomEvents eventsBefore{};
+
+        //! Details of the requested event.
+        RoomEventPtr event{};
+
+        //! A list of room events that happened just after the
+        //! requested event, in chronological order.
+        RoomEvents eventsAfter{};
+
+        //! The state of the room at the last event returned.
+        StateEvents state{};
+    };
+};
+
+template <std::derived_from<GetEventContextJob> JobT>
+constexpr inline auto doCollectResponse<JobT> = [](JobT* j) -> GetEventContextJob::Response {
+    return { j->begin(), j->end(), j->eventsBefore(), j->event(), j->eventsAfter(), j->state() };
 };
 
 } // namespace Quotient

--- a/Quotient/csapi/filter.h
+++ b/Quotient/csapi/filter.h
@@ -32,6 +32,8 @@ public:
     QString filterId() const { return loadFromJson<QString>("filter_id"_ls); }
 };
 
+inline auto collectResponse(const DefineFilterJob* job) { return job->filterId(); }
+
 //! \brief Download a filter
 class QUOTIENT_API GetFilterJob : public BaseJob {
 public:
@@ -53,5 +55,7 @@ public:
     //! The filter definition.
     Filter filter() const { return fromJson<Filter>(jsonData()); }
 };
+
+inline auto collectResponse(const GetFilterJob* job) { return job->filter(); }
 
 } // namespace Quotient

--- a/Quotient/csapi/joining.h
+++ b/Quotient/csapi/joining.h
@@ -44,6 +44,8 @@ public:
     QString roomId() const { return loadFromJson<QString>("room_id"_ls); }
 };
 
+inline auto collectResponse(const JoinRoomByIdJob* job) { return job->roomId(); }
+
 //! \brief Start the requesting user participating in a particular room.
 //!
 //! *Note that this API takes either a room ID or alias, unlike* `/rooms/{roomId}/join`.
@@ -82,5 +84,7 @@ public:
     //! The joined room ID.
     QString roomId() const { return loadFromJson<QString>("room_id"_ls); }
 };
+
+inline auto collectResponse(const JoinRoomJob* job) { return job->roomId(); }
 
 } // namespace Quotient

--- a/Quotient/csapi/key_backup.h
+++ b/Quotient/csapi/key_backup.h
@@ -29,6 +29,8 @@ public:
     QString version() const { return loadFromJson<QString>("version"_ls); }
 };
 
+inline auto collectResponse(const PostRoomKeysVersionJob* job) { return job->version(); }
+
 //! \brief Get information about the latest backup version.
 //!
 //! Get information about the latest backup version.
@@ -63,6 +65,34 @@ public:
 
     //! The backup version.
     QString version() const { return loadFromJson<QString>("version"_ls); }
+
+    struct Response {
+        //! The algorithm used for storing backups.
+        QString algorithm{};
+
+        //! Algorithm-dependent data. See the documentation for the backup
+        //! algorithms in [Server-side key backups](/client-server-api/#server-side-key-backups) for
+        //! more information on the expected format of the data.
+        QJsonObject authData{};
+
+        //! The number of keys stored in the backup.
+        int count{};
+
+        //! An opaque string representing stored keys in the backup.
+        //! Clients can compare it with the `etag` value they received
+        //! in the request of their last key storage request.  If not
+        //! equal, another client has modified the backup.
+        QString etag{};
+
+        //! The backup version.
+        QString version{};
+    };
+};
+
+template <std::derived_from<GetRoomKeysVersionCurrentJob> JobT>
+constexpr inline auto doCollectResponse<JobT> =
+    [](JobT* j) -> GetRoomKeysVersionCurrentJob::Response {
+    return { j->algorithm(), j->authData(), j->count(), j->etag(), j->version() };
 };
 
 //! \brief Get information about an existing backup.
@@ -105,6 +135,33 @@ public:
 
     //! The backup version.
     QString version() const { return loadFromJson<QString>("version"_ls); }
+
+    struct Response {
+        //! The algorithm used for storing backups.
+        QString algorithm{};
+
+        //! Algorithm-dependent data. See the documentation for the backup
+        //! algorithms in [Server-side key backups](/client-server-api/#server-side-key-backups) for
+        //! more information on the expected format of the data.
+        QJsonObject authData{};
+
+        //! The number of keys stored in the backup.
+        int count{};
+
+        //! An opaque string representing stored keys in the backup.
+        //! Clients can compare it with the `etag` value they received
+        //! in the request of their last key storage request.  If not
+        //! equal, another client has modified the backup.
+        QString etag{};
+
+        //! The backup version.
+        QString version{};
+    };
+};
+
+template <std::derived_from<GetRoomKeysVersionJob> JobT>
+constexpr inline auto doCollectResponse<JobT> = [](JobT* j) -> GetRoomKeysVersionJob::Response {
+    return { j->algorithm(), j->authData(), j->count(), j->etag(), j->version() };
 };
 
 //! \brief Update information about an existing backup.
@@ -181,7 +238,20 @@ public:
 
     //! The number of keys stored in the backup
     int count() const { return loadFromJson<int>("count"_ls); }
+
+    struct Response {
+        //! The new etag value representing stored keys in the backup.
+        //! See `GET /room_keys/version/{version}` for more details.
+        QString etag{};
+
+        //! The number of keys stored in the backup
+        int count{};
+    };
 };
+
+template <std::derived_from<PutRoomKeyBySessionIdJob> JobT>
+constexpr inline auto doCollectResponse<JobT> =
+    [](JobT* j) -> PutRoomKeyBySessionIdJob::Response { return { j->etag(), j->count() }; };
 
 //! \brief Retrieve a key from the backup.
 //!
@@ -211,6 +281,8 @@ public:
     //! The key data
     KeyBackupData data() const { return fromJson<KeyBackupData>(jsonData()); }
 };
+
+inline auto collectResponse(const GetRoomKeyBySessionIdJob* job) { return job->data(); }
 
 //! \brief Delete a key from the backup.
 //!
@@ -243,7 +315,20 @@ public:
 
     //! The number of keys stored in the backup
     int count() const { return loadFromJson<int>("count"_ls); }
+
+    struct Response {
+        //! The new etag value representing stored keys in the backup.
+        //! See `GET /room_keys/version/{version}` for more details.
+        QString etag{};
+
+        //! The number of keys stored in the backup
+        int count{};
+    };
 };
+
+template <std::derived_from<DeleteRoomKeyBySessionIdJob> JobT>
+constexpr inline auto doCollectResponse<JobT> =
+    [](JobT* j) -> DeleteRoomKeyBySessionIdJob::Response { return { j->etag(), j->count() }; };
 
 //! \brief Store several keys in the backup for a given room.
 //!
@@ -269,7 +354,20 @@ public:
 
     //! The number of keys stored in the backup
     int count() const { return loadFromJson<int>("count"_ls); }
+
+    struct Response {
+        //! The new etag value representing stored keys in the backup.
+        //! See `GET /room_keys/version/{version}` for more details.
+        QString etag{};
+
+        //! The number of keys stored in the backup
+        int count{};
+    };
 };
+
+template <std::derived_from<PutRoomKeysByRoomIdJob> JobT>
+constexpr inline auto doCollectResponse<JobT> =
+    [](JobT* j) -> PutRoomKeysByRoomIdJob::Response { return { j->etag(), j->count() }; };
 
 //! \brief Retrieve the keys from the backup for a given room.
 //!
@@ -295,6 +393,8 @@ public:
     //! `sessions` property will be returned (`{"sessions": {}}`).
     RoomKeyBackup data() const { return fromJson<RoomKeyBackup>(jsonData()); }
 };
+
+inline auto collectResponse(const GetRoomKeysByRoomIdJob* job) { return job->data(); }
 
 //! \brief Delete the keys from the backup for a given room.
 //!
@@ -322,7 +422,20 @@ public:
 
     //! The number of keys stored in the backup
     int count() const { return loadFromJson<int>("count"_ls); }
+
+    struct Response {
+        //! The new etag value representing stored keys in the backup.
+        //! See `GET /room_keys/version/{version}` for more details.
+        QString etag{};
+
+        //! The number of keys stored in the backup
+        int count{};
+    };
 };
+
+template <std::derived_from<DeleteRoomKeysByRoomIdJob> JobT>
+constexpr inline auto doCollectResponse<JobT> =
+    [](JobT* j) -> DeleteRoomKeysByRoomIdJob::Response { return { j->etag(), j->count() }; };
 
 //! \brief Store several keys in the backup.
 //!
@@ -344,7 +457,20 @@ public:
 
     //! The number of keys stored in the backup
     int count() const { return loadFromJson<int>("count"_ls); }
+
+    struct Response {
+        //! The new etag value representing stored keys in the backup.
+        //! See `GET /room_keys/version/{version}` for more details.
+        QString etag{};
+
+        //! The number of keys stored in the backup
+        int count{};
+    };
 };
+
+template <std::derived_from<PutRoomKeysJob> JobT>
+constexpr inline auto doCollectResponse<JobT> =
+    [](JobT* j) -> PutRoomKeysJob::Response { return { j->etag(), j->count() }; };
 
 //! \brief Retrieve the keys from the backup.
 //!
@@ -370,6 +496,8 @@ public:
     }
 };
 
+inline auto collectResponse(const GetRoomKeysJob* job) { return job->rooms(); }
+
 //! \brief Delete the keys from the backup.
 //!
 //! Delete the keys from the backup.
@@ -393,6 +521,19 @@ public:
 
     //! The number of keys stored in the backup
     int count() const { return loadFromJson<int>("count"_ls); }
+
+    struct Response {
+        //! The new etag value representing stored keys in the backup.
+        //! See `GET /room_keys/version/{version}` for more details.
+        QString etag{};
+
+        //! The number of keys stored in the backup
+        int count{};
+    };
 };
+
+template <std::derived_from<DeleteRoomKeysJob> JobT>
+constexpr inline auto doCollectResponse<JobT> =
+    [](JobT* j) -> DeleteRoomKeysJob::Response { return { j->etag(), j->count() }; };
 
 } // namespace Quotient

--- a/Quotient/csapi/knocking.h
+++ b/Quotient/csapi/knocking.h
@@ -44,4 +44,6 @@ public:
     QString roomId() const { return loadFromJson<QString>("room_id"_ls); }
 };
 
+inline auto collectResponse(const KnockRoomJob* job) { return job->roomId(); }
+
 } // namespace Quotient

--- a/Quotient/csapi/list_joined_rooms.h
+++ b/Quotient/csapi/list_joined_rooms.h
@@ -25,4 +25,6 @@ public:
     QStringList joinedRooms() const { return loadFromJson<QStringList>("joined_rooms"_ls); }
 };
 
+inline auto collectResponse(const GetJoinedRoomsJob* job) { return job->joinedRooms(); }
+
 } // namespace Quotient

--- a/Quotient/csapi/list_public_rooms.h
+++ b/Quotient/csapi/list_public_rooms.h
@@ -29,6 +29,11 @@ public:
     QString visibility() const { return loadFromJson<QString>("visibility"_ls); }
 };
 
+inline auto collectResponse(const GetRoomVisibilityOnDirectoryJob* job)
+{
+    return job->visibility();
+}
+
 //! \brief Sets the visibility of a room in the room directory
 //!
 //! Sets the visibility of a given room in the server's public room
@@ -102,6 +107,30 @@ public:
     {
         return loadFromJson<std::optional<int>>("total_room_count_estimate"_ls);
     }
+
+    struct Response {
+        //! A paginated chunk of public rooms.
+        QVector<PublicRoomsChunk> chunk{};
+
+        //! A pagination token for the response. The absence of this token
+        //! means there are no more results to fetch and the client should
+        //! stop paginating.
+        QString nextBatch{};
+
+        //! A pagination token that allows fetching previous results. The
+        //! absence of this token means there are no results before this
+        //! batch, i.e. this is the first batch.
+        QString prevBatch{};
+
+        //! An estimate on the total number of public rooms, if the
+        //! server has an estimate.
+        std::optional<int> totalRoomCountEstimate{};
+    };
+};
+
+template <std::derived_from<GetPublicRoomsJob> JobT>
+constexpr inline auto doCollectResponse<JobT> = [](JobT* j) -> GetPublicRoomsJob::Response {
+    return { j->chunk(), j->nextBatch(), j->prevBatch(), j->totalRoomCountEstimate() };
 };
 
 //! \brief Lists the public rooms on the server with optional filter.
@@ -182,6 +211,30 @@ public:
     {
         return loadFromJson<std::optional<int>>("total_room_count_estimate"_ls);
     }
+
+    struct Response {
+        //! A paginated chunk of public rooms.
+        QVector<PublicRoomsChunk> chunk{};
+
+        //! A pagination token for the response. The absence of this token
+        //! means there are no more results to fetch and the client should
+        //! stop paginating.
+        QString nextBatch{};
+
+        //! A pagination token that allows fetching previous results. The
+        //! absence of this token means there are no results before this
+        //! batch, i.e. this is the first batch.
+        QString prevBatch{};
+
+        //! An estimate on the total number of public rooms, if the
+        //! server has an estimate.
+        std::optional<int> totalRoomCountEstimate{};
+    };
+};
+
+template <std::derived_from<QueryPublicRoomsJob> JobT>
+constexpr inline auto doCollectResponse<JobT> = [](JobT* j) -> QueryPublicRoomsJob::Response {
+    return { j->chunk(), j->nextBatch(), j->prevBatch(), j->totalRoomCountEstimate() };
 };
 
 template <>

--- a/Quotient/csapi/login_token.h
+++ b/Quotient/csapi/login_token.h
@@ -57,6 +57,20 @@ public:
     //! The time remaining in milliseconds until the homeserver will no longer accept the token.
     //! `120000` (2 minutes) is recommended as a default.
     int expiresInMs() const { return loadFromJson<int>("expires_in_ms"_ls); }
+
+    struct Response {
+        //! The login token for the `m.login.token` login flow.
+        QString loginToken{};
+
+        //! The time remaining in milliseconds until the homeserver will no longer accept the token.
+        //! `120000` (2 minutes) is recommended as a default.
+        int expiresInMs{};
+    };
+};
+
+template <std::derived_from<GenerateLoginTokenJob> JobT>
+constexpr inline auto doCollectResponse<JobT> = [](JobT* j) -> GenerateLoginTokenJob::Response {
+    return { j->loginToken(), j->expiresInMs() };
 };
 
 } // namespace Quotient

--- a/Quotient/csapi/notifications.h
+++ b/Quotient/csapi/notifications.h
@@ -73,7 +73,21 @@ public:
     {
         return takeFromJson<std::vector<Notification>>("notifications"_ls);
     }
+
+    struct Response {
+        //! The token to supply in the `from` param of the next
+        //! `/notifications` request in order to request more
+        //! events. If this is absent, there are no more results.
+        QString nextToken{};
+
+        //! The list of events that triggered notifications.
+        std::vector<Notification> notifications{};
+    };
 };
+
+template <std::derived_from<GetNotificationsJob> JobT>
+constexpr inline auto doCollectResponse<JobT> =
+    [](JobT* j) -> GetNotificationsJob::Response { return { j->nextToken(), j->notifications() }; };
 
 template <>
 struct QUOTIENT_API JsonObjectConverter<GetNotificationsJob::Notification> {

--- a/Quotient/csapi/openid.h
+++ b/Quotient/csapi/openid.h
@@ -39,4 +39,6 @@ public:
     OpenIdCredentials tokenData() const { return fromJson<OpenIdCredentials>(jsonData()); }
 };
 
+inline auto collectResponse(const RequestOpenIdTokenJob* job) { return job->tokenData(); }
+
 } // namespace Quotient

--- a/Quotient/csapi/peeking_events.h
+++ b/Quotient/csapi/peeking_events.h
@@ -53,6 +53,23 @@ public:
 
     //! An array of events.
     RoomEvents chunk() { return takeFromJson<RoomEvents>("chunk"_ls); }
+
+    struct Response {
+        //! A token which correlates to the first value in `chunk`. This
+        //! is usually the same token supplied to `from=`.
+        QString begin{};
+
+        //! A token which correlates to the last value in `chunk`. This
+        //! token should be used in the next request to `/events`.
+        QString end{};
+
+        //! An array of events.
+        RoomEvents chunk{};
+    };
 };
+
+template <std::derived_from<PeekEventsJob> JobT>
+constexpr inline auto doCollectResponse<JobT> =
+    [](JobT* j) -> PeekEventsJob::Response { return { j->begin(), j->end(), j->chunk() }; };
 
 } // namespace Quotient

--- a/Quotient/csapi/presence.h
+++ b/Quotient/csapi/presence.h
@@ -61,6 +61,26 @@ public:
     {
         return loadFromJson<std::optional<bool>>("currently_active"_ls);
     }
+
+    struct Response {
+        //! This user's presence.
+        QString presence{};
+
+        //! The length of time in milliseconds since an action was performed
+        //! by this user.
+        std::optional<int> lastActiveAgo{};
+
+        //! The state message for this user if one was set.
+        QString statusMsg{};
+
+        //! Whether the user is currently active
+        std::optional<bool> currentlyActive{};
+    };
+};
+
+template <std::derived_from<GetPresenceJob> JobT>
+constexpr inline auto doCollectResponse<JobT> = [](JobT* j) -> GetPresenceJob::Response {
+    return { j->presence(), j->lastActiveAgo(), j->statusMsg(), j->currentlyActive() };
 };
 
 } // namespace Quotient

--- a/Quotient/csapi/profile.h
+++ b/Quotient/csapi/profile.h
@@ -43,6 +43,8 @@ public:
     QString displayname() const { return loadFromJson<QString>("displayname"_ls); }
 };
 
+inline auto collectResponse(const GetDisplayNameJob* job) { return job->displayname(); }
+
 //! \brief Set the user's avatar URL.
 //!
 //! This API sets the given user's avatar URL. You must have permission to
@@ -80,6 +82,8 @@ public:
     QUrl avatarUrl() const { return loadFromJson<QUrl>("avatar_url"_ls); }
 };
 
+inline auto collectResponse(const GetAvatarUrlJob* job) { return job->avatarUrl(); }
+
 //! \brief Get this user's profile information.
 //!
 //! Get the combined profile information for this user. This API may be used
@@ -105,6 +109,18 @@ public:
 
     //! The user's display name if they have set one, otherwise not present.
     QString displayname() const { return loadFromJson<QString>("displayname"_ls); }
+
+    struct Response {
+        //! The user's avatar URL if they have set one, otherwise not present.
+        QUrl avatarUrl{};
+
+        //! The user's display name if they have set one, otherwise not present.
+        QString displayname{};
+    };
 };
+
+template <std::derived_from<GetUserProfileJob> JobT>
+constexpr inline auto doCollectResponse<JobT> =
+    [](JobT* j) -> GetUserProfileJob::Response { return { j->avatarUrl(), j->displayname() }; };
 
 } // namespace Quotient

--- a/Quotient/csapi/pusher.h
+++ b/Quotient/csapi/pusher.h
@@ -76,6 +76,8 @@ public:
     QVector<Pusher> pushers() const { return loadFromJson<QVector<Pusher>>("pushers"_ls); }
 };
 
+inline auto collectResponse(const GetPushersJob* job) { return job->pushers(); }
+
 template <>
 struct QUOTIENT_API JsonObjectConverter<GetPushersJob::PusherData> {
     static void fillFrom(const QJsonObject& jo, GetPushersJob::PusherData& result)

--- a/Quotient/csapi/pushrules.h
+++ b/Quotient/csapi/pushrules.h
@@ -32,6 +32,8 @@ public:
     PushRuleset global() const { return loadFromJson<PushRuleset>("global"_ls); }
 };
 
+inline auto collectResponse(const GetPushRulesJob* job) { return job->global(); }
+
 //! \brief Retrieve a push rule.
 //!
 //! Retrieve a single specified push rule.
@@ -60,6 +62,8 @@ public:
     //! rule itself such as the rule's `actions` and `conditions` if set.
     PushRule pushRule() const { return fromJson<PushRule>(jsonData()); }
 };
+
+inline auto collectResponse(const GetPushRuleJob* job) { return job->pushRule(); }
 
 //! \brief Delete a push rule.
 //!
@@ -170,6 +174,8 @@ public:
     bool enabled() const { return loadFromJson<bool>("enabled"_ls); }
 };
 
+inline auto collectResponse(const IsPushRuleEnabledJob* job) { return job->enabled(); }
+
 //! \brief Enable or disable a push rule.
 //!
 //! This endpoint allows clients to enable or disable the specified push rule.
@@ -218,6 +224,8 @@ public:
     //! The action(s) to perform for this rule.
     QVector<QVariant> actions() const { return loadFromJson<QVector<QVariant>>("actions"_ls); }
 };
+
+inline auto collectResponse(const GetPushRuleActionsJob* job) { return job->actions(); }
 
 //! \brief Set the actions for a push rule.
 //!

--- a/Quotient/csapi/redaction.h
+++ b/Quotient/csapi/redaction.h
@@ -43,4 +43,6 @@ public:
     QString eventId() const { return loadFromJson<QString>("event_id"_ls); }
 };
 
+inline auto collectResponse(const RedactEventJob* job) { return job->eventId(); }
+
 } // namespace Quotient

--- a/Quotient/csapi/refresh.h
+++ b/Quotient/csapi/refresh.h
@@ -48,6 +48,26 @@ public:
     {
         return loadFromJson<std::optional<int>>("expires_in_ms"_ls);
     }
+
+    struct Response {
+        //! The new access token to use.
+        QString accessToken{};
+
+        //! The new refresh token to use when the access token needs to
+        //! be refreshed again. If not given, the old refresh token can
+        //! be re-used.
+        QString refreshToken{};
+
+        //! The lifetime of the access token, in milliseconds. If not
+        //! given, the client can assume that the access token will not
+        //! expire.
+        std::optional<int> expiresInMs{};
+    };
+};
+
+template <std::derived_from<RefreshJob> JobT>
+constexpr inline auto doCollectResponse<JobT> = [](JobT* j) -> RefreshJob::Response {
+    return { j->accessToken(), j->refreshToken(), j->expiresInMs() };
 };
 
 } // namespace Quotient

--- a/Quotient/csapi/registration.h
+++ b/Quotient/csapi/registration.h
@@ -134,6 +134,46 @@ public:
     //! corresponding parameter in the request, if one was specified.
     //! Required if the `inhibit_login` option is false.
     QString deviceId() const { return loadFromJson<QString>("device_id"_ls); }
+
+    struct Response {
+        //! The fully-qualified Matrix user ID (MXID) that has been registered.
+        //!
+        //! Any user ID returned by this API must conform to the grammar given in the
+        //! [Matrix specification](/appendices/#user-identifiers).
+        QString userId{};
+
+        //! An access token for the account.
+        //! This access token can then be used to authorize other requests.
+        //! Required if the `inhibit_login` option is false.
+        QString accessToken{};
+
+        //! A refresh token for the account. This token can be used to
+        //! obtain a new access token when it expires by calling the
+        //! `/refresh` endpoint.
+        //!
+        //! Omitted if the `inhibit_login` option is true.
+        QString refreshToken{};
+
+        //! The lifetime of the access token, in milliseconds. Once
+        //! the access token has expired a new access token can be
+        //! obtained by using the provided refresh token. If no
+        //! refresh token is provided, the client will need to re-log in
+        //! to obtain a new access token. If not given, the client can
+        //! assume that the access token will not expire.
+        //!
+        //! Omitted if the `inhibit_login` option is true.
+        std::optional<int> expiresInMs{};
+
+        //! ID of the registered device. Will be the same as the
+        //! corresponding parameter in the request, if one was specified.
+        //! Required if the `inhibit_login` option is false.
+        QString deviceId{};
+    };
+};
+
+template <std::derived_from<RegisterJob> JobT>
+constexpr inline auto doCollectResponse<JobT> = [](JobT* j) -> RegisterJob::Response {
+    return { j->userId(), j->accessToken(), j->refreshToken(), j->expiresInMs(), j->deviceId() };
 };
 
 //! \brief Begins the validation process for an email to be used during registration.
@@ -154,6 +194,8 @@ public:
     RequestTokenResponse response() const { return fromJson<RequestTokenResponse>(jsonData()); }
 };
 
+inline auto collectResponse(const RequestTokenToRegisterEmailJob* job) { return job->response(); }
+
 //! \brief Requests a validation token be sent to the given phone number for the purpose of
 //! registering an account
 //!
@@ -172,6 +214,8 @@ public:
     //! it may be informing the user of an error.
     RequestTokenResponse response() const { return fromJson<RequestTokenResponse>(jsonData()); }
 };
+
+inline auto collectResponse(const RequestTokenToRegisterMSISDNJob* job) { return job->response(); }
 
 //! \brief Changes a user's password.
 //!
@@ -234,6 +278,11 @@ public:
     RequestTokenResponse response() const { return fromJson<RequestTokenResponse>(jsonData()); }
 };
 
+inline auto collectResponse(const RequestTokenToResetPasswordEmailJob* job)
+{
+    return job->response();
+}
+
 //! \brief Requests a validation token be sent to the given phone number for the purpose of
 //! resetting a user's password.
 //!
@@ -261,6 +310,11 @@ public:
     //! An SMS message was sent to the given phone number.
     RequestTokenResponse response() const { return fromJson<RequestTokenResponse>(jsonData()); }
 };
+
+inline auto collectResponse(const RequestTokenToResetPasswordMSISDNJob* job)
+{
+    return job->response();
+}
 
 //! \brief Deactivate a user's account.
 //!
@@ -330,6 +384,8 @@ public:
     }
 };
 
+inline auto collectResponse(const DeactivateAccountJob* job) { return job->idServerUnbindResult(); }
+
 //! \brief Checks to see if a username is available on the server.
 //!
 //! Checks to see if a username is available, and valid, for the server.
@@ -365,5 +421,7 @@ public:
         return loadFromJson<std::optional<bool>>("available"_ls);
     }
 };
+
+inline auto collectResponse(const CheckUsernameAvailabilityJob* job) { return job->available(); }
 
 } // namespace Quotient

--- a/Quotient/csapi/registration_tokens.h
+++ b/Quotient/csapi/registration_tokens.h
@@ -34,4 +34,6 @@ public:
     bool valid() const { return loadFromJson<bool>("valid"_ls); }
 };
 
+inline auto collectResponse(const RegistrationTokenValidityJob* job) { return job->valid(); }
+
 } // namespace Quotient

--- a/Quotient/csapi/relations.h
+++ b/Quotient/csapi/relations.h
@@ -102,6 +102,29 @@ public:
 
     //! The child events of the requested event, ordered topologically most-recent first.
     RoomEvents chunk() { return takeFromJson<RoomEvents>("chunk"_ls); }
+
+    struct Response {
+        //! An opaque string representing a pagination token. The absence of this token
+        //! means there are no more results to fetch and the client should stop paginating.
+        QString nextBatch{};
+
+        //! An opaque string representing a pagination token. The absence of this token
+        //! means this is the start of the result set, i.e. this is the first batch/page.
+        QString prevBatch{};
+
+        //! If the `recurse` parameter was supplied by the client, this response field is
+        //! mandatory and gives the actual depth to which the server recursed. If the client
+        //! did not specify the `recurse` parameter, this field must be absent.
+        std::optional<int> recursionDepth{};
+
+        //! The child events of the requested event, ordered topologically most-recent first.
+        RoomEvents chunk{};
+    };
+};
+
+template <std::derived_from<GetRelatingEventsJob> JobT>
+constexpr inline auto doCollectResponse<JobT> = [](JobT* j) -> GetRelatingEventsJob::Response {
+    return { j->nextBatch(), j->prevBatch(), j->recursionDepth(), j->chunk() };
 };
 
 //! \brief Get the child events for a given parent event, with a given `relType`.
@@ -207,6 +230,32 @@ public:
     //! most-recent first. The events returned will match the `relType`
     //! supplied in the URL.
     RoomEvents chunk() { return takeFromJson<RoomEvents>("chunk"_ls); }
+
+    struct Response {
+        //! An opaque string representing a pagination token. The absence of this token
+        //! means there are no more results to fetch and the client should stop paginating.
+        QString nextBatch{};
+
+        //! An opaque string representing a pagination token. The absence of this token
+        //! means this is the start of the result set, i.e. this is the first batch/page.
+        QString prevBatch{};
+
+        //! If the `recurse` parameter was supplied by the client, this response field is
+        //! mandatory and gives the actual depth to which the server recursed. If the client
+        //! did not specify the `recurse` parameter, this field must be absent.
+        std::optional<int> recursionDepth{};
+
+        //! The child events of the requested event, ordered topologically
+        //! most-recent first. The events returned will match the `relType`
+        //! supplied in the URL.
+        RoomEvents chunk{};
+    };
+};
+
+template <std::derived_from<GetRelatingEventsWithRelTypeJob> JobT>
+constexpr inline auto doCollectResponse<JobT> =
+    [](JobT* j) -> GetRelatingEventsWithRelTypeJob::Response {
+    return { j->nextBatch(), j->prevBatch(), j->recursionDepth(), j->chunk() };
 };
 
 //! \brief Get the child events for a given parent event, with a given `relType` and `eventType`.
@@ -318,6 +367,32 @@ public:
     //! first. The events returned will match the `relType` and `eventType` supplied
     //! in the URL.
     RoomEvents chunk() { return takeFromJson<RoomEvents>("chunk"_ls); }
+
+    struct Response {
+        //! An opaque string representing a pagination token. The absence of this token
+        //! means there are no more results to fetch and the client should stop paginating.
+        QString nextBatch{};
+
+        //! An opaque string representing a pagination token. The absence of this token
+        //! means this is the start of the result set, i.e. this is the first batch/page.
+        QString prevBatch{};
+
+        //! If the `recurse` parameter was supplied by the client, this response field is
+        //! mandatory and gives the actual depth to which the server recursed. If the client
+        //! did not specify the `recurse` parameter, this field must be absent.
+        std::optional<int> recursionDepth{};
+
+        //! The child events of the requested event, ordered topologically most-recent
+        //! first. The events returned will match the `relType` and `eventType` supplied
+        //! in the URL.
+        RoomEvents chunk{};
+    };
+};
+
+template <std::derived_from<GetRelatingEventsWithRelTypeAndEventTypeJob> JobT>
+constexpr inline auto doCollectResponse<JobT> =
+    [](JobT* j) -> GetRelatingEventsWithRelTypeAndEventTypeJob::Response {
+    return { j->nextBatch(), j->prevBatch(), j->recursionDepth(), j->chunk() };
 };
 
 } // namespace Quotient

--- a/Quotient/csapi/room_event_by_timestamp.h
+++ b/Quotient/csapi/room_event_by_timestamp.h
@@ -61,6 +61,22 @@ public:
     //! `event_id` fetched is too far out of range to be useful for your
     //! use case.
     int originServerTimestamp() const { return loadFromJson<int>("origin_server_ts"_ls); }
+
+    struct Response {
+        //! The ID of the event found
+        QString eventId{};
+
+        //! The event's timestamp, in milliseconds since the Unix epoch.
+        //! This makes it easy to do a quick comparison to see if the
+        //! `event_id` fetched is too far out of range to be useful for your
+        //! use case.
+        int originServerTimestamp{};
+    };
+};
+
+template <std::derived_from<GetEventByTimestampJob> JobT>
+constexpr inline auto doCollectResponse<JobT> = [](JobT* j) -> GetEventByTimestampJob::Response {
+    return { j->eventId(), j->originServerTimestamp() };
 };
 
 } // namespace Quotient

--- a/Quotient/csapi/room_send.h
+++ b/Quotient/csapi/room_send.h
@@ -37,4 +37,6 @@ public:
     QString eventId() const { return loadFromJson<QString>("event_id"_ls); }
 };
 
+inline auto collectResponse(const SendMessageJob* job) { return job->eventId(); }
+
 } // namespace Quotient

--- a/Quotient/csapi/room_state.h
+++ b/Quotient/csapi/room_state.h
@@ -46,4 +46,6 @@ public:
     QString eventId() const { return loadFromJson<QString>("event_id"_ls); }
 };
 
+inline auto collectResponse(const SetRoomStateWithKeyJob* job) { return job->eventId(); }
+
 } // namespace Quotient

--- a/Quotient/csapi/room_upgrades.h
+++ b/Quotient/csapi/room_upgrades.h
@@ -24,4 +24,6 @@ public:
     QString replacementRoom() const { return loadFromJson<QString>("replacement_room"_ls); }
 };
 
+inline auto collectResponse(const UpgradeRoomJob* job) { return job->replacementRoom(); }
+
 } // namespace Quotient

--- a/Quotient/csapi/rooms.h
+++ b/Quotient/csapi/rooms.h
@@ -33,6 +33,8 @@ public:
     RoomEventPtr event() { return fromJson<RoomEventPtr>(jsonData()); }
 };
 
+inline auto collectResponse(GetOneRoomEventJob* job) { return job->event(); }
+
 //! \brief Get the state identified by the type and key.
 //!
 //! Looks up the contents of a state event in a room. If the user is
@@ -66,6 +68,8 @@ public:
     QJsonObject content() const { return fromJson<QJsonObject>(jsonData()); }
 };
 
+inline auto collectResponse(const GetRoomStateWithKeyJob* job) { return job->content(); }
+
 //! \brief Get all state events in the current state of a room.
 //!
 //! Get the state events for the current state of a room.
@@ -86,6 +90,8 @@ public:
     //! The current state of the room
     StateEvents events() { return fromJson<StateEvents>(jsonData()); }
 };
+
+inline auto collectResponse(GetRoomStateJob* job) { return job->events(); }
 
 //! \brief Get the m.room.member events for the room.
 //!
@@ -124,6 +130,8 @@ public:
 
     StateEvents chunk() { return takeFromJson<StateEvents>("chunk"_ls); }
 };
+
+inline auto collectResponse(GetMembersByRoomJob* job) { return job->chunk(); }
 
 //! \brief Gets the list of currently joined users and their profile data.
 //!
@@ -164,6 +172,8 @@ public:
         return loadFromJson<QHash<QString, RoomMember>>("joined"_ls);
     }
 };
+
+inline auto collectResponse(const GetJoinedMembersByRoomJob* job) { return job->joined(); }
 
 template <>
 struct QUOTIENT_API JsonObjectConverter<GetJoinedMembersByRoomJob::RoomMember> {

--- a/Quotient/csapi/search.h
+++ b/Quotient/csapi/search.h
@@ -198,6 +198,8 @@ public:
     }
 };
 
+inline auto collectResponse(const SearchJob* job) { return job->searchCategories(); }
+
 template <>
 struct QUOTIENT_API JsonObjectConverter<SearchJob::IncludeEventContext> {
     static void dumpTo(QJsonObject& jo, const SearchJob::IncludeEventContext& pod)

--- a/Quotient/csapi/space_hierarchy.h
+++ b/Quotient/csapi/space_hierarchy.h
@@ -115,7 +115,20 @@ public:
     //! A token to supply to `from` to keep paginating the responses. Not present when there are
     //! no further results.
     QString nextBatch() const { return loadFromJson<QString>("next_batch"_ls); }
+
+    struct Response {
+        //! The rooms for the current page, with the current filters.
+        std::vector<SpaceHierarchyRoomsChunk> rooms{};
+
+        //! A token to supply to `from` to keep paginating the responses. Not present when there are
+        //! no further results.
+        QString nextBatch{};
+    };
 };
+
+template <std::derived_from<GetSpaceHierarchyJob> JobT>
+constexpr inline auto doCollectResponse<JobT> =
+    [](JobT* j) -> GetSpaceHierarchyJob::Response { return { j->rooms(), j->nextBatch() }; };
 
 template <>
 struct QUOTIENT_API JsonObjectConverter<GetSpaceHierarchyJob::SpaceHierarchyRoomsChunk> {

--- a/Quotient/csapi/support.h
+++ b/Quotient/csapi/support.h
@@ -76,7 +76,26 @@ public:
     //!
     //! At least one of `contacts` or `support_page` is required.
     QString supportPage() const { return loadFromJson<QString>("support_page"_ls); }
+
+    struct Response {
+        //! Ways to contact the server administrator.
+        //!
+        //! At least one of `contacts` or `support_page` is required.
+        //! If only `contacts` is set, it must contain at least one
+        //! item.
+        QVector<Contact> contacts{};
+
+        //! The URL of a page to give users help specific to the
+        //! homeserver, like extra login/registration steps.
+        //!
+        //! At least one of `contacts` or `support_page` is required.
+        QString supportPage{};
+    };
 };
+
+template <std::derived_from<GetWellknownSupportJob> JobT>
+constexpr inline auto doCollectResponse<JobT> =
+    [](JobT* j) -> GetWellknownSupportJob::Response { return { j->contacts(), j->supportPage() }; };
 
 template <>
 struct QUOTIENT_API JsonObjectConverter<GetWellknownSupportJob::Contact> {

--- a/Quotient/csapi/tags.h
+++ b/Quotient/csapi/tags.h
@@ -42,6 +42,8 @@ public:
     QHash<QString, Tag> tags() const { return loadFromJson<QHash<QString, Tag>>("tags"_ls); }
 };
 
+inline auto collectResponse(const GetRoomTagsJob* job) { return job->tags(); }
+
 template <>
 struct QUOTIENT_API JsonObjectConverter<GetRoomTagsJob::Tag> {
     static void fillFrom(QJsonObject jo, GetRoomTagsJob::Tag& result)

--- a/Quotient/csapi/third_party_lookup.h
+++ b/Quotient/csapi/third_party_lookup.h
@@ -34,6 +34,8 @@ public:
     }
 };
 
+inline auto collectResponse(const GetProtocolsJob* job) { return job->protocols(); }
+
 //! \brief Retrieve metadata about a specific protocol that the homeserver supports.
 //!
 //! Fetches the metadata from the homeserver about a particular third-party protocol.
@@ -54,6 +56,8 @@ public:
     //! The protocol was found and metadata returned.
     ThirdPartyProtocol data() const { return fromJson<ThirdPartyProtocol>(jsonData()); }
 };
+
+inline auto collectResponse(const GetProtocolMetadataJob* job) { return job->data(); }
 
 //! \brief Retrieve Matrix-side portals rooms leading to a third-party location.
 //!
@@ -91,6 +95,8 @@ public:
     }
 };
 
+inline auto collectResponse(const QueryLocationByProtocolJob* job) { return job->data(); }
+
 //! \brief Retrieve the Matrix User ID of a corresponding third-party user.
 //!
 //! Retrieve a Matrix User ID linked to a user on the third-party service, given
@@ -118,6 +124,8 @@ public:
     QVector<ThirdPartyUser> data() const { return fromJson<QVector<ThirdPartyUser>>(jsonData()); }
 };
 
+inline auto collectResponse(const QueryUserByProtocolJob* job) { return job->data(); }
+
 //! \brief Reverse-lookup third-party locations given a Matrix room alias.
 //!
 //! Retrieve an array of third-party network locations from a Matrix room
@@ -143,6 +151,8 @@ public:
     }
 };
 
+inline auto collectResponse(const QueryLocationByAliasJob* job) { return job->data(); }
+
 //! \brief Reverse-lookup third-party users given a Matrix User ID.
 //!
 //! Retrieve an array of third-party users from a Matrix User ID.
@@ -163,5 +173,7 @@ public:
     //! An array of third-party users.
     QVector<ThirdPartyUser> data() const { return fromJson<QVector<ThirdPartyUser>>(jsonData()); }
 };
+
+inline auto collectResponse(const QueryUserByIDJob* job) { return job->data(); }
 
 } // namespace Quotient

--- a/Quotient/csapi/threads_list.h
+++ b/Quotient/csapi/threads_list.h
@@ -60,6 +60,26 @@ public:
     //! A token to supply to `from` to keep paginating the responses. Not present when there are
     //! no further results.
     QString nextBatch() const { return loadFromJson<QString>("next_batch"_ls); }
+
+    struct Response {
+        //! The thread roots, ordered by the `latest_event` in each event's aggregated children. All
+        //! events returned include bundled
+        //! [aggregations](/client-server-api/#aggregations-of-child-events).
+        //!
+        //! If the thread root event was sent by an [ignored
+        //! user](/client-server-api/#ignoring-users), the event is returned redacted to the caller.
+        //! This is to simulate the same behaviour of a client doing aggregation locally on the
+        //! thread.
+        RoomEvents chunk{};
+
+        //! A token to supply to `from` to keep paginating the responses. Not present when there are
+        //! no further results.
+        QString nextBatch{};
+    };
 };
+
+template <std::derived_from<GetThreadRootsJob> JobT>
+constexpr inline auto doCollectResponse<JobT> =
+    [](JobT* j) -> GetThreadRootsJob::Response { return { j->chunk(), j->nextBatch() }; };
 
 } // namespace Quotient

--- a/Quotient/csapi/users.h
+++ b/Quotient/csapi/users.h
@@ -51,7 +51,19 @@ public:
 
     //! Indicates if the result list has been truncated by the limit.
     bool limited() const { return loadFromJson<bool>("limited"_ls); }
+
+    struct Response {
+        //! Ordered by rank and then whether or not profile info is available.
+        QVector<User> results{};
+
+        //! Indicates if the result list has been truncated by the limit.
+        bool limited{};
+    };
 };
+
+template <std::derived_from<SearchUserDirectoryJob> JobT>
+constexpr inline auto doCollectResponse<JobT> =
+    [](JobT* j) -> SearchUserDirectoryJob::Response { return { j->results(), j->limited() }; };
 
 template <>
 struct QUOTIENT_API JsonObjectConverter<SearchUserDirectoryJob::User> {

--- a/Quotient/csapi/versions.h
+++ b/Quotient/csapi/versions.h
@@ -52,6 +52,20 @@ public:
     {
         return loadFromJson<QHash<QString, bool>>("unstable_features"_ls);
     }
+
+    struct Response {
+        //! The supported versions.
+        QStringList versions{};
+
+        //! Experimental features the server supports. Features not listed here,
+        //! or the lack of this property all together, indicate that a feature is
+        //! not supported.
+        QHash<QString, bool> unstableFeatures{};
+    };
 };
+
+template <std::derived_from<GetVersionsJob> JobT>
+constexpr inline auto doCollectResponse<JobT> =
+    [](JobT* j) -> GetVersionsJob::Response { return { j->versions(), j->unstableFeatures() }; };
 
 } // namespace Quotient

--- a/Quotient/csapi/voip.h
+++ b/Quotient/csapi/voip.h
@@ -26,4 +26,6 @@ public:
     QJsonObject data() const { return fromJson<QJsonObject>(jsonData()); }
 };
 
+inline auto collectResponse(const GetTurnServerJob* job) { return job->data(); }
+
 } // namespace Quotient

--- a/Quotient/csapi/wellknown.h
+++ b/Quotient/csapi/wellknown.h
@@ -34,4 +34,6 @@ public:
     DiscoveryInformation data() const { return fromJson<DiscoveryInformation>(jsonData()); }
 };
 
+inline auto collectResponse(const GetWellknownJob* job) { return job->data(); }
+
 } // namespace Quotient

--- a/Quotient/csapi/whoami.h
+++ b/Quotient/csapi/whoami.h
@@ -41,6 +41,27 @@ public:
     //! not present or `false`, the user is presumed to be a non-guest
     //! user.
     std::optional<bool> isGuest() const { return loadFromJson<std::optional<bool>>("is_guest"_ls); }
+
+    struct Response {
+        //! The user ID that owns the access token.
+        QString userId{};
+
+        //! Device ID associated with the access token. If no device
+        //! is associated with the access token (such as in the case
+        //! of application services) then this field can be omitted.
+        //! Otherwise this is required.
+        QString deviceId{};
+
+        //! When `true`, the user is a [Guest User](#guest-access). When
+        //! not present or `false`, the user is presumed to be a non-guest
+        //! user.
+        std::optional<bool> isGuest{};
+    };
+};
+
+template <std::derived_from<GetTokenOwnerJob> JobT>
+constexpr inline auto doCollectResponse<JobT> = [](JobT* j) -> GetTokenOwnerJob::Response {
+    return { j->userId(), j->deviceId(), j->isGuest() };
 };
 
 } // namespace Quotient

--- a/Quotient/jobs/basejob.cpp
+++ b/Quotient/jobs/basejob.cpp
@@ -800,6 +800,13 @@ void BaseJob::setStatus(int code, QString message)
     setStatus({ code, std::move(message) });
 }
 
+void BaseJob::forceResult(QJsonDocument resultDoc, Status s)
+{
+    d->jsonResponse = std::move(resultDoc);
+    setStatus(std::move(s));
+    QMetaObject::invokeMethod(this, [this] { finishJob(); }, Qt::QueuedConnection);
+}
+
 void BaseJob::abandon()
 {
     beforeAbandon();

--- a/Quotient/jobs/basejob.h
+++ b/Quotient/jobs/basejob.h
@@ -422,6 +422,12 @@ protected:
     void setStatus(Status s);
     void setStatus(int code, QString message);
 
+    //! \brief Force completion of the job for sake of testing
+    //!
+    //! Normal jobs should never use; this is only meant to be used in test mocks.
+    //! \sa Mocked
+    void forceResult(QJsonDocument resultDoc, Status s = { Success });
+
     //! \brief Set the logging category for the given job instance
     //!
     //! \param lcf The logging category function to provide the category -
@@ -476,4 +482,12 @@ inline bool QUOTIENT_API isJobPending(BaseJob* job)
 {
     return job && job->error() == BaseJob::Pending;
 }
+
+template <std::derived_from<BaseJob> JobT>
+class Mocked : public JobT {
+public:
+    using JobT::JobT;
+    void setResult(QJsonDocument d) { JobT::forceResult(std::move(d)); }
+};
+
 } // namespace Quotient

--- a/Quotient/jobs/basejob.h
+++ b/Quotient/jobs/basejob.h
@@ -483,6 +483,24 @@ inline bool QUOTIENT_API isJobPending(BaseJob* job)
     return job && job->error() == BaseJob::Pending;
 }
 
+template <typename JobT>
+constexpr inline auto doCollectResponse = nullptr;
+
+//! \brief Get a job response in a single structure
+//!
+//! Use this to get all parts of the job response in a single C++ type, defined by the job class.
+//! It can be either an aggregate of individual response parts returned by job accessors, or, if
+//! the response is already singular, a type of this response. The default implementation caters to
+//! generated jobs, where the code has to be generic enough to work with copyable and movable-only
+//! responses. For manually written code, simply overload collectResponse() for the respective
+//! job type, with appropriate constness.
+template <std::derived_from<BaseJob> JobT>
+inline auto collectResponse(JobT* job)
+    requires requires { doCollectResponse<JobT>(job); }
+{
+    return doCollectResponse<JobT>(job);
+}
+
 template <std::derived_from<BaseJob> JobT>
 class Mocked : public JobT {
 public:

--- a/Quotient/jobs/mediathumbnailjob.h
+++ b/Quotient/jobs/mediathumbnailjob.h
@@ -28,4 +28,7 @@ protected:
 private:
     QImage _thumbnail;
 };
+
+inline auto collectResponse(const MediaThumbnailJob* j) { return j->thumbnail(); }
+
 } // namespace Quotient

--- a/autotests/testcrosssigning.cpp
+++ b/autotests/testcrosssigning.cpp
@@ -23,10 +23,12 @@ private Q_SLOTS:
         file.open(QIODevice::ReadOnly);
         auto data = file.readAll();
         QVERIFY(!data.isEmpty());
-        auto json = QJsonDocument::fromJson(data).object();
+        auto jobMock = Mocked<QueryKeysJob>(QHash<QString, QStringList>{});
+        jobMock.setResult(QJsonDocument::fromJson(data));
+        auto mockKeys = collectResponse(&jobMock);
 
         auto connection = Connection::makeMockConnection("@tobiasfella:kde.org"_ls, true);
-        connection->d->encryptionData->handleQueryKeys(json);
+        connection->d->encryptionData->handleQueryKeys(mockKeys);
 
         QVERIFY(!connection->isUserVerified("@tobiasfella:kde.org"_ls));
         QVERIFY(!connection->isUserVerified("@carl:kde.org"_ls));
@@ -35,7 +37,7 @@ private Q_SLOTS:
         QVERIFY(!connection->isVerifiedDevice("@tobiasfella:kde.org"_ls, "LTLVYDIVMO"_ls));
         connection->database()->setMasterKeyVerified("iiNvK2+mJtBXj6t+FVnaPBZ4e/M/n84wPJBfUVN38OE"_ls);
         QVERIFY(connection->isUserVerified("@tobiasfella:kde.org"_ls));
-        connection->d->encryptionData->handleQueryKeys(json);
+        connection->d->encryptionData->handleQueryKeys(mockKeys);
 
         QVERIFY(connection->isUserVerified("@tobiasfella:kde.org"_ls));
         QVERIFY(connection->isUserVerified("@aloy:kde.org"_ls));

--- a/gtad/gtad.yaml
+++ b/gtad/gtad.yaml
@@ -231,6 +231,13 @@ mustache:
       {{>docCommentShort}}
       {{>maybeOptionalType}} {{paramName}}(){{^moveOnly}} const{{/moveOnly}}
 
+    overloadCollectResponse: |-
+
+      inline auto collectResponse({{^moveOnly}}const {{/moveOnly}}{{>titleCaseOperationId}}Job* job)
+      {
+        return job->{{paramName}}();
+      }
+
     # Doc-comment blocks. Comment indent is managed by clang-format
     # (without clang-format there'd have to be a separate partial definition
     # for each indent...) but we take care of line breaks to maintain

--- a/gtad/operation.h.mustache
+++ b/gtad/operation.h.mustache
@@ -56,8 +56,8 @@ public:
         {{/headers}}{{#inlineResponse}}
 
     {{>docCommentShort}}
-    {{dataType.name}} {{paramName}}()
-    {{^moveOnly}}{{^producesNonJson?}} const{{/producesNonJson?}}{{/moveOnly}}
+    {{dataType.name}} {{paramName}}(){{^moveOnly}}{{^producesNonJson?}}
+    const{{/producesNonJson?}}{{/moveOnly}}
     {
         return {{#producesNonJson?}}reply(){{/producesNonJson?}}
             {{^producesNonJson?
@@ -65,15 +65,36 @@ public:
             }};
     }
         {{/inlineResponse}}{{#properties}}
+            {{!there's nothing in #properties if the response is inline}}
 
-    {{!there's nothing in #properties if the response is inline}}
     {{>nonInlineResponseSignature}}
     {
         return {{>takeOrLoad}}FromJson<{{>maybeOptionalType}}>("{{baseName}}"_ls);
     }
-        {{/properties}}
+        {{/properties}}{{^singleValue?}}{{#properties?}}
+
+    struct Response { {{#properties}}
+        {{>docCommentShort}}
+        {{>maybeOptionalType}} {{paramName}}{};
+
+            {{/properties}}
+    };
+        {{/properties?}}{{/singleValue?}}
     {{/allProperties?}}{{/normalResponse?}}{{/responses}}
 };
+    {{#responses}}{{#normalResponse?}}{{#allProperties?}}
+        {{#inlineResponse}}{{^producesNonJson?}}
+            {{>overloadCollectResponse}}
+        {{/producesNonJson?}}{{/inlineResponse}}{{#singleValue?}}{{#properties}}
+            {{>overloadCollectResponse}}
+        {{/properties}}{{/singleValue?}}{{^singleValue?}}{{#properties?}}
+
+template <std::derived_from<{{>titleCaseOperationId}}Job> JobT>
+constexpr inline auto doCollectResponse<JobT> =
+    [](JobT* j) -> {{>titleCaseOperationId}}Job::Response {
+        return { {{#properties}}j->{{paramName}}(){{>cjoin}}{{/properties}} };
+    };  {{/properties?}}{{/singleValue?}}
+    {{/allProperties?}}{{/normalResponse?}}{{/responses}}
     {{#models.model}}
 
 template <> struct QUOTIENT_API JsonObjectConverter<{{qualifiedName}}> {


### PR DESCRIPTION
1. Jobs can be mocked for tests now.
2. You don't need to deal with job pointers in your result handlers any more - just get the job result as a C++ object, either via `JobHandle::responseFuture()` or as a parameter passed to the continuation function. `JobHandle` will retrieve all the results for you, and you don't need to think whether you should copy or move them, whether the job should be `const` or not etc.