### PR TITLE
Keep cache of messages in database

### DIFF
--- a/Quotient/database.cpp
+++ b/Quotient/database.cpp
@@ -47,7 +47,8 @@ Database::Database(const QString& userId, const QString& deviceId,
     case 6: migrateTo7(); [[fallthrough]];
     case 7: migrateTo8(); [[fallthrough]];
     case 8: migrateTo9(); [[fallthrough]];
-    case 9: migrateTo10();
+    case 9: migrateTo10(); [[fallthrough]];
+    case 10: migrateTo11();
     }
 }
 
@@ -269,9 +270,17 @@ void Database::migrateTo10()
         execute(updateQuery);
     }
 
-    execute(QStringLiteral("pragma user_version = 10"));
+    execute(QStringLiteral("pragma user_version = 10;"));
     commit();
+}
 
+void Database::migrateTo11()
+{
+    qCDebug(DATABASE) << "Migrating database to version 11";
+    transaction();
+    execute(QStringLiteral("CREATE TABLE events (roomId TEXT, ts INTEGER, json TEXT);"));
+    execute(QStringLiteral("pragma user_version = 11;"));
+    commit();
 }
 
 void Database::storeOlmAccount(const QOlmAccount& olmAccount)

--- a/Quotient/database.cpp
+++ b/Quotient/database.cpp
@@ -279,6 +279,7 @@ void Database::migrateTo11()
     qCDebug(DATABASE) << "Migrating database to version 11";
     transaction();
     execute(QStringLiteral("CREATE TABLE events (roomId TEXT, ts INTEGER, json TEXT);"));
+    execute(QStringLiteral("CREATE TABLE event_batch_tokens (roomId TEXT, token TEXT);"));
     execute(QStringLiteral("pragma user_version = 11;"));
     commit();
 }

--- a/Quotient/database.cpp
+++ b/Quotient/database.cpp
@@ -463,7 +463,9 @@ void Database::clearRoomData(const QString& roomId)
            QStringLiteral(
                "DELETE FROM outbound_megolm_sessions WHERE roomId=:roomId;"),
            QStringLiteral("DELETE FROM group_session_record_index WHERE "
-                          "roomId=:roomId;") }) {
+                          "roomId=:roomId;"),
+             QStringLiteral("DELETE FROM events WHERE roomID=:roomId;")
+        }) {
         auto q = prepareQuery(queryText);
         q.bindValue(QStringLiteral(":roomId"), roomId);
         execute(q);

--- a/Quotient/database.h
+++ b/Quotient/database.h
@@ -94,6 +94,7 @@ private:
     void migrateTo8();
     void migrateTo9();
     void migrateTo10();
+    void migrateTo11();
 
     QString m_userId;
     QString m_deviceId;

--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -569,7 +569,10 @@ int Room::requestedHistorySize() const
 
 bool Room::allHistoryLoaded() const
 {
-    return !d->prevBatch;
+    if (timelineSize() == 0) {
+        return false;
+    }
+    return messageEvents().front()->is<const RoomCreateEvent>();
 }
 
 QString Room::name() const


### PR DESCRIPTION
Improves startup time, general UX, allows for client-side message search in the future, ...
While increasing requiring more storage on the client, of course.

There are some TODOs left in the code for things that need to be implemented and figured out