### PR TITLE
Authenticated media and animated thumbnails support

### DIFF
--- a/Quotient/avatar.cpp
+++ b/Quotient/avatar.cpp
@@ -6,8 +6,6 @@
 #include "connection.h"
 #include "logging_categories_p.h"
 
-#include "csapi/content-repo.h"
-
 #include "jobs/mediathumbnailjob.h"
 
 #include <QtCore/QDir>

--- a/Quotient/avatar.cpp
+++ b/Quotient/avatar.cpp
@@ -6,6 +6,8 @@
 #include "connection.h"
 #include "logging_categories_p.h"
 
+#include "csapi/content-repo.h"
+
 #include "jobs/mediathumbnailjob.h"
 
 #include <QtCore/QDir>

--- a/Quotient/connection.cpp
+++ b/Quotient/connection.cpp
@@ -754,15 +754,15 @@ JobHandle<UploadContentJob> Connection::uploadFile(const QString& fileName,
                          overrideContentType);
 }
 
-GetContentJob* Connection::getContent(const QString& mediaId)
+BaseJob* Connection::getContent(const QString& mediaId)
 {
     auto idParts = splitMediaId(mediaId);
-    return callApi<GetContentJob>(idParts.front(), idParts.back());
+    return callApi<DownloadFileJob>(idParts.front(), idParts.back());
 }
 
-GetContentJob* Connection::getContent(const QUrl& url)
+BaseJob* Connection::getContent(const QUrl& url)
 {
-    return getContent(url.authority() + url.path());
+    QT_IGNORE_DEPRECATIONS(return getContent(url.authority() + url.path());)
 }
 
 DownloadFileJob* Connection::downloadFile(const QUrl& url, const QString& localFilename)

--- a/Quotient/connection.h
+++ b/Quotient/connection.h
@@ -12,6 +12,7 @@
 
 #include "csapi/create_room.h"
 #include "csapi/login.h"
+#include "csapi/content-repo.h"
 
 #include "e2ee/qolmoutboundsession.h"
 
@@ -46,8 +47,6 @@ class PostReceiptJob;
 class ForgetRoomJob;
 class MediaThumbnailJob;
 class JoinRoomJob;
-class UploadContentJob;
-class GetContentJob;
 class DownloadFileJob;
 class SendToDeviceJob;
 class SendMessageJob;
@@ -529,7 +528,7 @@ public:
     template <typename JobT, typename... JobArgTs>
     QUrl getUrlForApi(JobArgTs&&... jobArgs) const
     {
-        return JobT::makeRequestUrl(homeserver(), std::forward<JobArgTs>(jobArgs)...);
+        return JobT::makeRequestUrl(homeserverData(), std::forward<JobArgTs>(jobArgs)...);
     }
 
     //! \brief Start a local HTTP server and generate a single sign-on URL

--- a/Quotient/connection.h
+++ b/Quotient/connection.h
@@ -687,8 +687,9 @@ public Q_SLOTS:
                                               const QString& overrideContentType = {});
     JobHandle<UploadContentJob> uploadFile(const QString& fileName,
                                            const QString& overrideContentType = {});
-    GetContentJob* getContent(const QString& mediaId);
-    GetContentJob* getContent(const QUrl& url);
+    [[deprecated("Use downloadFile() instead")]] BaseJob* getContent(const QString& mediaId);
+    [[deprecated("Use downloadFile() instead")]] BaseJob* getContent(const QUrl& url);
+
     // If localFilename is empty, a temporary file will be created
     DownloadFileJob* downloadFile(const QUrl& url, const QString& localFilename = {});
 

--- a/Quotient/connection_p.h
+++ b/Quotient/connection_p.h
@@ -11,11 +11,11 @@
 #include "settings.h"
 #include "syncdata.h"
 
+#include "csapi/account-data.h"
 #include "csapi/capabilities.h"
 #include "csapi/logout.h"
+#include "csapi/versions.h"
 #include "csapi/wellknown.h"
-
-#include "csapi/account-data.h"
 
 #include <QtCore/QCoreApplication>
 
@@ -51,8 +51,8 @@ public:
     QMetaObject::Connection syncLoopConnection {};
     int syncTimeout = -1;
 
-    GetCapabilitiesJob* capabilitiesJob = nullptr;
-    GetCapabilitiesJob::Capabilities capabilities;
+    GetVersionsJob::Response apiVersions{};
+    GetCapabilitiesJob::Capabilities capabilities{};
 
     QVector<GetLoginFlowsJob::LoginFlow> loginFlows;
 

--- a/Quotient/connectiondata.h
+++ b/Quotient/connectiondata.h
@@ -29,6 +29,7 @@ public:
     const QString& deviceId() const;
     const QString& userId() const;
     bool needsToken(const QString& requestName) const;
+    HomeserverData homeserverData() const;
     Quotient::NetworkAccessManager *nam() const;
 
     void setBaseUrl(QUrl baseUrl);
@@ -36,6 +37,7 @@ public:
     void setDeviceId(const QString& deviceId);
     void setUserId(const QString& userId);
     void setNeedsToken(const QString& requestName);
+    void setSupportedSpecVersions(QStringList versions);
 
     QString lastEvent() const;
     void setLastEvent(QString identifier);

--- a/Quotient/csapi/account-data.cpp
+++ b/Quotient/csapi/account-data.cpp
@@ -12,10 +12,11 @@ SetAccountDataJob::SetAccountDataJob(const QString& userId, const QString& type,
     setRequestData({ toJson(content) });
 }
 
-QUrl GetAccountDataJob::makeRequestUrl(QUrl baseUrl, const QString& userId, const QString& type)
+QUrl GetAccountDataJob::makeRequestUrl(const HomeserverData& hsData, const QString& userId,
+                                       const QString& type)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl), makePath("/_matrix/client/v3", "/user/",
-                                                                userId, "/account_data/", type));
+    return BaseJob::makeRequestUrl(hsData, makePath("/_matrix/client/v3", "/user/", userId,
+                                                    "/account_data/", type));
 }
 
 GetAccountDataJob::GetAccountDataJob(const QString& userId, const QString& type)
@@ -32,12 +33,11 @@ SetAccountDataPerRoomJob::SetAccountDataPerRoomJob(const QString& userId, const 
     setRequestData({ toJson(content) });
 }
 
-QUrl GetAccountDataPerRoomJob::makeRequestUrl(QUrl baseUrl, const QString& userId,
+QUrl GetAccountDataPerRoomJob::makeRequestUrl(const HomeserverData& hsData, const QString& userId,
                                               const QString& roomId, const QString& type)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
-                                   makePath("/_matrix/client/v3", "/user/", userId, "/rooms/",
-                                            roomId, "/account_data/", type));
+    return BaseJob::makeRequestUrl(hsData, makePath("/_matrix/client/v3", "/user/", userId,
+                                                    "/rooms/", roomId, "/account_data/", type));
 }
 
 GetAccountDataPerRoomJob::GetAccountDataPerRoomJob(const QString& userId, const QString& roomId,

--- a/Quotient/csapi/account-data.h
+++ b/Quotient/csapi/account-data.h
@@ -47,7 +47,8 @@ public:
     //!
     //! This function can be used when a URL for GetAccountDataJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& userId, const QString& type);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& userId,
+                               const QString& type);
 
     // Result properties
 
@@ -104,8 +105,8 @@ public:
     //!
     //! This function can be used when a URL for GetAccountDataPerRoomJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& userId, const QString& roomId,
-                               const QString& type);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& userId,
+                               const QString& roomId, const QString& type);
 
     // Result properties
 

--- a/Quotient/csapi/admin.cpp
+++ b/Quotient/csapi/admin.cpp
@@ -4,10 +4,9 @@
 
 using namespace Quotient;
 
-QUrl GetWhoIsJob::makeRequestUrl(QUrl baseUrl, const QString& userId)
+QUrl GetWhoIsJob::makeRequestUrl(const HomeserverData& hsData, const QString& userId)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
-                                   makePath("/_matrix/client/v3", "/admin/whois/", userId));
+    return BaseJob::makeRequestUrl(hsData, makePath("/_matrix/client/v3", "/admin/whois/", userId));
 }
 
 GetWhoIsJob::GetWhoIsJob(const QString& userId)

--- a/Quotient/csapi/admin.h
+++ b/Quotient/csapi/admin.h
@@ -48,7 +48,7 @@ public:
     //!
     //! This function can be used when a URL for GetWhoIsJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& userId);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& userId);
 
     // Result properties
 

--- a/Quotient/csapi/administrative_contact.cpp
+++ b/Quotient/csapi/administrative_contact.cpp
@@ -4,10 +4,9 @@
 
 using namespace Quotient;
 
-QUrl GetAccount3PIDsJob::makeRequestUrl(QUrl baseUrl)
+QUrl GetAccount3PIDsJob::makeRequestUrl(const HomeserverData& hsData)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
-                                   makePath("/_matrix/client/v3", "/account/3pid"));
+    return BaseJob::makeRequestUrl(hsData, makePath("/_matrix/client/v3", "/account/3pid"));
 }
 
 GetAccount3PIDsJob::GetAccount3PIDsJob()

--- a/Quotient/csapi/administrative_contact.h
+++ b/Quotient/csapi/administrative_contact.h
@@ -49,7 +49,7 @@ public:
     //!
     //! This function can be used when a URL for GetAccount3PIDsJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl);
+    static QUrl makeRequestUrl(const HomeserverData& hsData);
 
     // Result properties
 

--- a/Quotient/csapi/authed-content-repo.cpp
+++ b/Quotient/csapi/authed-content-repo.cpp
@@ -11,10 +11,10 @@ auto queryToGetContentAuthed(qint64 timeoutMs)
     return _q;
 }
 
-QUrl GetContentAuthedJob::makeRequestUrl(QUrl baseUrl, const QString& serverName,
+QUrl GetContentAuthedJob::makeRequestUrl(const HomeserverData& hsData, const QString& serverName,
                                          const QString& mediaId, qint64 timeoutMs)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
+    return BaseJob::makeRequestUrl(hsData,
                                    makePath("/_matrix/client/v1", "/media/download/", serverName,
                                             "/", mediaId),
                                    queryToGetContentAuthed(timeoutMs));
@@ -36,11 +36,12 @@ auto queryToGetContentOverrideNameAuthed(qint64 timeoutMs)
     return _q;
 }
 
-QUrl GetContentOverrideNameAuthedJob::makeRequestUrl(QUrl baseUrl, const QString& serverName,
+QUrl GetContentOverrideNameAuthedJob::makeRequestUrl(const HomeserverData& hsData,
+                                                     const QString& serverName,
                                                      const QString& mediaId,
                                                      const QString& fileName, qint64 timeoutMs)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
+    return BaseJob::makeRequestUrl(hsData,
                                    makePath("/_matrix/client/v1", "/media/download/", serverName,
                                             "/", mediaId, "/", fileName),
                                    queryToGetContentOverrideNameAuthed(timeoutMs));
@@ -70,14 +71,13 @@ auto queryToGetContentThumbnailAuthed(int width, int height, const QString& meth
     return _q;
 }
 
-QUrl GetContentThumbnailAuthedJob::makeRequestUrl(QUrl baseUrl, const QString& serverName,
-                                                  const QString& mediaId, int width, int height,
-                                                  const QString& method, qint64 timeoutMs,
-                                                  std::optional<bool> animated)
+QUrl GetContentThumbnailAuthedJob::makeRequestUrl(const HomeserverData& hsData,
+                                                  const QString& serverName, const QString& mediaId,
+                                                  int width, int height, const QString& method,
+                                                  qint64 timeoutMs, std::optional<bool> animated)
 {
     return BaseJob::makeRequestUrl(
-        std::move(baseUrl),
-        makePath("/_matrix/client/v1", "/media/thumbnail/", serverName, "/", mediaId),
+        hsData, makePath("/_matrix/client/v1", "/media/thumbnail/", serverName, "/", mediaId),
         queryToGetContentThumbnailAuthed(width, height, method, timeoutMs, animated));
 }
 
@@ -101,10 +101,10 @@ auto queryToGetUrlPreviewAuthed(const QUrl& url, std::optional<qint64> ts)
     return _q;
 }
 
-QUrl GetUrlPreviewAuthedJob::makeRequestUrl(QUrl baseUrl, const QUrl& url, std::optional<qint64> ts)
+QUrl GetUrlPreviewAuthedJob::makeRequestUrl(const HomeserverData& hsData, const QUrl& url,
+                                            std::optional<qint64> ts)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
-                                   makePath("/_matrix/client/v1", "/media/preview_url"),
+    return BaseJob::makeRequestUrl(hsData, makePath("/_matrix/client/v1", "/media/preview_url"),
                                    queryToGetUrlPreviewAuthed(url, ts));
 }
 
@@ -114,10 +114,9 @@ GetUrlPreviewAuthedJob::GetUrlPreviewAuthedJob(const QUrl& url, std::optional<qi
               queryToGetUrlPreviewAuthed(url, ts))
 {}
 
-QUrl GetConfigAuthedJob::makeRequestUrl(QUrl baseUrl)
+QUrl GetConfigAuthedJob::makeRequestUrl(const HomeserverData& hsData)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
-                                   makePath("/_matrix/client/v1", "/media/config"));
+    return BaseJob::makeRequestUrl(hsData, makePath("/_matrix/client/v1", "/media/config"));
 }
 
 GetConfigAuthedJob::GetConfigAuthedJob()

