### PR TITLE
RoomMember PowerLevel

### DIFF
--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -1522,6 +1522,22 @@ RoomStateView Room::currentState() const
     return d->currentState;
 }
 
+int Room::memberEffectivePowerLevel(const QString& memberId) const
+{
+    if (!successorId().isEmpty()) {
+        return 0; // No one can upgrade a room that's already upgraded
+    }
+
+    const auto& mId = memberId.isEmpty() ? connection()->userId() :memberId;
+    if (const auto* plEvent = currentState().get<RoomPowerLevelsEvent>()) {
+        return plEvent->powerLevelForUser(mId);
+    }
+    if (const auto* createEvent = creation()) {
+        return createEvent->senderId() == mId ? 100 : 0;
+    }
+    return 0; // That's rather weird but may happen, according to rvdh
+}
+
 RoomEventPtr Room::decryptMessage(const EncryptedEvent& encryptedEvent)
 {
     if (const auto algorithm = encryptedEvent.algorithm();

--- a/Quotient/room.h
+++ b/Quotient/room.h
@@ -142,6 +142,7 @@ class QUOTIENT_API Room : public QObject {
     Q_PROPERTY(int totalMemberCount READ totalMemberCount NOTIFY memberListChanged)
     Q_PROPERTY(QList<RoomMember> membersTyping READ membersTyping NOTIFY typingChanged)
     Q_PROPERTY(QList<RoomMember> otherMembersTyping READ otherMembersTyping NOTIFY typingChanged)
+    Q_PROPERTY(int localMemberEffectivePowerLevel READ memberEffectivePowerLevel NOTIFY changed)
 
     Q_PROPERTY(bool displayed READ displayed WRITE setDisplayed NOTIFY
                    displayedChanged)
@@ -656,6 +657,20 @@ public:
 
     /// \brief Get the current room state
     RoomStateView currentState() const;
+
+    //! \brief The effective power level of the given member in the room.
+    //!
+    //! Since a RoomPowerLevels state event may not always be available the following
+    //! is taken into account in line with the Matrix spec
+    //! https://spec.matrix.org/v1.8/client-server-api/#mroompower_levels:
+    //!     - The users_default is assumed to be 0.
+    //!     - The room creator is assumed to be 100.
+    //!
+    //! If \p memberId is empty the power level of the local user will be returned.
+    //! If the room has been upgraded 0 will be returned to prevent further upgrade attempts.
+    //!
+    //! \sa RoomPowerLevelsEvent
+    Q_INVOKABLE int memberEffectivePowerLevel(const QString& memberId) const;
 
     //! Send a request to update the room state with the given event
     SetRoomStateWithKeyJob* setState(const StateEvent& evt);

--- a/Quotient/roommember.cpp
+++ b/Quotient/roommember.cpp
@@ -4,7 +4,6 @@
 #include "roommember.h"
 
 #include "events/roommemberevent.h"
-#include "events/roompowerlevelsevent.h"
 #include "room.h"
 #include "util.h"
 
@@ -137,14 +136,9 @@ QUrl RoomMember::avatarUrl() const {
 int RoomMember::powerLevel() const
 {
     if (_room == nullptr || _member == nullptr) {
-        return 0;
+        return std::numeric_limits<int>::min();
     }
-
-    auto powerLevelEvent = _room->currentState().get<RoomPowerLevelsEvent>();
-    if (!powerLevelEvent) {
-        return 0;
-    }
-    return powerLevelEvent->powerLevelForUser(id());
+    return _room->memberEffectivePowerLevel(id());
 }
 
 namespace {

--- a/Quotient/roommember.cpp
+++ b/Quotient/roommember.cpp
@@ -4,6 +4,7 @@
 #include "roommember.h"
 
 #include "events/roommemberevent.h"
+#include "events/roompowerlevelsevent.h"
 #include "room.h"
 #include "util.h"
 
@@ -131,6 +132,19 @@ QUrl RoomMember::avatarUrl() const {
         return mediaUrl;
     }
     return {};
+}
+
+int RoomMember::powerLevel() const
+{
+    if (_room == nullptr || _member == nullptr) {
+        return 0;
+    }
+
+    auto powerLevelEvent = _room->currentState().get<RoomPowerLevelsEvent>();
+    if (!powerLevelEvent) {
+        return 0;
+    }
+    return powerLevelEvent->powerLevelForUser(id());
 }
 
 namespace {

--- a/Quotient/roommember.h
+++ b/Quotient/roommember.h
@@ -42,6 +42,7 @@ class QUOTIENT_API RoomMember {
     Q_PROPERTY(qreal hueF READ hueF CONSTANT)
     Q_PROPERTY(QColor color READ color CONSTANT)
     Q_PROPERTY(QUrl avatarUrl READ avatarUrl CONSTANT)
+    Q_PROPERTY(int powerLevel READ powerLevel CONSTANT)
 
 public:
     RoomMember() = default;
@@ -194,6 +195,12 @@ public:
     //!
     //!This can be empty if none set.
     QUrl avatarUrl() const;
+
+    //! \brief The power level of the member.
+    //!
+    //! This is in the context of the current room. Will return the default power
+    //! level for the room if not specifically set.
+    int powerLevel() const;
 
 private:
     const Room* _room = nullptr;


### PR DESCRIPTION
Add a function to get the power level for a room member in the context of the current room.

Desirable to make sorting via power level easier.