### PR TITLE
Add a promise/future pair to PendingEventItem

### DIFF
--- a/Quotient/room.h
+++ b/Quotient/room.h
@@ -657,6 +657,8 @@ public:
     /// \brief Get the current room state
     RoomStateView currentState() const;
 
+    PendingEventItem::future_type whenMessageMerged(QString txnId) const;
+
     //! Send a request to update the room state with the given event
     SetRoomStateWithKeyJob* setState(const StateEvent& evt);
 

--- a/Quotient/room.h
+++ b/Quotient/room.h
@@ -657,6 +657,21 @@ public:
     /// \brief Get the current room state
     RoomStateView currentState() const;
 
+    //! \brief Post a pre-created room message event
+    //!
+    //! Takes ownership of the event, deleting it once the matching one arrives with the sync.
+    //! \note Do not assume that the event is already on the road to the homeserver when this (or
+    //!       any other `post*`) method returns; it can be queued internally.
+    //! \sa PendingEventItem::deliveryStatus()
+    //! \return a reference to the pending event item
+    const PendingEventItem& post(RoomEventPtr event);
+
+    template <typename EvT, typename... ArgTs>
+    const PendingEventItem& post(ArgTs&&... args)
+    {
+        return post(makeEvent<EvT>(std::forward<ArgTs>(args)...));
+    }
+
     PendingEventItem::future_type whenMessageMerged(QString txnId) const;
 
     //! Send a request to update the room state with the given event
@@ -705,6 +720,7 @@ public Q_SLOTS:
      * arrives with the sync
      * \return transaction id associated with the event.
      */
+    [[deprecated("Use post() instead")]]
     QString postEvent(RoomEvent* event);
     QString postJson(const QString& matrixType, const QJsonObject& eventContent);
     QString retryMessage(const QString& txnId);