--- a/Quotient/csapi/authed-content-repo.h
+++ b/Quotient/csapi/authed-content-repo.h
@@ -40,8 +40,8 @@ public:
     //!
     //! This function can be used when a URL for GetContentAuthedJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& serverName, const QString& mediaId,
-                               qint64 timeoutMs = 20000);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& serverName,
+                               const QString& mediaId, qint64 timeoutMs = 20000);
 
     // Result properties
 
@@ -96,8 +96,9 @@ public:
     //!
     //! This function can be used when a URL for GetContentOverrideNameAuthedJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& serverName, const QString& mediaId,
-                               const QString& fileName, qint64 timeoutMs = 20000);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& serverName,
+                               const QString& mediaId, const QString& fileName,
+                               qint64 timeoutMs = 20000);
 
     // Result properties
 
@@ -179,9 +180,9 @@ public:
     //!
     //! This function can be used when a URL for GetContentThumbnailAuthedJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& serverName, const QString& mediaId,
-                               int width, int height, const QString& method = {},
-                               qint64 timeoutMs = 20000,
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& serverName,
+                               const QString& mediaId, int width, int height,
+                               const QString& method = {}, qint64 timeoutMs = 20000,
                                std::optional<bool> animated = std::nullopt);
 
     // Result properties
@@ -218,7 +219,7 @@ public:
     //!
     //! This function can be used when a URL for GetUrlPreviewAuthedJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QUrl& url,
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QUrl& url,
                                std::optional<qint64> ts = std::nullopt);
 
     // Result properties
@@ -269,7 +270,7 @@ public:
     //!
     //! This function can be used when a URL for GetConfigAuthedJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl);
+    static QUrl makeRequestUrl(const HomeserverData& hsData);
 
     // Result properties
 

--- a/Quotient/csapi/capabilities.cpp
+++ b/Quotient/csapi/capabilities.cpp
@@ -4,10 +4,9 @@
 
 using namespace Quotient;
 
-QUrl GetCapabilitiesJob::makeRequestUrl(QUrl baseUrl)
+QUrl GetCapabilitiesJob::makeRequestUrl(const HomeserverData& hsData)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
-                                   makePath("/_matrix/client/v3", "/capabilities"));
+    return BaseJob::makeRequestUrl(hsData, makePath("/_matrix/client/v3", "/capabilities"));
 }
 
 GetCapabilitiesJob::GetCapabilitiesJob()

--- a/Quotient/csapi/capabilities.h
+++ b/Quotient/csapi/capabilities.h
@@ -49,7 +49,7 @@ public:
     //!
     //! This function can be used when a URL for GetCapabilitiesJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl);
+    static QUrl makeRequestUrl(const HomeserverData& hsData);
 
     // Result properties
 

--- a/Quotient/csapi/content-repo.cpp
+++ b/Quotient/csapi/content-repo.cpp
@@ -39,9 +39,9 @@ UploadContentToMXCJob::UploadContentToMXCJob(const QString& serverName, const QS
     setRequestData({ content });
 }
 
-QUrl CreateContentJob::makeRequestUrl(QUrl baseUrl)
+QUrl CreateContentJob::makeRequestUrl(const HomeserverData& hsData)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl), makePath("/_matrix", "/media/v1/create"));
+    return BaseJob::makeRequestUrl(hsData, makePath("/_matrix", "/media/v1/create"));
 }
 
 CreateContentJob::CreateContentJob()
@@ -60,10 +60,11 @@ auto queryToGetContent(bool allowRemote, qint64 timeoutMs, bool allowRedirect)
     return _q;
 }
 
-QUrl GetContentJob::makeRequestUrl(QUrl baseUrl, const QString& serverName, const QString& mediaId,
-                                   bool allowRemote, qint64 timeoutMs, bool allowRedirect)
+QUrl GetContentJob::makeRequestUrl(const HomeserverData& hsData, const QString& serverName,
+                                   const QString& mediaId, bool allowRemote, qint64 timeoutMs,
+                                   bool allowRedirect)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
+    return BaseJob::makeRequestUrl(hsData,
                                    makePath("/_matrix", "/media/v3/download/", serverName, "/",
                                             mediaId),
                                    queryToGetContent(allowRemote, timeoutMs, allowRedirect));
@@ -87,14 +88,13 @@ auto queryToGetContentOverrideName(bool allowRemote, qint64 timeoutMs, bool allo
     return _q;
 }
 
-QUrl GetContentOverrideNameJob::makeRequestUrl(QUrl baseUrl, const QString& serverName,
-                                               const QString& mediaId, const QString& fileName,
-                                               bool allowRemote, qint64 timeoutMs,
-                                               bool allowRedirect)
+QUrl GetContentOverrideNameJob::makeRequestUrl(const HomeserverData& hsData,
+                                               const QString& serverName, const QString& mediaId,
+                                               const QString& fileName, bool allowRemote,
+                                               qint64 timeoutMs, bool allowRedirect)
 {
     return BaseJob::makeRequestUrl(
-        std::move(baseUrl),
-        makePath("/_matrix", "/media/v3/download/", serverName, "/", mediaId, "/", fileName),
+        hsData, makePath("/_matrix", "/media/v3/download/", serverName, "/", mediaId, "/", fileName),
         queryToGetContentOverrideName(allowRemote, timeoutMs, allowRedirect));
 }
 
@@ -123,13 +123,13 @@ auto queryToGetContentThumbnail(int width, int height, const QString& method, bo
     return _q;
 }
 
-QUrl GetContentThumbnailJob::makeRequestUrl(QUrl baseUrl, const QString& serverName,
+QUrl GetContentThumbnailJob::makeRequestUrl(const HomeserverData& hsData, const QString& serverName,
                                             const QString& mediaId, int width, int height,
                                             const QString& method, bool allowRemote,
                                             qint64 timeoutMs, bool allowRedirect,
                                             std::optional<bool> animated)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
+    return BaseJob::makeRequestUrl(hsData,
                                    makePath("/_matrix", "/media/v3/thumbnail/", serverName, "/",
                                             mediaId),
                                    queryToGetContentThumbnail(width, height, method, allowRemote,
@@ -157,9 +157,10 @@ auto queryToGetUrlPreview(const QUrl& url, std::optional<qint64> ts)
     return _q;
 }
 
-QUrl GetUrlPreviewJob::makeRequestUrl(QUrl baseUrl, const QUrl& url, std::optional<qint64> ts)
+QUrl GetUrlPreviewJob::makeRequestUrl(const HomeserverData& hsData, const QUrl& url,
+                                      std::optional<qint64> ts)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl), makePath("/_matrix", "/media/v3/preview_url"),
+    return BaseJob::makeRequestUrl(hsData, makePath("/_matrix", "/media/v3/preview_url"),
                                    queryToGetUrlPreview(url, ts));
 }
 
@@ -168,9 +169,9 @@ GetUrlPreviewJob::GetUrlPreviewJob(const QUrl& url, std::optional<qint64> ts)
               makePath("/_matrix", "/media/v3/preview_url"), queryToGetUrlPreview(url, ts))
 {}
 
-QUrl GetConfigJob::makeRequestUrl(QUrl baseUrl)
+QUrl GetConfigJob::makeRequestUrl(const HomeserverData& hsData)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl), makePath("/_matrix", "/media/v3/config"));
+    return BaseJob::makeRequestUrl(hsData, makePath("/_matrix", "/media/v3/config"));
 }
 
 GetConfigJob::GetConfigJob()

--- a/Quotient/csapi/content-repo.h
+++ b/Quotient/csapi/content-repo.h
@@ -82,7 +82,7 @@ public:
     //!
     //! This function can be used when a URL for CreateContentJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl);
+    static QUrl makeRequestUrl(const HomeserverData& hsData);
 
     // Result properties
 
@@ -159,9 +159,9 @@ public:
     //!
     //! This function can be used when a URL for GetContentJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& serverName, const QString& mediaId,
-                               bool allowRemote = true, qint64 timeoutMs = 20000,
-                               bool allowRedirect = false);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& serverName,
+                               const QString& mediaId, bool allowRemote = true,
+                               qint64 timeoutMs = 20000, bool allowRedirect = false);
 
     // Result properties
 
@@ -232,9 +232,10 @@ public:
     //!
     //! This function can be used when a URL for GetContentOverrideNameJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& serverName, const QString& mediaId,
-                               const QString& fileName, bool allowRemote = true,
-                               qint64 timeoutMs = 20000, bool allowRedirect = false);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& serverName,
+                               const QString& mediaId, const QString& fileName,
+                               bool allowRemote = true, qint64 timeoutMs = 20000,
+                               bool allowRedirect = false);
 
     // Result properties
 
@@ -331,10 +332,10 @@ public:
     //!
     //! This function can be used when a URL for GetContentThumbnailJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& serverName, const QString& mediaId,
-                               int width, int height, const QString& method = {},
-                               bool allowRemote = true, qint64 timeoutMs = 20000,
-                               bool allowRedirect = false,
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& serverName,
+                               const QString& mediaId, int width, int height,
+                               const QString& method = {}, bool allowRemote = true,
+                               qint64 timeoutMs = 20000, bool allowRedirect = false,
                                std::optional<bool> animated = std::nullopt);
 
     // Result properties
@@ -376,7 +377,7 @@ public:
     //!
     //! This function can be used when a URL for GetUrlPreviewJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QUrl& url,
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QUrl& url,
                                std::optional<qint64> ts = std::nullopt);
 
     // Result properties
@@ -433,7 +434,7 @@ public:
     //!
     //! This function can be used when a URL for GetConfigJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl);
+    static QUrl makeRequestUrl(const HomeserverData& hsData);
 
     // Result properties
 

--- a/Quotient/csapi/device_management.cpp
+++ b/Quotient/csapi/device_management.cpp
@@ -4,9 +4,9 @@
 
 using namespace Quotient;
 
-QUrl GetDevicesJob::makeRequestUrl(QUrl baseUrl)
+QUrl GetDevicesJob::makeRequestUrl(const HomeserverData& hsData)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl), makePath("/_matrix/client/v3", "/devices"));
+    return BaseJob::makeRequestUrl(hsData, makePath("/_matrix/client/v3", "/devices"));
 }
 
 GetDevicesJob::GetDevicesJob()
@@ -14,10 +14,9 @@ GetDevicesJob::GetDevicesJob()
               makePath("/_matrix/client/v3", "/devices"))
 {}
 
-QUrl GetDeviceJob::makeRequestUrl(QUrl baseUrl, const QString& deviceId)
+QUrl GetDeviceJob::makeRequestUrl(const HomeserverData& hsData, const QString& deviceId)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
-                                   makePath("/_matrix/client/v3", "/devices/", deviceId));
+    return BaseJob::makeRequestUrl(hsData, makePath("/_matrix/client/v3", "/devices/", deviceId));
 }
 
 GetDeviceJob::GetDeviceJob(const QString& deviceId)

--- a/Quotient/csapi/device_management.h
+++ b/Quotient/csapi/device_management.h
@@ -20,7 +20,7 @@ public:
     //!
     //! This function can be used when a URL for GetDevicesJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl);
+    static QUrl makeRequestUrl(const HomeserverData& hsData);
 
     // Result properties
 
@@ -43,7 +43,7 @@ public:
     //!
     //! This function can be used when a URL for GetDeviceJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& deviceId);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& deviceId);
 
     // Result properties
 

--- a/Quotient/csapi/directory.cpp
+++ b/Quotient/csapi/directory.cpp
@@ -13,9 +13,9 @@ SetRoomAliasJob::SetRoomAliasJob(const QString& roomAlias, const QString& roomId
     setRequestData({ _dataJson });
 }
 
-QUrl GetRoomIdByAliasJob::makeRequestUrl(QUrl baseUrl, const QString& roomAlias)
+QUrl GetRoomIdByAliasJob::makeRequestUrl(const HomeserverData& hsData, const QString& roomAlias)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
+    return BaseJob::makeRequestUrl(hsData,
                                    makePath("/_matrix/client/v3", "/directory/room/", roomAlias));
 }
 
@@ -24,9 +24,9 @@ GetRoomIdByAliasJob::GetRoomIdByAliasJob(const QString& roomAlias)
               makePath("/_matrix/client/v3", "/directory/room/", roomAlias), false)
 {}
 
-QUrl DeleteRoomAliasJob::makeRequestUrl(QUrl baseUrl, const QString& roomAlias)
+QUrl DeleteRoomAliasJob::makeRequestUrl(const HomeserverData& hsData, const QString& roomAlias)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
+    return BaseJob::makeRequestUrl(hsData,
                                    makePath("/_matrix/client/v3", "/directory/room/", roomAlias));
 }
 
@@ -35,9 +35,9 @@ DeleteRoomAliasJob::DeleteRoomAliasJob(const QString& roomAlias)
               makePath("/_matrix/client/v3", "/directory/room/", roomAlias))
 {}
 
-QUrl GetLocalAliasesJob::makeRequestUrl(QUrl baseUrl, const QString& roomId)
+QUrl GetLocalAliasesJob::makeRequestUrl(const HomeserverData& hsData, const QString& roomId)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
+    return BaseJob::makeRequestUrl(hsData,
                                    makePath("/_matrix/client/v3", "/rooms/", roomId, "/aliases"));
 }
 

