### PR TITLE
Deserialize CBOR data without one allocation per value

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -364,7 +364,7 @@ target_include_directories(${QUOTIENT_LIB_NAME} PUBLIC
 
 target_link_libraries(${QUOTIENT_LIB_NAME}
     PUBLIC ${Qt}::Core ${Qt}::Network ${Qt}::Gui qt${${Qt}Core_VERSION_MAJOR}keychain Olm::Olm ${Qt}::Sql
-    PRIVATE OpenSSL::Crypto)
+    PRIVATE OpenSSL::Crypto ${Qt}::CorePrivate)
 
 configure_file(${PROJECT_NAME}.pc.in ${CMAKE_CURRENT_BINARY_DIR}/${QUOTIENT_LIB_NAME}.pc @ONLY NEWLINE_STYLE UNIX)
 

--- a/Quotient/syncdata.cpp
+++ b/Quotient/syncdata.cpp
@@ -8,6 +8,8 @@
 #include <QtCore/QFile>
 #include <QtCore/QFileInfo>
 
+#include <private/qjson_p.h>
+
 using namespace Quotient;
 
 bool RoomSummary::isEmpty() const
@@ -136,7 +138,7 @@ QJsonObject loadJson(const QString& fileName)
 
     const auto json = data.startsWith('{')
                           ? QJsonDocument::fromJson(data).object()
-                          : QCborValue::fromCbor(data).toJsonValue().toObject();
+                          : QJsonPrivate::Value::fromTrustedCbor(QCborValue::fromCbor(data)).toObject();
     if (json.isEmpty()) {
         qCWarning(MAIN) << "State cache in" << fileName
                         << "is broken or empty, discarding";


### PR DESCRIPTION
QCBorValue::toJsonValue checks whether the CBOR data is in the JSON subset, which results in one allocation per value. As this is our own serialized data here, we don't need that check and can use the CBOR data directly.

The API for that fast path is unfortunately not public, but it's inline code, so it doesn't bind us to Qt's unstable internal ABI either.

This saves about 12M allocations during the startup of Itinerary here.