### PR TITLE
Add signal for setting up cross signing keys

### DIFF
--- a/Quotient/connection.h
+++ b/Quotient/connection.h
@@ -901,6 +901,10 @@ Q_SIGNALS:
 
     void userVerified(const QString& userId);
 
+    //! The account does not yet have cross-signing keys. The client should ask the user
+    //! whether to create them now and then set them up, if desired.
+    void crossSigningSetupRequired();
+
     friend class ::TestCrossSigning;
 protected:
     //! Access the underlying ConnectionData class

--- a/Quotient/connectionencryptiondata_p.cpp
+++ b/Quotient/connectionencryptiondata_p.cpp
@@ -268,6 +268,15 @@ void ConnectionEncryptionData::onSyncSuccess(SyncData& syncResponse)
     }
 
     consumeDevicesList(syncResponse.takeDevicesList());
+
+    auto checkQuery = database.prepareQuery("SELECT * FROM master_keys WHERE userId=:userId"_ls);
+    checkQuery.bindValue(":userId"_ls, q->userId());
+    database.execute(checkQuery);
+    const auto haveMasterKey = checkQuery.next();
+    if (trackedUsers.contains(q->userId()) && !outdatedUsers.contains(q->userId()) && !haveMasterKey) {
+        emit q->crossSigningSetupRequired();
+    }
+
 }
 
 void ConnectionEncryptionData::consumeDevicesList(const DevicesList& devicesList)


### PR DESCRIPTION
This signals to the user that the account does not yet have cross-signing keys. Ideally, the app could then just call `Connection::setupCrossSigning`, but I'm afraid we're lacking high-level access to user-interactive authentication to do that in the library...