--- a/Quotient/csapi/directory.h
+++ b/Quotient/csapi/directory.h
@@ -36,7 +36,7 @@ public:
     //!
     //! This function can be used when a URL for GetRoomIdByAliasJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& roomAlias);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& roomAlias);
 
     // Result properties
 
@@ -83,7 +83,7 @@ public:
     //!
     //! This function can be used when a URL for DeleteRoomAliasJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& roomAlias);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& roomAlias);
 };
 
 //! \brief Get a list of local aliases on a given room.
@@ -114,7 +114,7 @@ public:
     //!
     //! This function can be used when a URL for GetLocalAliasesJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& roomId);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& roomId);
 
     // Result properties
 

--- a/Quotient/csapi/event_context.cpp
+++ b/Quotient/csapi/event_context.cpp
@@ -12,10 +12,11 @@ auto queryToGetEventContext(std::optional<int> limit, const QString& filter)
     return _q;
 }
 
-QUrl GetEventContextJob::makeRequestUrl(QUrl baseUrl, const QString& roomId, const QString& eventId,
-                                        std::optional<int> limit, const QString& filter)
+QUrl GetEventContextJob::makeRequestUrl(const HomeserverData& hsData, const QString& roomId,
+                                        const QString& eventId, std::optional<int> limit,
+                                        const QString& filter)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
+    return BaseJob::makeRequestUrl(hsData,
                                    makePath("/_matrix/client/v3", "/rooms/", roomId, "/context/",
                                             eventId),
                                    queryToGetEventContext(limit, filter));

--- a/Quotient/csapi/event_context.h
+++ b/Quotient/csapi/event_context.h
@@ -45,8 +45,9 @@ public:
     //!
     //! This function can be used when a URL for GetEventContextJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& roomId, const QString& eventId,
-                               std::optional<int> limit = std::nullopt, const QString& filter = {});
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& roomId,
+                               const QString& eventId, std::optional<int> limit = std::nullopt,
+                               const QString& filter = {});
 
     // Result properties
 

--- a/Quotient/csapi/filter.cpp
+++ b/Quotient/csapi/filter.cpp
@@ -12,10 +12,11 @@ DefineFilterJob::DefineFilterJob(const QString& userId, const Filter& filter)
     addExpectedKey("filter_id");
 }
 
-QUrl GetFilterJob::makeRequestUrl(QUrl baseUrl, const QString& userId, const QString& filterId)
+QUrl GetFilterJob::makeRequestUrl(const HomeserverData& hsData, const QString& userId,
+                                  const QString& filterId)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl), makePath("/_matrix/client/v3", "/user/",
-                                                                userId, "/filter/", filterId));
+    return BaseJob::makeRequestUrl(hsData, makePath("/_matrix/client/v3", "/user/", userId,
+                                                    "/filter/", filterId));
 }
 
 GetFilterJob::GetFilterJob(const QString& userId, const QString& filterId)

--- a/Quotient/csapi/filter.h
+++ b/Quotient/csapi/filter.h
@@ -48,7 +48,8 @@ public:
     //!
     //! This function can be used when a URL for GetFilterJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& userId, const QString& filterId);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& userId,
+                               const QString& filterId);
 
     // Result properties
 

--- a/Quotient/csapi/key_backup.cpp
+++ b/Quotient/csapi/key_backup.cpp
@@ -15,10 +15,9 @@ PostRoomKeysVersionJob::PostRoomKeysVersionJob(const QString& algorithm, const Q
     addExpectedKey("version");
 }
 
-QUrl GetRoomKeysVersionCurrentJob::makeRequestUrl(QUrl baseUrl)
+QUrl GetRoomKeysVersionCurrentJob::makeRequestUrl(const HomeserverData& hsData)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
-                                   makePath("/_matrix/client/v3", "/room_keys/version"));
+    return BaseJob::makeRequestUrl(hsData, makePath("/_matrix/client/v3", "/room_keys/version"));
 }
 
 GetRoomKeysVersionCurrentJob::GetRoomKeysVersionCurrentJob()
@@ -32,9 +31,9 @@ GetRoomKeysVersionCurrentJob::GetRoomKeysVersionCurrentJob()
     addExpectedKey("version");
 }
 
-QUrl GetRoomKeysVersionJob::makeRequestUrl(QUrl baseUrl, const QString& version)
+QUrl GetRoomKeysVersionJob::makeRequestUrl(const HomeserverData& hsData, const QString& version)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
+    return BaseJob::makeRequestUrl(hsData,
                                    makePath("/_matrix/client/v3", "/room_keys/version/", version));
 }
 
@@ -60,9 +59,9 @@ PutRoomKeysVersionJob::PutRoomKeysVersionJob(const QString& version, const QStri
     setRequestData({ _dataJson });
 }
 
-QUrl DeleteRoomKeysVersionJob::makeRequestUrl(QUrl baseUrl, const QString& version)
+QUrl DeleteRoomKeysVersionJob::makeRequestUrl(const HomeserverData& hsData, const QString& version)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
+    return BaseJob::makeRequestUrl(hsData,
                                    makePath("/_matrix/client/v3", "/room_keys/version/", version));
 }
 
@@ -96,10 +95,10 @@ auto queryToGetRoomKeyBySessionId(const QString& version)
     return _q;
 }
 
-QUrl GetRoomKeyBySessionIdJob::makeRequestUrl(QUrl baseUrl, const QString& roomId,
+QUrl GetRoomKeyBySessionIdJob::makeRequestUrl(const HomeserverData& hsData, const QString& roomId,
                                               const QString& sessionId, const QString& version)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
+    return BaseJob::makeRequestUrl(hsData,
                                    makePath("/_matrix/client/v3", "/room_keys/keys/", roomId, "/",
                                             sessionId),
                                    queryToGetRoomKeyBySessionId(version));
@@ -119,10 +118,10 @@ auto queryToDeleteRoomKeyBySessionId(const QString& version)
     return _q;
 }
 
-QUrl DeleteRoomKeyBySessionIdJob::makeRequestUrl(QUrl baseUrl, const QString& roomId,
+QUrl DeleteRoomKeyBySessionIdJob::makeRequestUrl(const HomeserverData& hsData, const QString& roomId,
                                                  const QString& sessionId, const QString& version)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
+    return BaseJob::makeRequestUrl(hsData,
                                    makePath("/_matrix/client/v3", "/room_keys/keys/", roomId, "/",
                                             sessionId),
                                    queryToDeleteRoomKeyBySessionId(version));
@@ -164,10 +163,10 @@ auto queryToGetRoomKeysByRoomId(const QString& version)
     return _q;
 }
 
-QUrl GetRoomKeysByRoomIdJob::makeRequestUrl(QUrl baseUrl, const QString& roomId,
+QUrl GetRoomKeysByRoomIdJob::makeRequestUrl(const HomeserverData& hsData, const QString& roomId,
                                             const QString& version)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
+    return BaseJob::makeRequestUrl(hsData,
                                    makePath("/_matrix/client/v3", "/room_keys/keys/", roomId),
                                    queryToGetRoomKeysByRoomId(version));
 }
@@ -185,10 +184,10 @@ auto queryToDeleteRoomKeysByRoomId(const QString& version)
     return _q;
 }
 
-QUrl DeleteRoomKeysByRoomIdJob::makeRequestUrl(QUrl baseUrl, const QString& roomId,
+QUrl DeleteRoomKeysByRoomIdJob::makeRequestUrl(const HomeserverData& hsData, const QString& roomId,
                                                const QString& version)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
+    return BaseJob::makeRequestUrl(hsData,
                                    makePath("/_matrix/client/v3", "/room_keys/keys/", roomId),
                                    queryToDeleteRoomKeysByRoomId(version));
 }
@@ -227,10 +226,9 @@ auto queryToGetRoomKeys(const QString& version)
     return _q;
 }
 
-QUrl GetRoomKeysJob::makeRequestUrl(QUrl baseUrl, const QString& version)
+QUrl GetRoomKeysJob::makeRequestUrl(const HomeserverData& hsData, const QString& version)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
-                                   makePath("/_matrix/client/v3", "/room_keys/keys"),
+    return BaseJob::makeRequestUrl(hsData, makePath("/_matrix/client/v3", "/room_keys/keys"),
                                    queryToGetRoomKeys(version));
 }
 
@@ -248,10 +246,9 @@ auto queryToDeleteRoomKeys(const QString& version)
     return _q;
 }
 
-QUrl DeleteRoomKeysJob::makeRequestUrl(QUrl baseUrl, const QString& version)
+QUrl DeleteRoomKeysJob::makeRequestUrl(const HomeserverData& hsData, const QString& version)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
-                                   makePath("/_matrix/client/v3", "/room_keys/keys"),
+    return BaseJob::makeRequestUrl(hsData, makePath("/_matrix/client/v3", "/room_keys/keys"),
                                    queryToDeleteRoomKeys(version));
 }
 

--- a/Quotient/csapi/key_backup.h
+++ b/Quotient/csapi/key_backup.h
@@ -42,7 +42,7 @@ public:
     //!
     //! This function can be used when a URL for GetRoomKeysVersionCurrentJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl);
+    static QUrl makeRequestUrl(const HomeserverData& hsData);
 
     // Result properties
 
@@ -112,7 +112,7 @@ public:
     //!
     //! This function can be used when a URL for GetRoomKeysVersionJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& version);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& version);
 
     // Result properties
 
@@ -208,7 +208,7 @@ public:
     //!
     //! This function can be used when a URL for DeleteRoomKeysVersionJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& version);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& version);
 };
 
 //! \brief Store a key in the backup.
@@ -273,8 +273,8 @@ public:
     //!
     //! This function can be used when a URL for GetRoomKeyBySessionIdJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& roomId, const QString& sessionId,
-                               const QString& version);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& roomId,
+                               const QString& sessionId, const QString& version);
 
     // Result properties
 
@@ -304,8 +304,8 @@ public:
     //!
     //! This function can be used when a URL for DeleteRoomKeyBySessionIdJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& roomId, const QString& sessionId,
-                               const QString& version);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& roomId,
+                               const QString& sessionId, const QString& version);
 
     // Result properties
 
@@ -385,7 +385,8 @@ public:
     //!
     //! This function can be used when a URL for GetRoomKeysByRoomIdJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& roomId, const QString& version);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& roomId,
+                               const QString& version);
 
     // Result properties
 
@@ -412,7 +413,8 @@ public:
     //!
     //! This function can be used when a URL for DeleteRoomKeysByRoomIdJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& roomId, const QString& version);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& roomId,
+                               const QString& version);
 
     // Result properties
 
@@ -485,7 +487,7 @@ public:
     //!
     //! This function can be used when a URL for GetRoomKeysJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& version);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& version);
 
     // Result properties
 
@@ -511,7 +513,7 @@ public:
     //!
     //! This function can be used when a URL for DeleteRoomKeysJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& version);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& version);
 
     // Result properties
 

--- a/Quotient/csapi/keys.cpp
+++ b/Quotient/csapi/keys.cpp
@@ -47,10 +47,10 @@ auto queryToGetKeysChanges(const QString& from, const QString& to)
     return _q;
 }
 
-QUrl GetKeysChangesJob::makeRequestUrl(QUrl baseUrl, const QString& from, const QString& to)
+QUrl GetKeysChangesJob::makeRequestUrl(const HomeserverData& hsData, const QString& from,
+                                       const QString& to)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
-                                   makePath("/_matrix/client/v3", "/keys/changes"),
+    return BaseJob::makeRequestUrl(hsData, makePath("/_matrix/client/v3", "/keys/changes"),
                                    queryToGetKeysChanges(from, to));
 }
 

--- a/Quotient/csapi/keys.h
+++ b/Quotient/csapi/keys.h
@@ -311,7 +311,7 @@ public:
     //!
     //! This function can be used when a URL for GetKeysChangesJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& from, const QString& to);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& from, const QString& to);
 
     // Result properties
 

--- a/Quotient/csapi/leaving.cpp
+++ b/Quotient/csapi/leaving.cpp
@@ -13,9 +13,9 @@ LeaveRoomJob::LeaveRoomJob(const QString& roomId, const QString& reason)
     setRequestData({ _dataJson });
 }
 
-QUrl ForgetRoomJob::makeRequestUrl(QUrl baseUrl, const QString& roomId)
+QUrl ForgetRoomJob::makeRequestUrl(const HomeserverData& hsData, const QString& roomId)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
+    return BaseJob::makeRequestUrl(hsData,
                                    makePath("/_matrix/client/v3", "/rooms/", roomId, "/forget"));
 }
 

--- a/Quotient/csapi/leaving.h
+++ b/Quotient/csapi/leaving.h
@@ -51,7 +51,7 @@ public:
     //!
     //! This function can be used when a URL for ForgetRoomJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& roomId);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& roomId);
 };
 
 } // namespace Quotient

--- a/Quotient/csapi/list_joined_rooms.cpp
+++ b/Quotient/csapi/list_joined_rooms.cpp
@@ -4,10 +4,9 @@
 
 using namespace Quotient;
 
