### PR TITLE
Bug/regression fixes and some cleanup

### DIFF
--- a/Quotient/connection.cpp
+++ b/Quotient/connection.cpp
@@ -1302,6 +1302,8 @@ void Connection::removeFromIgnoredUsers(const QString& userId)
     }
 }
 
+QStringList Connection::userIds() const { return d->userMap.keys(); }
+
 const ConnectionData* Connection::connectionData() const
 {
     return d->data.get();

--- a/Quotient/connection.h
+++ b/Quotient/connection.h
@@ -283,6 +283,11 @@ public:
     //! \sa ignoredUsersListChanged
     Q_INVOKABLE void removeFromIgnoredUsers(const QString& userId);
 
+    //! \brief Get the entire list of users known to the current user on this homeserver
+    //! \note Be mindful that this can easily count thousands or tens of thousands, and use
+    //!       sparingly; when in a room context, always use Room::members() instead
+    Q_INVOKABLE QStringList userIds() const;
+
     //! Get the base URL of the homeserver to connect to
     QUrl homeserver() const;
     //! Get the domain name used for ids/aliases on the server

--- a/Quotient/connection_p.h
+++ b/Quotient/connection_p.h
@@ -39,6 +39,7 @@ public:
     QHash<QString, QString> roomAliasMap;
     QVector<QString> roomIdsToForget;
     QVector<QString> pendingStateRoomIds;
+    // It's an ordered map to make Connection::userIds() return an already sorted list
     QMap<QString, User*> userMap;
     std::unordered_map<QString, Avatar> userAvatarMap;
     DirectChatsMap directChats;

--- a/Quotient/connectiondata.cpp
+++ b/Quotient/connectiondata.cpp
@@ -30,7 +30,6 @@ public:
     QString userId;
     QString deviceId;
     QStringList supportedSpecVersions;
-    std::vector<QString> needToken;
 
     mutable unsigned int txnCounter = 0;
     const qint64 txnBase = QDateTime::currentMSecsSinceEpoch();
@@ -134,12 +133,6 @@ const QString& ConnectionData::deviceId() const { return d->deviceId; }
 
 const QString& ConnectionData::userId() const { return d->userId; }
 
-bool ConnectionData::needsToken(const QString& requestName) const
-{
-    return std::find(d->needToken.cbegin(), d->needToken.cend(), requestName)
-           != d->needToken.cend();
-}
-
 void ConnectionData::setDeviceId(const QString& deviceId)
 {
     d->deviceId = deviceId;
@@ -154,11 +147,6 @@ void ConnectionData::setUserId(const QString& userId)
             NetworkAccessManager::addAccount(userId, d->baseUrl);
     }
     d->userId = userId;
-}
-
-void ConnectionData::setNeedsToken(const QString& requestName)
-{
-    d->needToken.push_back(requestName);
 }
 
 void ConnectionData::setSupportedSpecVersions(QStringList versions)

--- a/Quotient/connectiondata.h
+++ b/Quotient/connectiondata.h
@@ -28,7 +28,6 @@ public:
     QUrl baseUrl() const;
     const QString& deviceId() const;
     const QString& userId() const;
-    bool needsToken(const QString& requestName) const;
     HomeserverData homeserverData() const;
     Quotient::NetworkAccessManager *nam() const;
 
@@ -36,7 +35,6 @@ public:
     void setToken(QByteArray accessToken);
     void setDeviceId(const QString& deviceId);
     void setUserId(const QString& userId);
-    void setNeedsToken(const QString& requestName);
     void setSupportedSpecVersions(QStringList versions);
 
     QString lastEvent() const;

--- a/Quotient/e2ee/e2ee_common.h
+++ b/Quotient/e2ee/e2ee_common.h
@@ -238,14 +238,12 @@ public:
     using FixedBufferBase::data;
     value_type* data() requires DataIsWriteable { return dataForWriting(); }
 
-    // NOLINTNEXTLINE(google-explicit-constructor)
-    QUO_IMPLICIT operator byte_view_t<ExtentN>() const
+    Q_IMPLICIT operator byte_view_t<ExtentN>() const
     {
         return byte_view_t<ExtentN>(data(), size());
     }
 