--- a/quotest/quotest.cpp
+++ b/quotest/quotest.cpp
@@ -509,13 +509,13 @@ DEFINE_SIMPLE_EVENT(CustomEvent, RoomEvent, "quotest.custom", int, testValue,
 
 TEST_IMPL(sendCustomEvent)
 {
-    auto txnId = targetRoom->postEvent(new CustomEvent(42));
-    if (!validatePendingEvent<CustomEvent>(txnId)) {
+    const auto& pendingEventItem = targetRoom->post<CustomEvent>(42);
+    if (!validatePendingEvent<CustomEvent>(pendingEventItem->transactionId())) {
         clog << "Invalid pending event right after submitting" << endl;
         FAIL_TEST();
     }
-    targetRoom->whenMessageMerged(txnId).then(
-        this, [this, thisTest, txnId](const RoomEvent& evt) {
+    pendingEventItem.whenMerged().then(
+        this, [this, thisTest, txnId = pendingEventItem->transactionId()](const RoomEvent& evt) {
             evt.switchOnType(
                 [this, thisTest, txnId, &evt](const CustomEvent& e) {
                     FINISH_TEST(!evt.id().isEmpty() && evt.transactionId() == txnId

--- a/quotest/quotest.cpp
+++ b/quotest/quotest.cpp
@@ -342,18 +342,15 @@ TEST_IMPL(sendMessage)
         clog << "Invalid pending event right after submitting" << endl;
         FAIL_TEST();
     }
-    connectUntil(targetRoom, &Room::pendingEventAboutToMerge, this,
-        [this, thisTest, txnId](const RoomEvent* evt, int pendingIdx) {
-            const auto& pendingEvents = targetRoom->pendingEvents();
-            Q_ASSERT(pendingIdx >= 0 && pendingIdx < int(pendingEvents.size()));
-
-            if (evt->transactionId() != txnId)
-                return false;
-
-            FINISH_TEST(is<RoomMessageEvent>(*evt) && !evt->id().isEmpty()
-                        && pendingEvents[size_t(pendingIdx)]->transactionId()
-                               == evt->transactionId());
-        });
+    targetRoom->whenMessageMerged(txnId).then(this, [this, thisTest, txnId](const RoomEvent& evt) {
+        const auto pendingIt = targetRoom->findPendingEvent(txnId);
+        if (pendingIt == targetRoom->pendingEvents().end()) {
+            clog << "Pending event not found at the moment of local echo merging\n";
+            FAIL_TEST();
+        }
+        FINISH_TEST(evt.is<RoomMessageEvent>() && !evt.id().isEmpty()
+                    && txnId == (*pendingIt)->transactionId() && txnId == evt.transactionId());
+    });
     return false;
 }
 
@@ -490,28 +487,17 @@ bool TestSuite::checkFileSendingOutcome(const TestToken& thisTest,
         FAIL_TEST();
     }
 
-    connectUntil(targetRoom, &Room::pendingEventAboutToMerge, this,
-        [this, thisTest, txnId, fileName](const RoomEvent* evt, int pendingIdx) {
-            const auto& pendingEvents = targetRoom->pendingEvents();
-            Q_ASSERT(pendingIdx >= 0 && pendingIdx < int(pendingEvents.size()));
-
-            if (evt->transactionId() != txnId)
-                return false;
-
-            clog << "File event " << txnId.toStdString()
-                 << " arrived in the timeline" << endl;
-            return switchOnType(
-                *evt,
+    targetRoom->whenMessageMerged(txnId).then(
+        this, [this, thisTest, txnId, fileName](const RoomEvent& evt) {
+            clog << "File event " << txnId.toStdString() << " arrived in the timeline" << endl;
+            evt.switchOnType(
                 [&](const RoomMessageEvent& e) {
                     // TODO: check #366 once #368 is implemented
-                    FINISH_TEST(
-                        !e.id().isEmpty()
-                        && pendingEvents[size_t(pendingIdx)]->transactionId()
-                               == txnId
-                        && e.hasFileContent()
-                        && e.content()->fileInfo()->originalName == fileName
-                        && testDownload(targetRoom->connection()->makeMediaUrl(
-                            e.content()->fileInfo()->url())));
+                    FINISH_TEST(!e.id().isEmpty() && evt.transactionId() == txnId
+                                && e.hasFileContent()
+                                && e.content()->fileInfo()->originalName == fileName
+                                && testDownload(targetRoom->connection()->makeMediaUrl(
+                                    e.content()->fileInfo()->url())));
                 },
                 [this, thisTest](const RoomEvent&) { FAIL_TEST(); });
         });
@@ -528,20 +514,14 @@ TEST_IMPL(sendCustomEvent)
         clog << "Invalid pending event right after submitting" << endl;
         FAIL_TEST();
     }
-    connectUntil(
-        targetRoom, &Room::pendingEventAboutToMerge, this,
-        [this, thisTest, txnId](const RoomEvent* evt, int pendingIdx) {
-            const auto& pendingEvents = targetRoom->pendingEvents();
-            Q_ASSERT(pendingIdx >= 0 && pendingIdx < int(pendingEvents.size()));
-
-            if (evt->transactionId() != txnId)
-                return false;
-
-            return switchOnType(*evt,
-                [this, thisTest, &evt](const CustomEvent& e) {
-                    FINISH_TEST(!evt->id().isEmpty() && e.testValue() == 42);
+    targetRoom->whenMessageMerged(txnId).then(
+        this, [this, thisTest, txnId](const RoomEvent& evt) {
+            evt.switchOnType(
+                [this, thisTest, txnId, &evt](const CustomEvent& e) {
+                    FINISH_TEST(!evt.id().isEmpty() && evt.transactionId() == txnId
+                                && e.testValue() == 42);
                 },
-                [this, thisTest] (const RoomEvent&) { FAIL_TEST(); });
+                [this, thisTest](const RoomEvent&) { FAIL_TEST(); });
         });
     return false;
 


### PR DESCRIPTION
`PendingEventItem` screams that it has semantics of a future even with its name - now one can obtain a future from it and do useful things in `then()`, instead of connecting to `pendingEvent*` signals. The downside - the future carries no information about the pending item index so it seems of limited use in event item models.