-QUrl GetJoinedRoomsJob::makeRequestUrl(QUrl baseUrl)
+QUrl GetJoinedRoomsJob::makeRequestUrl(const HomeserverData& hsData)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
-                                   makePath("/_matrix/client/v3", "/joined_rooms"));
+    return BaseJob::makeRequestUrl(hsData, makePath("/_matrix/client/v3", "/joined_rooms"));
 }
 
 GetJoinedRoomsJob::GetJoinedRoomsJob()

--- a/Quotient/csapi/list_joined_rooms.h
+++ b/Quotient/csapi/list_joined_rooms.h
@@ -17,7 +17,7 @@ public:
     //!
     //! This function can be used when a URL for GetJoinedRoomsJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl);
+    static QUrl makeRequestUrl(const HomeserverData& hsData);
 
     // Result properties
 

--- a/Quotient/csapi/list_public_rooms.cpp
+++ b/Quotient/csapi/list_public_rooms.cpp
@@ -4,9 +4,10 @@
 
 using namespace Quotient;
 
-QUrl GetRoomVisibilityOnDirectoryJob::makeRequestUrl(QUrl baseUrl, const QString& roomId)
+QUrl GetRoomVisibilityOnDirectoryJob::makeRequestUrl(const HomeserverData& hsData,
+                                                     const QString& roomId)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
+    return BaseJob::makeRequestUrl(hsData,
                                    makePath("/_matrix/client/v3", "/directory/list/room/", roomId));
 }
 
@@ -34,11 +35,10 @@ auto queryToGetPublicRooms(std::optional<int> limit, const QString& since, const
     return _q;
 }
 
-QUrl GetPublicRoomsJob::makeRequestUrl(QUrl baseUrl, std::optional<int> limit, const QString& since,
-                                       const QString& server)
+QUrl GetPublicRoomsJob::makeRequestUrl(const HomeserverData& hsData, std::optional<int> limit,
+                                       const QString& since, const QString& server)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
-                                   makePath("/_matrix/client/v3", "/publicRooms"),
+    return BaseJob::makeRequestUrl(hsData, makePath("/_matrix/client/v3", "/publicRooms"),
                                    queryToGetPublicRooms(limit, since, server));
 }
 

--- a/Quotient/csapi/list_public_rooms.h
+++ b/Quotient/csapi/list_public_rooms.h
@@ -21,7 +21,7 @@ public:
     //!
     //! This function can be used when a URL for GetRoomVisibilityOnDirectoryJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& roomId);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& roomId);
 
     // Result properties
 
@@ -80,7 +80,7 @@ public:
     //!
     //! This function can be used when a URL for GetPublicRoomsJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, std::optional<int> limit = std::nullopt,
+    static QUrl makeRequestUrl(const HomeserverData& hsData, std::optional<int> limit = std::nullopt,
                                const QString& since = {}, const QString& server = {});
 
     // Result properties

--- a/Quotient/csapi/login.cpp
+++ b/Quotient/csapi/login.cpp
@@ -4,9 +4,9 @@
 
 using namespace Quotient;
 
-QUrl GetLoginFlowsJob::makeRequestUrl(QUrl baseUrl)
+QUrl GetLoginFlowsJob::makeRequestUrl(const HomeserverData& hsData)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl), makePath("/_matrix/client/v3", "/login"));
+    return BaseJob::makeRequestUrl(hsData, makePath("/_matrix/client/v3", "/login"));
 }
 
 GetLoginFlowsJob::GetLoginFlowsJob()

--- a/Quotient/csapi/login.h
+++ b/Quotient/csapi/login.h
@@ -39,7 +39,7 @@ public:
     //!
     //! This function can be used when a URL for GetLoginFlowsJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl);
+    static QUrl makeRequestUrl(const HomeserverData& hsData);
 
     // Result properties
 

--- a/Quotient/csapi/logout.cpp
+++ b/Quotient/csapi/logout.cpp
@@ -4,19 +4,18 @@
 
 using namespace Quotient;
 
-QUrl LogoutJob::makeRequestUrl(QUrl baseUrl)
+QUrl LogoutJob::makeRequestUrl(const HomeserverData& hsData)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl), makePath("/_matrix/client/v3", "/logout"));
+    return BaseJob::makeRequestUrl(hsData, makePath("/_matrix/client/v3", "/logout"));
 }
 
 LogoutJob::LogoutJob()
     : BaseJob(HttpVerb::Post, QStringLiteral("LogoutJob"), makePath("/_matrix/client/v3", "/logout"))
 {}
 
-QUrl LogoutAllJob::makeRequestUrl(QUrl baseUrl)
+QUrl LogoutAllJob::makeRequestUrl(const HomeserverData& hsData)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
-                                   makePath("/_matrix/client/v3", "/logout/all"));
+    return BaseJob::makeRequestUrl(hsData, makePath("/_matrix/client/v3", "/logout/all"));
 }
 
 LogoutAllJob::LogoutAllJob()

--- a/Quotient/csapi/logout.h
+++ b/Quotient/csapi/logout.h
@@ -19,7 +19,7 @@ public:
     //!
     //! This function can be used when a URL for LogoutJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl);
+    static QUrl makeRequestUrl(const HomeserverData& hsData);
 };
 
 //! \brief Invalidates all access tokens for a user
@@ -43,7 +43,7 @@ public:
     //!
     //! This function can be used when a URL for LogoutAllJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl);
+    static QUrl makeRequestUrl(const HomeserverData& hsData);
 };
 
 } // namespace Quotient

--- a/Quotient/csapi/message_pagination.cpp
+++ b/Quotient/csapi/message_pagination.cpp
@@ -16,11 +16,11 @@ auto queryToGetRoomEvents(const QString& from, const QString& to, const QString&
     return _q;
 }
 
-QUrl GetRoomEventsJob::makeRequestUrl(QUrl baseUrl, const QString& roomId, const QString& dir,
-                                      const QString& from, const QString& to,
+QUrl GetRoomEventsJob::makeRequestUrl(const HomeserverData& hsData, const QString& roomId,
+                                      const QString& dir, const QString& from, const QString& to,
                                       std::optional<int> limit, const QString& filter)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
+    return BaseJob::makeRequestUrl(hsData,
                                    makePath("/_matrix/client/v3", "/rooms/", roomId, "/messages"),
                                    queryToGetRoomEvents(from, to, dir, limit, filter));
 }

--- a/Quotient/csapi/message_pagination.h
+++ b/Quotient/csapi/message_pagination.h
@@ -56,8 +56,8 @@ public:
     //!
     //! This function can be used when a URL for GetRoomEventsJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& roomId, const QString& dir,
-                               const QString& from = {}, const QString& to = {},
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& roomId,
+                               const QString& dir, const QString& from = {}, const QString& to = {},
                                std::optional<int> limit = std::nullopt, const QString& filter = {});
 
     // Result properties

--- a/Quotient/csapi/notifications.cpp
+++ b/Quotient/csapi/notifications.cpp
@@ -13,11 +13,10 @@ auto queryToGetNotifications(const QString& from, std::optional<int> limit, cons
     return _q;
 }
 
-QUrl GetNotificationsJob::makeRequestUrl(QUrl baseUrl, const QString& from,
+QUrl GetNotificationsJob::makeRequestUrl(const HomeserverData& hsData, const QString& from,
                                          std::optional<int> limit, const QString& only)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
-                                   makePath("/_matrix/client/v3", "/notifications"),
+    return BaseJob::makeRequestUrl(hsData, makePath("/_matrix/client/v3", "/notifications"),
                                    queryToGetNotifications(from, limit, only));
 }
 

--- a/Quotient/csapi/notifications.h
+++ b/Quotient/csapi/notifications.h
@@ -58,7 +58,7 @@ public:
     //!
     //! This function can be used when a URL for GetNotificationsJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& from = {},
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& from = {},
                                std::optional<int> limit = std::nullopt, const QString& only = {});
 
     // Result properties

--- a/Quotient/csapi/peeking_events.cpp
+++ b/Quotient/csapi/peeking_events.cpp
@@ -13,10 +13,10 @@ auto queryToPeekEvents(const QString& from, std::optional<int> timeout, const QS
     return _q;
 }
 
-QUrl PeekEventsJob::makeRequestUrl(QUrl baseUrl, const QString& from, std::optional<int> timeout,
-                                   const QString& roomId)
+QUrl PeekEventsJob::makeRequestUrl(const HomeserverData& hsData, const QString& from,
+                                   std::optional<int> timeout, const QString& roomId)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl), makePath("/_matrix/client/v3", "/events"),
+    return BaseJob::makeRequestUrl(hsData, makePath("/_matrix/client/v3", "/events"),
                                    queryToPeekEvents(from, timeout, roomId));
 }
 

--- a/Quotient/csapi/peeking_events.h
+++ b/Quotient/csapi/peeking_events.h
@@ -37,7 +37,7 @@ public:
     //!
     //! This function can be used when a URL for PeekEventsJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& from = {},
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& from = {},
                                std::optional<int> timeout = std::nullopt,
                                const QString& roomId = {});
 

--- a/Quotient/csapi/presence.cpp
+++ b/Quotient/csapi/presence.cpp
@@ -15,9 +15,9 @@ SetPresenceJob::SetPresenceJob(const QString& userId, const QString& presence,
     setRequestData({ _dataJson });
 }
 
-QUrl GetPresenceJob::makeRequestUrl(QUrl baseUrl, const QString& userId)
+QUrl GetPresenceJob::makeRequestUrl(const HomeserverData& hsData, const QString& userId)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
+    return BaseJob::makeRequestUrl(hsData,
                                    makePath("/_matrix/client/v3", "/presence/", userId, "/status"));
 }
 

--- a/Quotient/csapi/presence.h
+++ b/Quotient/csapi/presence.h
@@ -39,7 +39,7 @@ public:
     //!
     //! This function can be used when a URL for GetPresenceJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& userId);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& userId);
 
     // Result properties
 

--- a/Quotient/csapi/profile.cpp
+++ b/Quotient/csapi/profile.cpp
@@ -13,10 +13,10 @@ SetDisplayNameJob::SetDisplayNameJob(const QString& userId, const QString& displ
     setRequestData({ _dataJson });
 }
 
-QUrl GetDisplayNameJob::makeRequestUrl(QUrl baseUrl, const QString& userId)
+QUrl GetDisplayNameJob::makeRequestUrl(const HomeserverData& hsData, const QString& userId)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl), makePath("/_matrix/client/v3", "/profile/",
-                                                                userId, "/displayname"));
+    return BaseJob::makeRequestUrl(hsData, makePath("/_matrix/client/v3", "/profile/", userId,
+                                                    "/displayname"));
 }
 
 GetDisplayNameJob::GetDisplayNameJob(const QString& userId)
@@ -33,10 +33,10 @@ SetAvatarUrlJob::SetAvatarUrlJob(const QString& userId, const QUrl& avatarUrl)
     setRequestData({ _dataJson });
 }
 
-QUrl GetAvatarUrlJob::makeRequestUrl(QUrl baseUrl, const QString& userId)
+QUrl GetAvatarUrlJob::makeRequestUrl(const HomeserverData& hsData, const QString& userId)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl), makePath("/_matrix/client/v3", "/profile/",
-                                                                userId, "/avatar_url"));
+    return BaseJob::makeRequestUrl(hsData, makePath("/_matrix/client/v3", "/profile/", userId,
+                                                    "/avatar_url"));
 }
 
 GetAvatarUrlJob::GetAvatarUrlJob(const QString& userId)
@@ -44,10 +44,9 @@ GetAvatarUrlJob::GetAvatarUrlJob(const QString& userId)
               makePath("/_matrix/client/v3", "/profile/", userId, "/avatar_url"), false)
 {}
 
-QUrl GetUserProfileJob::makeRequestUrl(QUrl baseUrl, const QString& userId)
+QUrl GetUserProfileJob::makeRequestUrl(const HomeserverData& hsData, const QString& userId)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
-                                   makePath("/_matrix/client/v3", "/profile/", userId));
+    return BaseJob::makeRequestUrl(hsData, makePath("/_matrix/client/v3", "/profile/", userId));
 }
 
 GetUserProfileJob::GetUserProfileJob(const QString& userId)

--- a/Quotient/csapi/profile.h
+++ b/Quotient/csapi/profile.h
@@ -35,7 +35,7 @@ public:
     //!
     //! This function can be used when a URL for GetDisplayNameJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& userId);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& userId);
 
     // Result properties
 
@@ -74,7 +74,7 @@ public:
     //!
     //! This function can be used when a URL for GetAvatarUrlJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& userId);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& userId);
 
     // Result properties
 
@@ -100,7 +100,7 @@ public:
     //!
     //! This function can be used when a URL for GetUserProfileJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& userId);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& userId);
 
     // Result properties
 

--- a/Quotient/csapi/pusher.cpp
+++ b/Quotient/csapi/pusher.cpp
@@ -4,9 +4,9 @@
 
 using namespace Quotient;
 
-QUrl GetPushersJob::makeRequestUrl(QUrl baseUrl)
+QUrl GetPushersJob::makeRequestUrl(const HomeserverData& hsData)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl), makePath("/_matrix/client/v3", "/pushers"));
+    return BaseJob::makeRequestUrl(hsData, makePath("/_matrix/client/v3", "/pushers"));
 }
 
 GetPushersJob::GetPushersJob()