-    // NOLINTNEXTLINE(google-explicit-constructor)
-    QUO_IMPLICIT operator byte_span_t<ExtentN>()
+    Q_IMPLICIT operator byte_span_t<ExtentN>()
         requires DataIsWriteable
     {
         return byte_span_t<ExtentN>(dataForWriting(), size());

--- a/Quotient/e2ee/e2ee_common.h
+++ b/Quotient/e2ee/e2ee_common.h
@@ -45,22 +45,20 @@ inline bool isSupportedAlgorithm(const QString& algorithm)
 }
 
 #define QOLM_INTERNAL_ERROR_X(Message_, LastError_) \
-    qFatal("%s, internal error: %s", Message_, LastError_)
+    qFatal("%s, internal error: %s", QUO_CSTR(Message_), LastError_)
 
 #define QOLM_INTERNAL_ERROR(Message_) \
-    QOLM_INTERNAL_ERROR_X(Message_, lastError())
+    QOLM_INTERNAL_ERROR_X((Message_), lastError())
 
-#define QOLM_FAIL_OR_LOG_X(InternalCondition_, Message_, LastErrorText_)   \
-    do {                                                                   \
-        const QString errorMsg{ (Message_) };                              \
-        if (InternalCondition_)                                            \
-            QOLM_INTERNAL_ERROR_X(qPrintable(errorMsg), (LastErrorText_)); \
-        qWarning(E2EE).nospace() << errorMsg << ": " << (LastErrorText_);  \
+#define QOLM_FAIL_OR_LOG_X(InternalCondition_, Message_, LastErrorText_)    \
+    do {                                                                    \
+        if (InternalCondition_)                                             \
+            QOLM_INTERNAL_ERROR_X((Message_), (LastErrorText_));   \
+        qWarning(E2EE).nospace() << (Message_) << ": " << (LastErrorText_); \
     } while (false) /* End of macro */
 
 #define QOLM_FAIL_OR_LOG(InternalFailureValue_, Message_)                      \
-    QOLM_FAIL_OR_LOG_X(lastErrorCode() == (InternalFailureValue_), (Message_), \
-                       lastError())
+    QOLM_FAIL_OR_LOG_X(lastErrorCode() == (InternalFailureValue_), (Message_), lastError())
 
 template <typename T>
 using QOlmExpected = Expected<T, OlmErrorCode>;

--- a/Quotient/e2ee/qolmaccount.cpp
+++ b/Quotient/e2ee/qolmaccount.cpp
@@ -101,8 +101,7 @@ QByteArray QOlmAccount::pickle(const PicklingKey& key) const
     if (olm_pickle_account(olmData, key.data(), key.size(),
                            pickleBuffer.data(), pickleLength)
         == olm_error())
-        QOLM_INTERNAL_ERROR(qPrintable("Failed to pickle Olm account "_ls
-                                       + accountId()));
+        QOLM_INTERNAL_ERROR("Failed to pickle Olm account "_ls + accountId());
 
     return pickleBuffer;
 }
@@ -113,8 +112,7 @@ IdentityKeys QOlmAccount::identityKeys() const
     auto keyBuffer = byteArrayForOlm(keyLength);
     if (olm_account_identity_keys(olmData, keyBuffer.data(), keyLength)
         == olm_error()) {
-        QOLM_INTERNAL_ERROR(
-            qPrintable("Failed to get "_ls % accountId() % " identity keys"_ls));
+        QOLM_INTERNAL_ERROR("Failed to get "_ls % accountId() % " identity keys"_ls);
     }
     const auto key = QJsonDocument::fromJson(keyBuffer).object();
     return { key.value(QStringLiteral("curve25519")).toString(),
@@ -166,8 +164,7 @@ size_t QOlmAccount::generateOneTimeKeys(size_t numberOfKeys)
         olmData, numberOfKeys, getRandom(randomLength).data(), randomLength);
 
     if (result == olm_error())
-        QOLM_INTERNAL_ERROR(qPrintable(
-            "Failed to generate one-time keys for account "_ls + accountId()));
+        QOLM_INTERNAL_ERROR("Failed to generate one-time keys for account "_ls + accountId());
 
     emit needsSave();
     return result;
@@ -181,8 +178,7 @@ UnsignedOneTimeKeys QOlmAccount::oneTimeKeys() const
     if (olm_account_one_time_keys(olmData, oneTimeKeysBuffer.data(),
                                   oneTimeKeyLength)
         == olm_error())