--- a/Quotient/csapi/pusher.h
+++ b/Quotient/csapi/pusher.h
@@ -68,7 +68,7 @@ public:
     //!
     //! This function can be used when a URL for GetPushersJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl);
+    static QUrl makeRequestUrl(const HomeserverData& hsData);
 
     // Result properties
 

--- a/Quotient/csapi/pushrules.cpp
+++ b/Quotient/csapi/pushrules.cpp
@@ -4,10 +4,9 @@
 
 using namespace Quotient;
 
-QUrl GetPushRulesJob::makeRequestUrl(QUrl baseUrl)
+QUrl GetPushRulesJob::makeRequestUrl(const HomeserverData& hsData)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
-                                   makePath("/_matrix/client/v3", "/pushrules"));
+    return BaseJob::makeRequestUrl(hsData, makePath("/_matrix/client/v3", "/pushrules"));
 }
 
 GetPushRulesJob::GetPushRulesJob()
@@ -17,11 +16,11 @@ GetPushRulesJob::GetPushRulesJob()
     addExpectedKey("global");
 }
 
-QUrl GetPushRuleJob::makeRequestUrl(QUrl baseUrl, const QString& scope, const QString& kind,
-                                    const QString& ruleId)
+QUrl GetPushRuleJob::makeRequestUrl(const HomeserverData& hsData, const QString& scope,
+                                    const QString& kind, const QString& ruleId)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl), makePath("/_matrix/client/v3", "/pushrules/",
-                                                                scope, "/", kind, "/", ruleId));
+    return BaseJob::makeRequestUrl(hsData, makePath("/_matrix/client/v3", "/pushrules/", scope, "/",
+                                                    kind, "/", ruleId));
 }
 
 GetPushRuleJob::GetPushRuleJob(const QString& scope, const QString& kind, const QString& ruleId)
@@ -29,11 +28,11 @@ GetPushRuleJob::GetPushRuleJob(const QString& scope, const QString& kind, const 
               makePath("/_matrix/client/v3", "/pushrules/", scope, "/", kind, "/", ruleId))
 {}
 
-QUrl DeletePushRuleJob::makeRequestUrl(QUrl baseUrl, const QString& scope, const QString& kind,
-                                       const QString& ruleId)
+QUrl DeletePushRuleJob::makeRequestUrl(const HomeserverData& hsData, const QString& scope,
+                                       const QString& kind, const QString& ruleId)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl), makePath("/_matrix/client/v3", "/pushrules/",
-                                                                scope, "/", kind, "/", ruleId));
+    return BaseJob::makeRequestUrl(hsData, makePath("/_matrix/client/v3", "/pushrules/", scope, "/",
+                                                    kind, "/", ruleId));
 }
 
 DeletePushRuleJob::DeletePushRuleJob(const QString& scope, const QString& kind,
@@ -65,12 +64,11 @@ SetPushRuleJob::SetPushRuleJob(const QString& scope, const QString& kind, const 
     setRequestData({ _dataJson });
 }
 
-QUrl IsPushRuleEnabledJob::makeRequestUrl(QUrl baseUrl, const QString& scope, const QString& kind,
-                                          const QString& ruleId)
+QUrl IsPushRuleEnabledJob::makeRequestUrl(const HomeserverData& hsData, const QString& scope,
+                                          const QString& kind, const QString& ruleId)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
-                                   makePath("/_matrix/client/v3", "/pushrules/", scope, "/", kind,
-                                            "/", ruleId, "/enabled"));
+    return BaseJob::makeRequestUrl(hsData, makePath("/_matrix/client/v3", "/pushrules/", scope, "/",
+                                                    kind, "/", ruleId, "/enabled"));
 }
 
 IsPushRuleEnabledJob::IsPushRuleEnabledJob(const QString& scope, const QString& kind,
@@ -93,12 +91,11 @@ SetPushRuleEnabledJob::SetPushRuleEnabledJob(const QString& scope, const QString
     setRequestData({ _dataJson });
 }
 
-QUrl GetPushRuleActionsJob::makeRequestUrl(QUrl baseUrl, const QString& scope, const QString& kind,
-                                           const QString& ruleId)
+QUrl GetPushRuleActionsJob::makeRequestUrl(const HomeserverData& hsData, const QString& scope,
+                                           const QString& kind, const QString& ruleId)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
-                                   makePath("/_matrix/client/v3", "/pushrules/", scope, "/", kind,
-                                            "/", ruleId, "/actions"));
+    return BaseJob::makeRequestUrl(hsData, makePath("/_matrix/client/v3", "/pushrules/", scope, "/",
+                                                    kind, "/", ruleId, "/actions"));
 }
 
 GetPushRuleActionsJob::GetPushRuleActionsJob(const QString& scope, const QString& kind,

--- a/Quotient/csapi/pushrules.h
+++ b/Quotient/csapi/pushrules.h
@@ -24,7 +24,7 @@ public:
     //!
     //! This function can be used when a URL for GetPushRulesJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl);
+    static QUrl makeRequestUrl(const HomeserverData& hsData);
 
     // Result properties
 
@@ -53,8 +53,8 @@ public:
     //!
     //! This function can be used when a URL for GetPushRuleJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& scope, const QString& kind,
-                               const QString& ruleId);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& scope,
+                               const QString& kind, const QString& ruleId);
 
     // Result properties
 
@@ -84,8 +84,8 @@ public:
     //!
     //! This function can be used when a URL for DeletePushRuleJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& scope, const QString& kind,
-                               const QString& ruleId);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& scope,
+                               const QString& kind, const QString& ruleId);
 };
 
 //! \brief Add or change a push rule.
@@ -165,8 +165,8 @@ public:
     //!
     //! This function can be used when a URL for IsPushRuleEnabledJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& scope, const QString& kind,
-                               const QString& ruleId);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& scope,
+                               const QString& kind, const QString& ruleId);
 
     // Result properties
 
@@ -216,8 +216,8 @@ public:
     //!
     //! This function can be used when a URL for GetPushRuleActionsJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& scope, const QString& kind,
-                               const QString& ruleId);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& scope,
+                               const QString& kind, const QString& ruleId);
 
     // Result properties
 

--- a/Quotient/csapi/registration.cpp
+++ b/Quotient/csapi/registration.cpp
@@ -93,10 +93,10 @@ auto queryToCheckUsernameAvailability(const QString& username)
     return _q;
 }
 
-QUrl CheckUsernameAvailabilityJob::makeRequestUrl(QUrl baseUrl, const QString& username)
+QUrl CheckUsernameAvailabilityJob::makeRequestUrl(const HomeserverData& hsData,
+                                                  const QString& username)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
-                                   makePath("/_matrix/client/v3", "/register/available"),
+    return BaseJob::makeRequestUrl(hsData, makePath("/_matrix/client/v3", "/register/available"),
                                    queryToCheckUsernameAvailability(username));
 }
 

--- a/Quotient/csapi/registration.h
+++ b/Quotient/csapi/registration.h
@@ -410,7 +410,7 @@ public:
     //!
     //! This function can be used when a URL for CheckUsernameAvailabilityJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& username);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& username);
 
     // Result properties
 

--- a/Quotient/csapi/registration_tokens.cpp
+++ b/Quotient/csapi/registration_tokens.cpp
@@ -11,9 +11,9 @@ auto queryToRegistrationTokenValidity(const QString& token)
     return _q;
 }
 
-QUrl RegistrationTokenValidityJob::makeRequestUrl(QUrl baseUrl, const QString& token)
+QUrl RegistrationTokenValidityJob::makeRequestUrl(const HomeserverData& hsData, const QString& token)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
+    return BaseJob::makeRequestUrl(hsData,
                                    makePath("/_matrix/client/v1",
                                             "/register/m.login.registration_token/validity"),
                                    queryToRegistrationTokenValidity(token));

--- a/Quotient/csapi/registration_tokens.h
+++ b/Quotient/csapi/registration_tokens.h
@@ -24,7 +24,7 @@ public:
     //!
     //! This function can be used when a URL for RegistrationTokenValidityJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& token);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& token);
 
     // Result properties
 

--- a/Quotient/csapi/relations.cpp
+++ b/Quotient/csapi/relations.cpp
@@ -16,12 +16,12 @@ auto queryToGetRelatingEvents(const QString& from, const QString& to, std::optio
     return _q;
 }
 
-QUrl GetRelatingEventsJob::makeRequestUrl(QUrl baseUrl, const QString& roomId,
+QUrl GetRelatingEventsJob::makeRequestUrl(const HomeserverData& hsData, const QString& roomId,
                                           const QString& eventId, const QString& from,
                                           const QString& to, std::optional<int> limit,
                                           const QString& dir, std::optional<bool> recurse)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
+    return BaseJob::makeRequestUrl(hsData,
                                    makePath("/_matrix/client/v1", "/rooms/", roomId, "/relations/",
                                             eventId),
                                    queryToGetRelatingEvents(from, to, limit, dir, recurse));
@@ -51,14 +51,14 @@ auto queryToGetRelatingEventsWithRelType(const QString& from, const QString& to,
     return _q;
 }
 
-QUrl GetRelatingEventsWithRelTypeJob::makeRequestUrl(QUrl baseUrl, const QString& roomId,
-                                                     const QString& eventId, const QString& relType,
-                                                     const QString& from, const QString& to,
-                                                     std::optional<int> limit, const QString& dir,
-                                                     std::optional<bool> recurse)
+QUrl GetRelatingEventsWithRelTypeJob::makeRequestUrl(const HomeserverData& hsData,
+                                                     const QString& roomId, const QString& eventId,
+                                                     const QString& relType, const QString& from,
+                                                     const QString& to, std::optional<int> limit,
+                                                     const QString& dir, std::optional<bool> recurse)
 {
     return BaseJob::makeRequestUrl(
-        std::move(baseUrl),
+        hsData,
         makePath("/_matrix/client/v1", "/rooms/", roomId, "/relations/", eventId, "/", relType),
         queryToGetRelatingEventsWithRelType(from, to, limit, dir, recurse));
 }
@@ -88,11 +88,11 @@ auto queryToGetRelatingEventsWithRelTypeAndEventType(const QString& from, const 
 }
 
 QUrl GetRelatingEventsWithRelTypeAndEventTypeJob::makeRequestUrl(
-    QUrl baseUrl, const QString& roomId, const QString& eventId, const QString& relType,
-    const QString& eventType, const QString& from, const QString& to, std::optional<int> limit,
-    const QString& dir, std::optional<bool> recurse)
+    const HomeserverData& hsData, const QString& roomId, const QString& eventId,
+    const QString& relType, const QString& eventType, const QString& from, const QString& to,
+    std::optional<int> limit, const QString& dir, std::optional<bool> recurse)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
+    return BaseJob::makeRequestUrl(hsData,
                                    makePath("/_matrix/client/v1", "/rooms/", roomId, "/relations/",
                                             eventId, "/", relType, "/", eventType),
                                    queryToGetRelatingEventsWithRelTypeAndEventType(from, to, limit,

--- a/Quotient/csapi/relations.h
+++ b/Quotient/csapi/relations.h
@@ -76,10 +76,10 @@ public:
     //!
     //! This function can be used when a URL for GetRelatingEventsJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& roomId, const QString& eventId,
-                               const QString& from = {}, const QString& to = {},
-                               std::optional<int> limit = std::nullopt, const QString& dir = {},
-                               std::optional<bool> recurse = std::nullopt);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& roomId,
+                               const QString& eventId, const QString& from = {},
+                               const QString& to = {}, std::optional<int> limit = std::nullopt,
+                               const QString& dir = {}, std::optional<bool> recurse = std::nullopt);
 
     // Result properties
 
@@ -201,10 +201,11 @@ public:
     //!
     //! This function can be used when a URL for GetRelatingEventsWithRelTypeJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& roomId, const QString& eventId,
-                               const QString& relType, const QString& from = {},
-                               const QString& to = {}, std::optional<int> limit = std::nullopt,
-                               const QString& dir = {}, std::optional<bool> recurse = std::nullopt);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& roomId,
+                               const QString& eventId, const QString& relType,
+                               const QString& from = {}, const QString& to = {},
+                               std::optional<int> limit = std::nullopt, const QString& dir = {},
+                               std::optional<bool> recurse = std::nullopt);
 
     // Result properties
 
@@ -336,11 +337,11 @@ public:
     //!
     //! This function can be used when a URL for GetRelatingEventsWithRelTypeAndEventTypeJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& roomId, const QString& eventId,
-                               const QString& relType, const QString& eventType,
-                               const QString& from = {}, const QString& to = {},
-                               std::optional<int> limit = std::nullopt, const QString& dir = {},
-                               std::optional<bool> recurse = std::nullopt);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& roomId,
+                               const QString& eventId, const QString& relType,
+                               const QString& eventType, const QString& from = {},
+                               const QString& to = {}, std::optional<int> limit = std::nullopt,
+                               const QString& dir = {}, std::optional<bool> recurse = std::nullopt);
 
     // Result properties
 

--- a/Quotient/csapi/room_event_by_timestamp.cpp
+++ b/Quotient/csapi/room_event_by_timestamp.cpp
@@ -12,10 +12,10 @@ auto queryToGetEventByTimestamp(int ts, const QString& dir)
     return _q;
 }
 
-QUrl GetEventByTimestampJob::makeRequestUrl(QUrl baseUrl, const QString& roomId, int ts,
-                                            const QString& dir)
+QUrl GetEventByTimestampJob::makeRequestUrl(const HomeserverData& hsData, const QString& roomId,
+                                            int ts, const QString& dir)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
+    return BaseJob::makeRequestUrl(hsData,
                                    makePath("/_matrix/client/v1", "/rooms/", roomId,
                                             "/timestamp_to_event"),
                                    queryToGetEventByTimestamp(ts, dir));

--- a/Quotient/csapi/room_event_by_timestamp.h
+++ b/Quotient/csapi/room_event_by_timestamp.h
@@ -49,7 +49,8 @@ public:
     //!
     //! This function can be used when a URL for GetEventByTimestampJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& roomId, int ts, const QString& dir);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& roomId, int ts,
+                               const QString& dir);
 
     // Result properties
 

--- a/Quotient/csapi/rooms.cpp
+++ b/Quotient/csapi/rooms.cpp
@@ -4,10 +4,11 @@
 
 using namespace Quotient;
 
-QUrl GetOneRoomEventJob::makeRequestUrl(QUrl baseUrl, const QString& roomId, const QString& eventId)
+QUrl GetOneRoomEventJob::makeRequestUrl(const HomeserverData& hsData, const QString& roomId,
+                                        const QString& eventId)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl), makePath("/_matrix/client/v3", "/rooms/",
-                                                                roomId, "/event/", eventId));
+    return BaseJob::makeRequestUrl(hsData, makePath("/_matrix/client/v3", "/rooms/", roomId,
+                                                    "/event/", eventId));
 }
 
 GetOneRoomEventJob::GetOneRoomEventJob(const QString& roomId, const QString& eventId)
@@ -15,12 +16,11 @@ GetOneRoomEventJob::GetOneRoomEventJob(const QString& roomId, const QString& eve
               makePath("/_matrix/client/v3", "/rooms/", roomId, "/event/", eventId))
 {}
 
-QUrl GetRoomStateWithKeyJob::makeRequestUrl(QUrl baseUrl, const QString& roomId,
+QUrl GetRoomStateWithKeyJob::makeRequestUrl(const HomeserverData& hsData, const QString& roomId,
                                             const QString& eventType, const QString& stateKey)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
-                                   makePath("/_matrix/client/v3", "/rooms/", roomId, "/state/",
-                                            eventType, "/", stateKey));
+    return BaseJob::makeRequestUrl(hsData, makePath("/_matrix/client/v3", "/rooms/", roomId,
+                                                    "/state/", eventType, "/", stateKey));
 }
 
 GetRoomStateWithKeyJob::GetRoomStateWithKeyJob(const QString& roomId, const QString& eventType,
@@ -29,9 +29,9 @@ GetRoomStateWithKeyJob::GetRoomStateWithKeyJob(const QString& roomId, const QStr
               makePath("/_matrix/client/v3", "/rooms/", roomId, "/state/", eventType, "/", stateKey))
 {}
 
-QUrl GetRoomStateJob::makeRequestUrl(QUrl baseUrl, const QString& roomId)
+QUrl GetRoomStateJob::makeRequestUrl(const HomeserverData& hsData, const QString& roomId)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
+    return BaseJob::makeRequestUrl(hsData,
                                    makePath("/_matrix/client/v3", "/rooms/", roomId, "/state"));
 }
 
@@ -50,10 +50,11 @@ auto queryToGetMembersByRoom(const QString& at, const QString& membership,
     return _q;
 }
 
-QUrl GetMembersByRoomJob::makeRequestUrl(QUrl baseUrl, const QString& roomId, const QString& at,
-                                         const QString& membership, const QString& notMembership)
+QUrl GetMembersByRoomJob::makeRequestUrl(const HomeserverData& hsData, const QString& roomId,
+                                         const QString& at, const QString& membership,
+                                         const QString& notMembership)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
+    return BaseJob::makeRequestUrl(hsData,
                                    makePath("/_matrix/client/v3", "/rooms/", roomId, "/members"),
                                    queryToGetMembersByRoom(at, membership, notMembership));
 }
@@ -65,10 +66,10 @@ GetMembersByRoomJob::GetMembersByRoomJob(const QString& roomId, const QString& a
               queryToGetMembersByRoom(at, membership, notMembership))
 {}
 
-QUrl GetJoinedMembersByRoomJob::makeRequestUrl(QUrl baseUrl, const QString& roomId)
+QUrl GetJoinedMembersByRoomJob::makeRequestUrl(const HomeserverData& hsData, const QString& roomId)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl), makePath("/_matrix/client/v3", "/rooms/",
-                                                                roomId, "/joined_members"));
+    return BaseJob::makeRequestUrl(hsData, makePath("/_matrix/client/v3", "/rooms/", roomId,
+                                                    "/joined_members"));
 }
 
 GetJoinedMembersByRoomJob::GetJoinedMembersByRoomJob(const QString& roomId)

--- a/Quotient/csapi/rooms.h
+++ b/Quotient/csapi/rooms.h
@@ -25,7 +25,8 @@ public:
     //!
     //! This function can be used when a URL for GetOneRoomEventJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& roomId, const QString& eventId);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& roomId,
+                               const QString& eventId);
 
     // Result properties
 
@@ -59,8 +60,8 @@ public:
     //!
     //! This function can be used when a URL for GetRoomStateWithKeyJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& roomId, const QString& eventType,
-                               const QString& stateKey);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& roomId,
+                               const QString& eventType, const QString& stateKey);
 
     // Result properties
 
@@ -83,7 +84,7 @@ public:
     //!
     //! This function can be used when a URL for GetRoomStateJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& roomId);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& roomId);
 
     // Result properties
 
@@ -123,8 +124,9 @@ public:
     //!
     //! This function can be used when a URL for GetMembersByRoomJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& roomId, const QString& at = {},
-                               const QString& membership = {}, const QString& notMembership = {});
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& roomId,
+                               const QString& at = {}, const QString& membership = {},
+                               const QString& notMembership = {});
 
     // Result properties
 
@@ -162,7 +164,7 @@ public:
     //!
     //! This function can be used when a URL for GetJoinedMembersByRoomJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& roomId);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& roomId);
 
     // Result properties
 

--- a/Quotient/csapi/space_hierarchy.cpp
+++ b/Quotient/csapi/space_hierarchy.cpp
@@ -15,12 +15,12 @@ auto queryToGetSpaceHierarchy(std::optional<bool> suggestedOnly, std::optional<i
     return _q;
 }
 
-QUrl GetSpaceHierarchyJob::makeRequestUrl(QUrl baseUrl, const QString& roomId,
+QUrl GetSpaceHierarchyJob::makeRequestUrl(const HomeserverData& hsData, const QString& roomId,
                                           std::optional<bool> suggestedOnly,
                                           std::optional<int> limit, std::optional<int> maxDepth,
                                           const QString& from)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
+    return BaseJob::makeRequestUrl(hsData,
                                    makePath("/_matrix/client/v1", "/rooms/", roomId, "/hierarchy"),
                                    queryToGetSpaceHierarchy(suggestedOnly, limit, maxDepth, from));
 }

--- a/Quotient/csapi/space_hierarchy.h
+++ b/Quotient/csapi/space_hierarchy.h
@@ -99,7 +99,7 @@ public:
     //!
     //! This function can be used when a URL for GetSpaceHierarchyJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& roomId,
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& roomId,
                                std::optional<bool> suggestedOnly = std::nullopt,
                                std::optional<int> limit = std::nullopt,
                                std::optional<int> maxDepth = std::nullopt, const QString& from = {});

--- a/Quotient/csapi/sso_login_redirect.cpp
+++ b/Quotient/csapi/sso_login_redirect.cpp
@@ -11,10 +11,9 @@ auto queryToRedirectToSSO(const QString& redirectUrl)
     return _q;
 }
 
-QUrl RedirectToSSOJob::makeRequestUrl(QUrl baseUrl, const QString& redirectUrl)
+QUrl RedirectToSSOJob::makeRequestUrl(const HomeserverData& hsData, const QString& redirectUrl)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
-                                   makePath("/_matrix/client/v3", "/login/sso/redirect"),
+    return BaseJob::makeRequestUrl(hsData, makePath("/_matrix/client/v3", "/login/sso/redirect"),
                                    queryToRedirectToSSO(redirectUrl));
 }
 
@@ -31,9 +30,10 @@ auto queryToRedirectToIdP(const QString& redirectUrl)
     return _q;
 }
 
-QUrl RedirectToIdPJob::makeRequestUrl(QUrl baseUrl, const QString& idpId, const QString& redirectUrl)
+QUrl RedirectToIdPJob::makeRequestUrl(const HomeserverData& hsData, const QString& idpId,
+                                      const QString& redirectUrl)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
+    return BaseJob::makeRequestUrl(hsData,
                                    makePath("/_matrix/client/v3", "/login/sso/redirect/", idpId),
                                    queryToRedirectToIdP(redirectUrl));
 }

--- a/Quotient/csapi/sso_login_redirect.h
+++ b/Quotient/csapi/sso_login_redirect.h
@@ -25,7 +25,7 @@ public:
     //!
     //! This function can be used when a URL for RedirectToSSOJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& redirectUrl);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& redirectUrl);
 };
 
 //! \brief Redirect the user's browser to the SSO interface for an IdP.
@@ -51,7 +51,8 @@ public:
     //!
     //! This function can be used when a URL for RedirectToIdPJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& idpId, const QString& redirectUrl);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& idpId,
+                               const QString& redirectUrl);
 };
 
 } // namespace Quotient

--- a/Quotient/csapi/support.cpp
+++ b/Quotient/csapi/support.cpp
@@ -4,9 +4,9 @@
 
 using namespace Quotient;
 
-QUrl GetWellknownSupportJob::makeRequestUrl(QUrl baseUrl)
+QUrl GetWellknownSupportJob::makeRequestUrl(const HomeserverData& hsData)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl), makePath("/.well-known", "/matrix/support"));
+    return BaseJob::makeRequestUrl(hsData, makePath("/.well-known", "/matrix/support"));
 }
 
 GetWellknownSupportJob::GetWellknownSupportJob()

--- a/Quotient/csapi/support.h
+++ b/Quotient/csapi/support.h
@@ -60,7 +60,7 @@ public:
     //!
     //! This function can be used when a URL for GetWellknownSupportJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl);
+    static QUrl makeRequestUrl(const HomeserverData& hsData);
 
     // Result properties
 

--- a/Quotient/csapi/tags.cpp
+++ b/Quotient/csapi/tags.cpp
@@ -4,10 +4,11 @@
 
 using namespace Quotient;
 
-QUrl GetRoomTagsJob::makeRequestUrl(QUrl baseUrl, const QString& userId, const QString& roomId)
+QUrl GetRoomTagsJob::makeRequestUrl(const HomeserverData& hsData, const QString& userId,
+                                    const QString& roomId)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl), makePath("/_matrix/client/v3", "/user/",
-                                                                userId, "/rooms/", roomId, "/tags"));
+    return BaseJob::makeRequestUrl(hsData, makePath("/_matrix/client/v3", "/user/", userId,
+                                                    "/rooms/", roomId, "/tags"));
 }
 
 GetRoomTagsJob::GetRoomTagsJob(const QString& userId, const QString& roomId)
@@ -23,12 +24,11 @@ SetRoomTagJob::SetRoomTagJob(const QString& userId, const QString& roomId, const
     setRequestData({ toJson(data) });
 }
 
-QUrl DeleteRoomTagJob::makeRequestUrl(QUrl baseUrl, const QString& userId, const QString& roomId,
-                                      const QString& tag)
+QUrl DeleteRoomTagJob::makeRequestUrl(const HomeserverData& hsData, const QString& userId,
+                                      const QString& roomId, const QString& tag)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
-                                   makePath("/_matrix/client/v3", "/user/", userId, "/rooms/",
-                                            roomId, "/tags/", tag));
+    return BaseJob::makeRequestUrl(hsData, makePath("/_matrix/client/v3", "/user/", userId,
+                                                    "/rooms/", roomId, "/tags/", tag));
 }
 
 DeleteRoomTagJob::DeleteRoomTagJob(const QString& userId, const QString& roomId, const QString& tag)

--- a/Quotient/csapi/tags.h
+++ b/Quotient/csapi/tags.h
@@ -25,7 +25,8 @@ public:
     //!
     //! This function can be used when a URL for GetRoomTagsJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& userId, const QString& roomId);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& userId,
+                               const QString& roomId);
 
     // Result properties
 
@@ -75,8 +76,8 @@ public:
     //!
     //! This function can be used when a URL for DeleteRoomTagJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& userId, const QString& roomId,
-                               const QString& tag);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& userId,
+                               const QString& roomId, const QString& tag);
 };
 
 } // namespace Quotient

--- a/Quotient/csapi/third_party_lookup.cpp
+++ b/Quotient/csapi/third_party_lookup.cpp
@@ -4,10 +4,9 @@
 
 using namespace Quotient;
 