-        QOLM_INTERNAL_ERROR(qPrintable(
-            "Failed to obtain one-time keys for account"_ls % accountId()));
+        QOLM_INTERNAL_ERROR("Failed to obtain one-time keys for account"_ls % accountId());
 
     const auto json = QJsonDocument::fromJson(oneTimeKeysBuffer).object();
     UnsignedOneTimeKeys oneTimeKeys;
@@ -265,7 +261,7 @@ QOlmExpected<QOlmSession> QOlmAccount::createOutboundSession(
         == olm_error()) {
         const auto errorCode = olmOutboundSession.lastErrorCode();
         QOLM_FAIL_OR_LOG_X(errorCode == OLM_NOT_ENOUGH_RANDOM,
-                         "Failed to create an outbound Olm session"_ls,
+                           "Failed to create an outbound Olm session"_ls,
                            olmOutboundSession.lastError());
         return errorCode;
     }

--- a/Quotient/e2ee/qolmsession.cpp
+++ b/Quotient/e2ee/qolmsession.cpp
@@ -89,8 +89,7 @@ QOlmExpected<QByteArray> QOlmSession::decrypt(const QOlmMessage& message) const
                                           unsignedSize(ciphertext),
                                           plaintextBuf.data(), plaintextMaxLen);
     if (actualLength == olm_error()) {
-        QOLM_FAIL_OR_LOG(OLM_OUTPUT_BUFFER_TOO_SMALL,
-                         "Failed to decrypt the message"_ls);
+        QOLM_FAIL_OR_LOG(OLM_OUTPUT_BUFFER_TOO_SMALL, "Failed to decrypt the message"_ls);
         return lastErrorCode();
     }
     // actualLength cannot be more than plainTextLength because the resulting