-QUrl GetProtocolsJob::makeRequestUrl(QUrl baseUrl)
+QUrl GetProtocolsJob::makeRequestUrl(const HomeserverData& hsData)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
-                                   makePath("/_matrix/client/v3", "/thirdparty/protocols"));
+    return BaseJob::makeRequestUrl(hsData, makePath("/_matrix/client/v3", "/thirdparty/protocols"));
 }
 
 GetProtocolsJob::GetProtocolsJob()
@@ -15,10 +14,10 @@ GetProtocolsJob::GetProtocolsJob()
               makePath("/_matrix/client/v3", "/thirdparty/protocols"))
 {}
 
-QUrl GetProtocolMetadataJob::makeRequestUrl(QUrl baseUrl, const QString& protocol)
+QUrl GetProtocolMetadataJob::makeRequestUrl(const HomeserverData& hsData, const QString& protocol)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl), makePath("/_matrix/client/v3",
-                                                                "/thirdparty/protocol/", protocol));
+    return BaseJob::makeRequestUrl(hsData, makePath("/_matrix/client/v3", "/thirdparty/protocol/",
+                                                    protocol));
 }
 
 GetProtocolMetadataJob::GetProtocolMetadataJob(const QString& protocol)
@@ -33,10 +32,10 @@ auto queryToQueryLocationByProtocol(const QString& searchFields)
     return _q;
 }
 
-QUrl QueryLocationByProtocolJob::makeRequestUrl(QUrl baseUrl, const QString& protocol,
-                                                const QString& searchFields)
+QUrl QueryLocationByProtocolJob::makeRequestUrl(const HomeserverData& hsData,
+                                                const QString& protocol, const QString& searchFields)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
+    return BaseJob::makeRequestUrl(hsData,
                                    makePath("/_matrix/client/v3", "/thirdparty/location/", protocol),
                                    queryToQueryLocationByProtocol(searchFields));
 }
@@ -55,10 +54,10 @@ auto queryToQueryUserByProtocol(const QHash<QString, QString>& fields)
     return _q;
 }
 
-QUrl QueryUserByProtocolJob::makeRequestUrl(QUrl baseUrl, const QString& protocol,
+QUrl QueryUserByProtocolJob::makeRequestUrl(const HomeserverData& hsData, const QString& protocol,
                                             const QHash<QString, QString>& fields)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
+    return BaseJob::makeRequestUrl(hsData,
                                    makePath("/_matrix/client/v3", "/thirdparty/user/", protocol),
                                    queryToQueryUserByProtocol(fields));
 }
@@ -77,10 +76,9 @@ auto queryToQueryLocationByAlias(const QString& alias)
     return _q;
 }
 
-QUrl QueryLocationByAliasJob::makeRequestUrl(QUrl baseUrl, const QString& alias)
+QUrl QueryLocationByAliasJob::makeRequestUrl(const HomeserverData& hsData, const QString& alias)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
-                                   makePath("/_matrix/client/v3", "/thirdparty/location"),
+    return BaseJob::makeRequestUrl(hsData, makePath("/_matrix/client/v3", "/thirdparty/location"),
                                    queryToQueryLocationByAlias(alias));
 }
 
@@ -97,10 +95,9 @@ auto queryToQueryUserByID(const QString& userid)
     return _q;
 }
 
-QUrl QueryUserByIDJob::makeRequestUrl(QUrl baseUrl, const QString& userid)
+QUrl QueryUserByIDJob::makeRequestUrl(const HomeserverData& hsData, const QString& userid)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
-                                   makePath("/_matrix/client/v3", "/thirdparty/user"),
+    return BaseJob::makeRequestUrl(hsData, makePath("/_matrix/client/v3", "/thirdparty/user"),
                                    queryToQueryUserByID(userid));
 }
 

--- a/Quotient/csapi/third_party_lookup.h
+++ b/Quotient/csapi/third_party_lookup.h
@@ -23,7 +23,7 @@ public:
     //!
     //! This function can be used when a URL for GetProtocolsJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl);
+    static QUrl makeRequestUrl(const HomeserverData& hsData);
 
     // Result properties
 
@@ -49,7 +49,7 @@ public:
     //!
     //! This function can be used when a URL for GetProtocolMetadataJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& protocol);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& protocol);
 
     // Result properties
 
@@ -83,7 +83,7 @@ public:
     //!
     //! This function can be used when a URL for QueryLocationByProtocolJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& protocol,
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& protocol,
                                const QString& searchFields = {});
 
     // Result properties
@@ -115,7 +115,7 @@ public:
     //!
     //! This function can be used when a URL for QueryUserByProtocolJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& protocol,
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& protocol,
                                const QHash<QString, QString>& fields = {});
 
     // Result properties
@@ -140,7 +140,7 @@ public:
     //!
     //! This function can be used when a URL for QueryLocationByAliasJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& alias);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& alias);
 
     // Result properties
 
@@ -166,7 +166,7 @@ public:
     //!
     //! This function can be used when a URL for QueryUserByIDJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& userid);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& userid);
 
     // Result properties
 

--- a/Quotient/csapi/threads_list.cpp
+++ b/Quotient/csapi/threads_list.cpp
@@ -13,10 +13,11 @@ auto queryToGetThreadRoots(const QString& include, std::optional<int> limit, con
     return _q;
 }
 
-QUrl GetThreadRootsJob::makeRequestUrl(QUrl baseUrl, const QString& roomId, const QString& include,
-                                       std::optional<int> limit, const QString& from)
+QUrl GetThreadRootsJob::makeRequestUrl(const HomeserverData& hsData, const QString& roomId,
+                                       const QString& include, std::optional<int> limit,
+                                       const QString& from)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
+    return BaseJob::makeRequestUrl(hsData,
                                    makePath("/_matrix/client/v1", "/rooms/", roomId, "/threads"),
                                    queryToGetThreadRoots(include, limit, from));
 }

--- a/Quotient/csapi/threads_list.h
+++ b/Quotient/csapi/threads_list.h
@@ -43,8 +43,9 @@ public:
     //!
     //! This function can be used when a URL for GetThreadRootsJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl, const QString& roomId, const QString& include = {},
-                               std::optional<int> limit = std::nullopt, const QString& from = {});
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& roomId,
+                               const QString& include = {}, std::optional<int> limit = std::nullopt,
+                               const QString& from = {});
 
     // Result properties
 

--- a/Quotient/csapi/versions.cpp
+++ b/Quotient/csapi/versions.cpp
@@ -4,9 +4,9 @@
 
 using namespace Quotient;
 
-QUrl GetVersionsJob::makeRequestUrl(QUrl baseUrl)
+QUrl GetVersionsJob::makeRequestUrl(const HomeserverData& hsData)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl), makePath("/_matrix/client", "/versions"));
+    return BaseJob::makeRequestUrl(hsData, makePath("/_matrix/client", "/versions"));
 }
 
 GetVersionsJob::GetVersionsJob()

--- a/Quotient/csapi/versions.h
+++ b/Quotient/csapi/versions.h
@@ -38,7 +38,7 @@ public:
     //!
     //! This function can be used when a URL for GetVersionsJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl);
+    static QUrl makeRequestUrl(const HomeserverData& hsData);
 
     // Result properties
 

--- a/Quotient/csapi/voip.cpp
+++ b/Quotient/csapi/voip.cpp
@@ -4,10 +4,9 @@
 
 using namespace Quotient;
 
-QUrl GetTurnServerJob::makeRequestUrl(QUrl baseUrl)
+QUrl GetTurnServerJob::makeRequestUrl(const HomeserverData& hsData)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
-                                   makePath("/_matrix/client/v3", "/voip/turnServer"));
+    return BaseJob::makeRequestUrl(hsData, makePath("/_matrix/client/v3", "/voip/turnServer"));
 }
 
 GetTurnServerJob::GetTurnServerJob()

--- a/Quotient/csapi/voip.h
+++ b/Quotient/csapi/voip.h
@@ -18,7 +18,7 @@ public:
     //!
     //! This function can be used when a URL for GetTurnServerJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl);
+    static QUrl makeRequestUrl(const HomeserverData& hsData);
 
     // Result properties
 

--- a/Quotient/csapi/wellknown.cpp
+++ b/Quotient/csapi/wellknown.cpp
@@ -4,9 +4,9 @@
 
 using namespace Quotient;
 
-QUrl GetWellknownJob::makeRequestUrl(QUrl baseUrl)
+QUrl GetWellknownJob::makeRequestUrl(const HomeserverData& hsData)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl), makePath("/.well-known", "/matrix/client"));
+    return BaseJob::makeRequestUrl(hsData, makePath("/.well-known", "/matrix/client"));
 }
 
 GetWellknownJob::GetWellknownJob()

--- a/Quotient/csapi/wellknown.h
+++ b/Quotient/csapi/wellknown.h
@@ -26,7 +26,7 @@ public:
     //!
     //! This function can be used when a URL for GetWellknownJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl);
+    static QUrl makeRequestUrl(const HomeserverData& hsData);
 
     // Result properties
 

--- a/Quotient/csapi/whoami.cpp
+++ b/Quotient/csapi/whoami.cpp
@@ -4,10 +4,9 @@
 
 using namespace Quotient;
 
-QUrl GetTokenOwnerJob::makeRequestUrl(QUrl baseUrl)
+QUrl GetTokenOwnerJob::makeRequestUrl(const HomeserverData& hsData)
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl),
-                                   makePath("/_matrix/client/v3", "/account/whoami"));
+    return BaseJob::makeRequestUrl(hsData, makePath("/_matrix/client/v3", "/account/whoami"));
 }
 
 GetTokenOwnerJob::GetTokenOwnerJob()

--- a/Quotient/csapi/whoami.h
+++ b/Quotient/csapi/whoami.h
@@ -24,7 +24,7 @@ public:
     //!
     //! This function can be used when a URL for GetTokenOwnerJob
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl);
+    static QUrl makeRequestUrl(const HomeserverData& hsData);
 
     // Result properties
 

--- a/Quotient/jobs/basejob.h
+++ b/Quotient/jobs/basejob.h
@@ -339,6 +339,8 @@ Q_SIGNALS:
 protected:
     using headers_t = QHash<QByteArray, QByteArray>;
 
+    QByteArray apiEndpoint() const;
+    void setApiEndpoint(QByteArray apiEndpoint);
     const headers_t& requestHeaders() const;
     void setRequestHeader(const headers_t::key_type& headerName,
                           const headers_t::mapped_type& headerValue);
@@ -362,7 +364,7 @@ protected:
      * The function ensures exactly one '/' between the path component of
      * \p baseUrl and \p path. The query component of \p baseUrl is ignored.
      */
-    static QUrl makeRequestUrl(QUrl baseUrl, const QByteArray &encodedPath,
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QByteArray& encodedPath,
                                const QUrlQuery& query = {});
 
     /*! Prepares the job for execution
@@ -371,7 +373,7 @@ protected:
      * when it's first scheduled for execution; in particular, it is not called
      * on retries.
      */