--- a/Quotient/events/encryptionevent.h
+++ b/Quotient/events/encryptionevent.h
@@ -10,8 +10,7 @@
 namespace Quotient {
 class QUOTIENT_API EncryptionEventContent {
 public:
-    // NOLINTNEXTLINE(google-explicit-constructor)
-    QUO_IMPLICIT EncryptionEventContent(Quotient::EncryptionType et);
+    Q_IMPLICIT EncryptionEventContent(Quotient::EncryptionType et);
     explicit EncryptionEventContent(const QJsonObject& json);
 
     QJsonObject toJson() const;

--- a/Quotient/events/roommemberevent.h
+++ b/Quotient/events/roommemberevent.h
@@ -11,8 +11,7 @@
 namespace Quotient {
 class QUOTIENT_API MemberEventContent {
 public:
-    // NOLINTNEXTLINE(google-explicit-constructor)
-    QUO_IMPLICIT MemberEventContent(Membership ms) : membership(ms) {}
+    Q_IMPLICIT MemberEventContent(Membership ms) : membership(ms) {}
     explicit MemberEventContent(const QJsonObject& json);
     QJsonObject toJson() const;
 

--- a/Quotient/events/single_key_value.h
+++ b/Quotient/events/single_key_value.h
@@ -7,10 +7,8 @@ namespace Quotient {
 namespace EventContent {
     template <typename T, const QLatin1String& KeyStr>
     struct SingleKeyValue {
-        // NOLINTBEGIN(google-explicit-constructor): that check should learn about explicit(false)
-        QUO_IMPLICIT SingleKeyValue(const T& v = {}) : value(v) {}
-        QUO_IMPLICIT SingleKeyValue(T&& v) : value(std::move(v)) {}
-        // NOLINTEND(google-explicit-constructor)
+        Q_IMPLICIT SingleKeyValue(const T& v = {}) : value(v) {}
+        Q_IMPLICIT SingleKeyValue(T&& v) : value(std::move(v)) {}
         T value;
     };
 } // namespace EventContent

--- a/Quotient/expected.h
+++ b/Quotient/expected.h
@@ -28,8 +28,7 @@ public:
 
     template <typename X>
         requires is_constructible_v<X>
-    QUO_IMPLICIT Expected(X&& x) // NOLINT(google-explicit-constructor)
-        : data(std::forward<X>(x))
+    Q_IMPLICIT Expected(X&& x) : data(std::forward<X>(x))
     {}
 
     Expected& operator=(const Expected&) = default;

--- a/Quotient/jobs/basejob.cpp
+++ b/Quotient/jobs/basejob.cpp
@@ -381,7 +381,6 @@ void BaseJob::sendRequest()
         return;
     }
     Q_ASSERT(d->connection && status().code == Pending);
-    d->needsToken |= d->connection->needsToken(objectName());
     auto req = d->prepareRequest();
     emit aboutToSendRequest(&req);
     d->sendRequest(req);
@@ -601,17 +600,6 @@ void BaseJob::finishJob()
         emit rateLimited();
         d->connection->submit(this);
         return;
-    case Unauthorised:
-        if (!d->needsToken && !d->connection->accessToken().isEmpty()) {
-            // Rerun with access token (extension of the spec while
-            // https://github.com/matrix-org/matrix-doc/issues/701 is pending)
-            d->connection->setNeedsToken(objectName());
-            qCWarning(d->logCat) << this << "re-running with authentication";
-            emit retryScheduled(d->retriesTaken, 0);
-            d->connection->submit(this);
-            return;
-        }
-        break;
     case NetworkError:
     case IncorrectResponse:
     case Timeout:

--- a/Quotient/jobs/basejob.cpp
+++ b/Quotient/jobs/basejob.cpp
@@ -334,7 +334,7 @@ void BaseJob::Private::sendRequest(const QNetworkRequest& req)
     }
 }
 
-void BaseJob::doPrepare(const ConnectionData* connectionData) { }
+void BaseJob::doPrepare(const ConnectionData*) { }
 
 void BaseJob::onSentRequest(QNetworkReply*) { }
 

--- a/Quotient/jobs/basejob.cpp
+++ b/Quotient/jobs/basejob.cpp
@@ -467,10 +467,10 @@ bool checkContentType(const QByteArray& type, const QByteArrayList& patterns)
             return true;
 
         auto patternParts = pattern.split('/');
-        Q_ASSERT_X(patternParts.size() <= 2, __FUNCTION__,
-                   qPrintable(
-                       "BaseJob: Expected content type should have up to two /-separated parts; violating pattern: "_ls
-                       + QString::fromLatin1(pattern)));
+        if (ALARM_X(patternParts.size() > 2,
+                    "Expected content type should have up to two /-separated parts; violating pattern: "
+                        % pattern))
+            return false;
 
         if (ctype.split('/').front() == patternParts.front()
             && patternParts.back() == "*")

--- a/Quotient/jobs/basejob.h
+++ b/Quotient/jobs/basejob.h
@@ -373,7 +373,7 @@ protected:
      * when it's first scheduled for execution; in particular, it is not called
      * on retries.
      */
-    virtual void doPrepare(const ConnectionData* connectionData);
+    virtual void doPrepare(const ConnectionData*);
 
     /*! Postprocessing after the network request has been sent
      *

--- a/Quotient/jobs/jobhandle.h
+++ b/Quotient/jobs/jobhandle.h
@@ -90,7 +90,7 @@ private:
     }
 
 public:
-    QUO_IMPLICIT JobHandle(JobT* job = nullptr) : JobHandle(job, setupFuture(job)) {}
+    Q_IMPLICIT JobHandle(JobT* job = nullptr) : JobHandle(job, setupFuture(job)) {}
 
     //! \brief Attach a continuation to a successful or unsuccessful completion of the future
     //!

--- a/Quotient/jobs/requestdata.h
+++ b/Quotient/jobs/requestdata.h
@@ -19,13 +19,10 @@ namespace Quotient {
  */
 class QUOTIENT_API RequestData {
 public:
-    // NOLINTBEGIN(google-explicit-constructor): that check should learn about
-    //                                           explicit(false)
-    QUO_IMPLICIT RequestData(const QByteArray& a = {});
-    QUO_IMPLICIT RequestData(const QJsonObject& jo);
-    QUO_IMPLICIT RequestData(const QJsonArray& ja);
-    QUO_IMPLICIT RequestData(QIODevice* source);
-    // NOLINTEND(google-explicit-constructor)
+    Q_IMPLICIT RequestData(const QByteArray& a = {});
+    Q_IMPLICIT RequestData(const QJsonObject& jo);
+    Q_IMPLICIT RequestData(const QJsonArray& ja);
+    Q_IMPLICIT RequestData(QIODevice* source);
 
     QIODevice* source() const { return _source.get(); }
 

--- a/Quotient/util.cpp
+++ b/Quotient/util.cpp
@@ -128,6 +128,12 @@ int Quotient::minorVersion()
 
 int Quotient::patchVersion() { return Quotient_VERSION_PATCH; }
 
+bool Quotient::isGuestUserId(const UserId& uId)
+{
+    static const QRegularExpression guestMxIdRe{ QStringLiteral("^@\\d+:") };
+    return guestMxIdRe.match(uId).hasMatch();
+}
+
 bool Quotient::HomeserverData::checkMatrixSpecVersion(QStringView targetVersion) const
 {
     // TODO: Replace this naïve implementation with something smarter that can check things like

--- a/Quotient/util.cpp
+++ b/Quotient/util.cpp
@@ -128,7 +128,7 @@ int Quotient::minorVersion()
 
 int Quotient::patchVersion() { return Quotient_VERSION_PATCH; }
 
-bool HomeserverData::checkMatrixSpecVersion(QStringView targetVersion) const
+bool Quotient::HomeserverData::checkMatrixSpecVersion(QStringView targetVersion) const
 {
     // TODO: Replace this naïve implementation with something smarter that can check things like
     //   1.12 > 1.11 and maybe even 1.10 > 1.9

--- a/Quotient/util.h
+++ b/Quotient/util.h
@@ -429,6 +429,8 @@ using UserId = QString;
 using RoomId = QString;
 using EventId = QString;
 
+QUOTIENT_API bool isGuestUserId(const UserId& uId);
+
 struct QUOTIENT_API HomeserverData {
     QUrl baseUrl;
     QStringList supportedSpecVersions;

--- a/Quotient/util.h
+++ b/Quotient/util.h
@@ -17,8 +17,6 @@
 #include <source_location>
 #include <unordered_map>
 
-#define QUO_IMPLICIT explicit(false)
-
 #define DECL_DEPRECATED_ENUMERATOR(Deprecated, Recommended) \
     Deprecated Q_DECL_ENUMERATOR_DEPRECATED_X("Use " #Recommended) = Recommended
 

--- a/Quotient/util.h
+++ b/Quotient/util.h
@@ -369,6 +369,7 @@ inline QDebug operator<<(QDebug dbg, QElapsedTimer et)
     return dbg;
 }
 
+namespace Quotient {
 //! \brief Lift an operation into dereferenceable types (std::optional or pointers)
 //!
 //! This is a more generic version of std::optional::and_then() that accepts an arbitrary number of
@@ -434,3 +435,4 @@ struct QUOTIENT_API HomeserverData {
 
     bool checkMatrixSpecVersion(QStringView targetVersion) const;
 };
+} // namespace Quotient

--- a/Quotient/util.h
+++ b/Quotient/util.h
@@ -40,18 +40,33 @@
 
 namespace Quotient {
 
-inline const char* printable(std::convertible_to<QString> auto s)
-{
-    return QString(s).toUtf8().constData();
+namespace _impl {
+    template <typename S>
+    constexpr inline auto toUtf8(S&& s)
+    {
+        if constexpr (std::convertible_to<S, std::string_view>)
+            return std::string_view(std::forward<S>(s));
+        else if constexpr (std::convertible_to<S, QByteArray>)
+            return QByteArray(std::forward<S>(s));
+        else //if constexpr (std::convertible_to<S, QString>)
+            return QString(std::forward<S>(s)).toUtf8();
+    }
 }
-inline const char* printable(const char* s) { return s; }
-inline const char* printable(QUtf8StringView s) { return s.data(); }
+
+//! \brief q(Utf8)Printable that can handle more than just QStrings
+//!
+//! This macro accepts all kinds of string-like input, from const char* all the way to raw
+//! QStringBuilder constructs. It returns a `const char*` pointer to a UTF-8 string; if the original
+//! input was QChar/u16-based, it creates a temporary buffer to store the UTF-8 representation that
+//! is destroyed once the statement containing QUO_CSTR() is done (therefore, ALWAYS copy the result
+//! based on QUO_CSTR() contents if you need to store it).
+#define QUO_CSTR(StringConvertible_) std::data(_impl::toUtf8(StringConvertible_))
 
 inline bool alarmX(bool alarmCondition, const auto& msg,
                    [[maybe_unused]] std::source_location loc = std::source_location::current())
 {
     if (alarmCondition) [[unlikely]] {
-        Q_ASSERT_X(false, loc.function_name(), printable(msg));
+        Q_ASSERT_X(false, loc.function_name(), QUO_CSTR(msg));
         qCritical() << msg;
     }
     return alarmCondition;
@@ -67,9 +82,9 @@ inline bool alarmX(bool alarmCondition, const auto& msg,
 //! if \p AlarmCondition holds, not the other way around.
 //!
 //! This macro is a trivial wrapper around alarmX(), provided for API uniformity with ALARM()
-#define ALARM_X(AlarmCondition, Message) alarmX(AlarmCondition, Message)
+#define ALARM_X(AlarmCondition, Message) alarmX((AlarmCondition), (Message))
 
-#define ALARM(AlarmCondition) alarmX(AlarmCondition, "Alarm: " #AlarmCondition)
+#define ALARM(AlarmCondition) alarmX((AlarmCondition), "Alarm: " #AlarmCondition)
 
 #if Quotient_VERSION_MAJOR == 0 && Quotient_VERSION_MINOR < 10
 /// This is only to make UnorderedMap alias work until we get rid of it

--- a/autotests/utiltests.cpp
+++ b/autotests/utiltests.cpp
@@ -87,7 +87,9 @@ void TestUtils::testQuoCStr()
     T(QStringLiteral);
     T(QByteArrayLiteral);
     T(QLatin1StringView); // clazy:exclude=qt6-qlatin1stringchar-to-u
+#if QT_VERSION_MINOR > 7 // Qt 6.7 brought implicit QUtf8StringView -> std::string_view conversion
     T(QUtf8StringView);
+#endif
 #undef T
     QVERIFY("Test QStringBuilder<QString>"sv
             == QUO_CSTR(QStringLiteral("Test ") % u"QStringBuilder<QString>"));

--- a/autotests/utiltests.cpp
+++ b/autotests/utiltests.cpp
@@ -3,6 +3,7 @@
 
 #include <Quotient/util.h>
 
+#include <QtCore/QStringBuilder>
 #include <QtTest/QtTest>
 
 using namespace Quotient;
@@ -26,6 +27,7 @@ class TestUtils : public QObject {
 private Q_SLOTS:
     void testLinkifyUrl();
     void testIsGuestUserId();
+    void testQuoCStr();
 
 private:
     void testLinkified(QString original, const QString& expected, const int sourceLine) const
@@ -74,6 +76,23 @@ void TestUtils::testIsGuestUserId()
 {
     QVERIFY(isGuestUserId("@123:example.org"_ls));
     QVERIFY(!isGuestUserId("@normal:example.org"_ls));
+}
+
+void TestUtils::testQuoCStr()
+{
+    using namespace std::string_view_literals; // strncmp() is clumsy
+    QVERIFY("Test const char[]"sv == QUO_CSTR("Test const char[]"));
+#define T(Wrapper_) QVERIFY("Test " #Wrapper_##sv == QUO_CSTR(Wrapper_("Test " #Wrapper_)))
+    T(std::string);
+    T(QStringLiteral);
+    T(QByteArrayLiteral);
+    T(QLatin1StringView); // clazy:exclude=qt6-qlatin1stringchar-to-u
+    T(QUtf8StringView);
+#undef T
+    QVERIFY("Test QStringBuilder<QString>"sv
+            == QUO_CSTR(QStringLiteral("Test ") % u"QStringBuilder<QString>"));
+    QVERIFY("Test QStringBuilder<QByteArray>"sv
+            == QUO_CSTR(QByteArrayLiteral("Test ") % "QStringBuilder<QByteArray>"));
 }
 
 QTEST_APPLESS_MAIN(TestUtils)

--- a/autotests/utiltests.cpp
+++ b/autotests/utiltests.cpp
@@ -25,6 +25,7 @@ class TestUtils : public QObject {
     Q_OBJECT
 private Q_SLOTS:
     void testLinkifyUrl();
+    void testIsGuestUserId();
 
 private:
     void testLinkified(QString original, const QString& expected, const int sourceLine) const
@@ -67,6 +68,12 @@ void TestUtils::testLinkifyUrl()
       "<a href='https://matrix.to/#/#room_alias:example.org'>#room_alias:example.org</a>"_ls);
 
 #undef T
+}
+
+void TestUtils::testIsGuestUserId()
+{
+    QVERIFY(isGuestUserId("@123:example.org"_ls));
+    QVERIFY(!isGuestUserId("@normal:example.org"_ls));
 }
 
 QTEST_APPLESS_MAIN(TestUtils)


### PR DESCRIPTION
The cleanup pieces are about `needsToken` logic in `ConnectionData` that is no more needed; using `Q_IMPLICIT` that has been around since Qt 6.0; and dropping a name of an unused argument. The rest is fixing regressions introduced over the last month and I somehow stumbled into them one after another within one day.