-    virtual void doPrepare();
+    virtual void doPrepare(const ConnectionData* connectionData);
 
     /*! Postprocessing after the network request has been sent
      *

--- a/Quotient/jobs/downloadfilejob.h
+++ b/Quotient/jobs/downloadfilejob.h
@@ -3,21 +3,20 @@
 
 #pragma once
 
-#include <Quotient/csapi/content-repo.h>
+#include "basejob.h"
 
 namespace Quotient {
 struct EncryptedFileMetadata;
 
-class QUOTIENT_API DownloadFileJob : public GetContentJob {
+class QUOTIENT_API DownloadFileJob : public BaseJob {
 public:
-    using GetContentJob::makeRequestUrl;
-    static QUrl makeRequestUrl(QUrl baseUrl, const QUrl& mxcUri);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QUrl& mxcUri);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& serverName,
+                               const QString& mediaId);
 
-    DownloadFileJob(const QString& serverName, const QString& mediaId,
-                    const QString& localFilename = {});
+    DownloadFileJob(QString serverName, QString mediaId, const QString& localFilename = {});
 
-    DownloadFileJob(const QString& serverName, const QString& mediaId,
-                    const EncryptedFileMetadata& file,
+    DownloadFileJob(QString serverName, QString mediaId, const EncryptedFileMetadata& file,
                     const QString& localFilename = {});
     QString targetFileName() const;
 
@@ -25,7 +24,7 @@ private:
     class Private;
     ImplPtr<Private> d;
 
-    void doPrepare() override;
+    void doPrepare(const ConnectionData* connectionData) override;
     void onSentRequest(QNetworkReply* reply) override;
     void beforeAbandon() override;
     Status prepareResult() override;

--- a/Quotient/jobs/mediathumbnailjob.h
+++ b/Quotient/jobs/mediathumbnailjob.h
@@ -3,30 +3,37 @@
 
 #pragma once
 
-#include <Quotient/csapi/content-repo.h>
+#include "basejob.h"
 
 #include <QtGui/QPixmap>
 
 namespace Quotient {
-class QUOTIENT_API MediaThumbnailJob : public GetContentThumbnailJob {
+class QUOTIENT_API MediaThumbnailJob : public BaseJob {
 public:
-    using GetContentThumbnailJob::makeRequestUrl;
-    static QUrl makeRequestUrl(QUrl baseUrl, const QUrl& mxcUri,
-                               QSize requestedSize);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QUrl& mxcUri,
+                               QSize requestedSize, std::optional<bool> animated = std::nullopt);
+    static QUrl makeRequestUrl(const HomeserverData& hsData, const QString& serverName,
+                               const QString& mediaId, QSize requestedSize,
+                               std::optional<bool> animated = std::nullopt);
 
-    MediaThumbnailJob(const QString& serverName, const QString& mediaId,
-                      QSize requestedSize);
-    MediaThumbnailJob(const QUrl& mxcUri, QSize requestedSize);
+    MediaThumbnailJob(QString serverName, QString mediaId, QSize requestedSize,
+                      std::optional<bool> animated = std::nullopt);
+    MediaThumbnailJob(const QUrl& mxcUri, QSize requestedSize,
+                      std::optional<bool> animated = std::nullopt);
 
     QImage thumbnail() const;
     [[deprecated("Use thumbnail().scaled() instead")]]
     QImage scaledThumbnail(QSize toSize) const;
 
-protected:
-    Status prepareResult() override;
-
 private:
+    QString serverName;
+    QString mediaId;
+    QSize requestedSize;
+    std::optional<bool> animated;
     QImage _thumbnail;
+
+    void doPrepare(const ConnectionData* connectionData) override;
+    Status prepareResult() override;
 };
 
 inline auto collectResponse(const MediaThumbnailJob* j) { return j->thumbnail(); }

--- a/Quotient/networkaccessmanager.cpp
+++ b/Quotient/networkaccessmanager.cpp
@@ -37,8 +37,8 @@ public:
             it != connectionData.end()) {
             it->hsData.baseUrl = std::move(baseUrl);
         } else
-            connectionData.emplace_back(std::move(accountId),
-                                        HomeserverData{ std::move(baseUrl), {} });
+            connectionData.push_back(
+                { std::move(accountId), HomeserverData{ std::move(baseUrl), {} } });
     }
     void addSpecVersions(QStringView accountId, QStringList versions)
     {

--- a/Quotient/networkaccessmanager.cpp
+++ b/Quotient/networkaccessmanager.cpp
@@ -160,8 +160,8 @@ QNetworkReply* NetworkAccessManager::createRequest(
             << "No connection specified, cannot convert mxc request";
         return new MxcReply();
     }
-    const auto& baseUrl = d.getConnection(accountId).baseUrl;
-    if (!baseUrl.isValid()) {
+    const auto& hsData = d.getConnection(accountId);
+    if (!hsData.baseUrl.isValid()) {
         // Strictly speaking, it should be an assert...
         qCCritical(NETWORK) << "Homeserver for" << accountId
                             << "not found, cannot convert mxc request";
@@ -170,7 +170,7 @@ QNetworkReply* NetworkAccessManager::createRequest(
 
     // Convert mxc:// URL into normal http(s) for the given homeserver
     QNetworkRequest rewrittenRequest(request);
-    rewrittenRequest.setUrl(DownloadFileJob::makeRequestUrl(baseUrl, url));
+    rewrittenRequest.setUrl(DownloadFileJob::makeRequestUrl(hsData, url));
 
     auto* implReply = QNetworkAccessManager::createRequest(op, rewrittenRequest);
     implReply->ignoreSslErrors(d.getIgnoredSslErrors());

--- a/Quotient/networkaccessmanager.cpp
+++ b/Quotient/networkaccessmanager.cpp
@@ -3,6 +3,7 @@
 
 #include "networkaccessmanager.h"
 
+#include "connectiondata.h"
 #include "logging_categories_p.h"
 #include "mxcreply.h"
 
@@ -21,20 +22,48 @@ using namespace Quotient;
 namespace {
 class {
 public:
-    void addBaseUrl(const QString& accountId, const QUrl& baseUrl)
+    struct ConnectionData {
+        QString accountId;
+        HomeserverData hsData;
+    };
+
+    void addConnection(QString accountId, QUrl baseUrl)
+    {
+        if (baseUrl.isEmpty())
+            return;
+
+        const QWriteLocker _(&namLock);
+        if (auto it = std::ranges::find(connectionData, accountId, &ConnectionData::accountId);
+            it != connectionData.end()) {
+            it->hsData.baseUrl = std::move(baseUrl);
+        } else
+            connectionData.emplace_back(std::move(accountId),
+                                        HomeserverData{ std::move(baseUrl), {} });
+    }
+    void addSpecVersions(QStringView accountId, QStringList versions)
+    {
+        if (versions.isEmpty())
+            return;
+
+        const QWriteLocker _(&namLock);
+        auto it = std::ranges::find(connectionData, accountId, &ConnectionData::accountId);
+        if (ALARM_X(it == connectionData.end(), "Quotient::NAM: Trying to save supported spec "
+                                                "versions on an inexistent account"))
+            return;
+
+        it->hsData.supportedSpecVersions = std::move(versions);
+    }
+    void dropConnection(QStringView accountId)
     {
         const QWriteLocker _(&namLock);
-        baseUrls.insert(accountId, baseUrl);
+        std::erase_if(connectionData,
+                      [&accountId](const ConnectionData& cd) { return cd.accountId == accountId; });
     }
-    void dropBaseUrl(const QString& accountId)
-    {
-        const QWriteLocker _(&namLock);
-        baseUrls.remove(accountId);
-    }
-    QUrl getBaseUrl(const QString& accountId) const
+    HomeserverData getConnection(const QString& accountId) const
     {
         const QReadLocker _(&namLock);
-        return baseUrls.value(accountId);
+        auto it = std::ranges::find(connectionData, accountId, &ConnectionData::accountId);
+        return it == connectionData.cend() ? HomeserverData{ } : it->hsData;
     }
     void addIgnoredSslError(const QSslError& error)
     {
@@ -54,22 +83,27 @@ public:
 
 private:
     mutable QReadWriteLock namLock{};
-    QHash<QString, QUrl> baseUrls{};
+    std::vector<ConnectionData> connectionData{};
     QList<QSslError> ignoredSslErrors{};
 } d;
 
 } // anonymous namespace
 
-void NetworkAccessManager::addBaseUrl(const QString& accountId,
-                                      const QUrl& homeserver)
+void NetworkAccessManager::addAccount(QString accountId, QUrl homeserver)
 {
-    Q_ASSERT(!accountId.isEmpty() && homeserver.isValid());
-    d.addBaseUrl(accountId, homeserver);
+    Q_ASSERT(!accountId.isEmpty());
+    d.addConnection( accountId, std::move(homeserver));
 }
 
-void NetworkAccessManager::dropBaseUrl(const QString& accountId)
+void NetworkAccessManager::updateAccountSpecVersions(QStringView accountId, QStringList versions)
 {
-    d.dropBaseUrl(accountId);
+    Q_ASSERT(!accountId.isEmpty());
+    d.addSpecVersions(accountId, std::move(versions));
+}
+
+void NetworkAccessManager::dropAccount(QStringView accountId)
+{
+    d.dropConnection(accountId);
 }
 
 QList<QSslError> NetworkAccessManager::ignoredSslErrors()
@@ -126,7 +160,7 @@ QNetworkReply* NetworkAccessManager::createRequest(
             << "No connection specified, cannot convert mxc request";
         return new MxcReply();
     }
-    const auto& baseUrl = d.getBaseUrl(accountId);
+    const auto& baseUrl = d.getConnection(accountId).baseUrl;
     if (!baseUrl.isValid()) {
         // Strictly speaking, it should be an assert...
         qCCritical(NETWORK) << "Homeserver for" << accountId

--- a/Quotient/networkaccessmanager.h
+++ b/Quotient/networkaccessmanager.h
@@ -14,8 +14,9 @@ class QUOTIENT_API NetworkAccessManager : public QNetworkAccessManager {
 public:
     using QNetworkAccessManager::QNetworkAccessManager;
 
-    static void addBaseUrl(const QString& accountId, const QUrl& homeserver);
-    static void dropBaseUrl(const QString& accountId);
+    static void addAccount(QString accountId, QUrl homeserver);
+    static void updateAccountSpecVersions(QStringView accountId, QStringList versions);
+    static void dropAccount(QStringView accountId);
 
     static QList<QSslError> ignoredSslErrors();
     static void addIgnoredSslError(const QSslError& error);

--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -504,7 +504,7 @@ QString Room::version() const
 
 bool Room::isUnstable() const
 {
-    return !connection()->loadingCapabilities()
+    return connection()->capabilitiesReady()
            && !connection()->stableRoomVersions().contains(version());
 }
 

--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -26,6 +26,7 @@
 
 #include "csapi/account-data.h"
 #include "csapi/banning.h"
+#include "csapi/content-repo.h"
 #include "csapi/inviting.h"
 #include "csapi/kicking.h"
 #include "csapi/leaving.h"

--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -26,7 +26,6 @@
 
 #include "csapi/account-data.h"
 #include "csapi/banning.h"
-#include "csapi/content-repo.h"
 #include "csapi/inviting.h"
 #include "csapi/kicking.h"
 #include "csapi/leaving.h"

--- a/Quotient/util.cpp
+++ b/Quotient/util.cpp
@@ -126,7 +126,13 @@ int Quotient::minorVersion()
     return Quotient_VERSION_MINOR;
 }
 
-int Quotient::patchVersion()
+int Quotient::patchVersion() { return Quotient_VERSION_PATCH; }
+
+bool HomeserverData::checkMatrixSpecVersion(QStringView targetVersion) const
 {
-    return Quotient_VERSION_PATCH;
+    // TODO: Replace this naïve implementation with something smarter that can check things like
+    //   1.12 > 1.11 and maybe even 1.10 > 1.9
+    return std::ranges::any_of(supportedSpecVersions, [targetVersion](const QString& v) {
+        return v.startsWith(targetVersion);
+    });
 }

--- a/Quotient/util.h
+++ b/Quotient/util.h
@@ -428,8 +428,9 @@ using UserId = QString;
 using RoomId = QString;
 using EventId = QString;
 
-struct HomeserverData {
+struct QUOTIENT_API HomeserverData {
     QUrl baseUrl;
     QStringList supportedSpecVersions;
-};
 
+    bool checkMatrixSpecVersion(QStringView targetVersion) const;
+};

--- a/Quotient/util.h
+++ b/Quotient/util.h
@@ -6,15 +6,16 @@
 
 #include "quotient_export.h"
 
-#include <QtCore/QLatin1String>
-#include <QtCore/QHashFunctions>
 #include <QtCore/QDebug>
 #include <QtCore/QElapsedTimer>
+#include <QtCore/QHashFunctions>
+#include <QtCore/QLatin1String>
+#include <QtCore/QUrl>
 
 #include <memory>
-#include <unordered_map>
 #include <optional>
 #include <source_location>
+#include <unordered_map>
 
 #define QUO_IMPLICIT explicit(false)
 
@@ -426,3 +427,9 @@ constexpr inline size_t mergeStruct(StructT& lhs, const StructT& rhs, const auto
 using UserId = QString;
 using RoomId = QString;
 using EventId = QString;
+
+struct HomeserverData {
+    QUrl baseUrl;
+    QStringList supportedSpecVersions;
+};
+

--- a/gtad/operation.cpp.mustache
+++ b/gtad/operation.cpp.mustache
@@ -19,10 +19,10 @@ auto queryTo{{>titleCaseOperationId}}(
     {{/queryParams?}}
     {{^hasBody?}}
 
-QUrl {{>titleCaseOperationId}}Job::makeRequestUrl(QUrl baseUrl{{#allParams?}},
+QUrl {{>titleCaseOperationId}}Job::makeRequestUrl(const HomeserverData& hsData{{#allParams?}},
         {{#allParams}}{{>joinedParamDef}}{{/allParams}}{{/allParams?}})
 {
-    return BaseJob::makeRequestUrl(std::move(baseUrl), {{>passPathAndMaybeQuery}});
+    return BaseJob::makeRequestUrl(hsData, {{>passPathAndMaybeQuery}});
 }   {{/hasBody?}}
 
 {{>titleCaseOperationId}}Job::{{>titleCaseOperationId}}Job(

--- a/gtad/operation.h.mustache
+++ b/gtad/operation.h.mustache
@@ -41,7 +41,7 @@ public:
     //!
     //! This function can be used when a URL for {{>titleCaseOperationId}}Job
     //! is necessary but the job itself isn't.
-    static QUrl makeRequestUrl(QUrl baseUrl{{#allParams?}},
+    static QUrl makeRequestUrl(const HomeserverData& hsData{{#allParams?}},
                     {{#allParams}}{{>joinedParamDecl}}{{/allParams}}{{/allParams?}});
     {{/hasBody?}}
     {{#responses}}{{#normalResponse?}}{{#allProperties?}}


### PR DESCRIPTION
This commit implements a proxy layer (almost entirely in terms of existing facilities - `Connection::downloadFile()/DownloadFileJob` and `Connection::getThumbnail()/MediaThumbnailJob` respectively) to spare clients from having to figure out which API, old or new, they should use to retrieve media on any given homeserver. In all honesty, the code for the new API hasn't been tested yet but it's almost entirely based on the generated API classes, so nothing should go wrong because our CS API descriptions are perfect, right? :-D

Implements [MSC3916](https://github.com/matrix-org/matrix-spec-proposals/pull/3916) and, while at it, [MSC2705](https://github.com/matrix-org/matrix-spec-proposals/pull/2705] (animated thumbnails).