### PR TITLE
Overhaul connection management

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,6 +190,8 @@ target_sources(${QUOTIENT_LIB_NAME} PUBLIC FILE_SET HEADERS BASE_DIRS .
         Quotient/events/keyverificationevent.h
         Quotient/keyimport.h
         Quotient/qt_connection_util.h
+        Quotient/pendingconnection.h
+        Quotient/config.h
     PRIVATE
         Quotient/function_traits.cpp
         Quotient/networkaccessmanager.cpp
@@ -247,6 +249,8 @@ target_sources(${QUOTIENT_LIB_NAME} PUBLIC FILE_SET HEADERS BASE_DIRS .
         Quotient/e2ee/cryptoutils.cpp
         Quotient/e2ee/sssshandler.cpp
         Quotient/keyimport.cpp
+        Quotient/pendingconnection.cpp
+        Quotient/config.cpp
         libquotientemojis.qrc
 )
 

--- a/Quotient/accountregistry.h
+++ b/Quotient/accountregistry.h
@@ -12,6 +12,13 @@
 
 namespace Quotient {
 class Connection;
+class PendingConnection;
+
+struct ConnectionSettings
+{
+    QString deviceId;
+    QString initialDeviceName;
+};
 
 class QUOTIENT_API AccountRegistry : public QAbstractListModel,
                                      private QVector<Connection*> {
@@ -63,9 +70,15 @@ public:
 
     QStringList accountsLoading() const;
 
-    [[deprecated("This may leak Connection objects when failing and cannot be"
-                 "fixed without breaking the API; do not use it")]] //
-    void invokeLogin();
+    Quotient::PendingConnection *loginWithPassword(const QString& matrixId, const QString& password, const ConnectionSettings& settings = {});
+    Quotient::PendingConnection *restoreConnection(const QString& matrixId, const ConnectionSettings& settings = {});
+
+    Quotient::PendingConnection *mockConnection(const QString& userId) {
+        //TODO
+        return nullptr;
+    }
+
+    QStringList availableConnections() const;
 
 Q_SIGNALS:
     void accountCountChanged();

--- a/Quotient/accountregistry.h
+++ b/Quotient/accountregistry.h
@@ -16,8 +16,14 @@ class PendingConnection;
 
 struct ConnectionSettings
 {
+    // Only relevant when logging in or registering. This can be left empty to get a random device id
     QString deviceId;
+    // Only relevant when logging in or registering. Otherwise leave empty
     QString initialDeviceName;
+    bool useEncryption = true;
+    bool cacheState = true;
+    bool rememberConnection = true;
+    bool sync = true;
 };
 
 class QUOTIENT_API AccountRegistry : public QAbstractListModel,

--- a/Quotient/config.cpp
+++ b/Quotient/config.cpp
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2024 Tobias Fella <tobias.fella@kde.org>
+// SPDX-License-Identifier: LGPL-2.0-or-later
+
+#include "config.h"
+
+#include <QSettings>
+
+class QSettingsConfig : public Config
+{
+    //TODO this backend currently ignores the type and stores everything in the same backend
+    QString load(const QString& group, const QString& childGroup, const QString& key, Type type) override
+    {
+        settings.beginGroup(group);
+        settings.beginGroup(childGroup);
+        auto value = settings.value(key).toString();
+        settings.endGroup();
+        settings.endGroup();
+        return value;
+    }
+
+    void store(const QString& group, const QString& childGroup, const QString& key, const QString& value, Type type) override
+    {
+        settings.beginGroup(group);
+        settings.beginGroup(childGroup);
+        settings.setValue(key, value);
+        settings.endGroup();
+        settings.endGroup();
+        settings.sync();
+    }
+
+    QStringList childGroups(const QString& group, Type type) override
+    {
+        settings.beginGroup(group);
+        auto childGroups = settings.childGroups();
+        settings.endGroup();
+        return childGroups;
+    }
+
+    QSettings settings;
+};
+
+Config* Config::s_instance = nullptr;
+
+Config* Config::instance()
+{
+    if (!s_instance) {
+        s_instance = new QSettingsConfig();
+    }
+    return s_instance;
+}
+
+void Config::setInstance(Config* config)
+{
+    s_instance = config;
+}

--- a/Quotient/config.h
+++ b/Quotient/config.h
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2024 Tobias Fella <tobias.fella@kde.org>
+// SPDX-License-Identifier: LGPL-2.0-or-later
+
+#pragma once
+
+#include <QString>
+
+class Config
+{
+public:
+    enum Type
+    {
+        Settings,
+        Data,
+    };
+    virtual QString load(const QString& group, const QString& childGroup, const QString& key, Type type) = 0;
+    virtual void store(const QString& group, const QString& childGroup, const QString& key, const QString& value, Type type) = 0;
+    virtual QStringList childGroups(const QString& group, Type type) = 0;
+
+    static Config* instance();
+    static void setInstance(Config* config);
+
+private:
+    static Config* s_instance;
+};

--- a/Quotient/pendingconnection.cpp
+++ b/Quotient/pendingconnection.cpp
@@ -1,0 +1,424 @@
+// SPDX-FileCopyrightText: 2024 Tobias Fella <tobias.fella@kde.org>
+// SPDX-License-Identifier: LGPL-2.0-or-later
+
+#include "pendingconnection.h"
+
+#include "connectiondata.h"
+#include "connectionencryptiondata_p.h"
+#include "logging_categories_p.h"
+#include "csapi/login.h"
+#include "csapi/wellknown.h"
+#include "jobs/jobhandle.h"
+#include "connection.h"
+#include "connection_p.h"
+#include "config.h"
+
+#include <QtCore/QCoreApplication>
+#include <QtCore/QPointer>
+
+using namespace Quotient;
+using namespace Qt::Literals::StringLiterals;
+
+using LoginFlow = GetLoginFlowsJob::LoginFlow;
+
+//! Predefined login flows
+namespace LoginFlows {
+    inline const LoginFlow Password { "m.login.password"_ls };
+    inline const LoginFlow SSO { "m.login.sso"_ls };
+    inline const LoginFlow Token { "m.login.token"_ls };
+}
+
+// To simplify comparisons of LoginFlows
+
+inline bool operator==(const LoginFlow& lhs, const LoginFlow& rhs)
+{
+    return lhs.type == rhs.type;
+}
+
+inline bool operator!=(const LoginFlow& lhs, const LoginFlow& rhs)
+{
+    return !(lhs == rhs);
+}
+
+
+class Quotient::PendingConnection::Private
+{
+public:
+    Private(PendingConnection *qq)
+        : q(qq)
+        , connectionData(new ConnectionData({}))
+        {}
+
+    //! \brief Check the homeserver and resolve it if needed, before connecting
+    //!
+    //! A single entry for functions that need to check whether the homeserver is valid before
+    //! running. Emits resolveError() if the homeserver URL is not valid and cannot be resolved
+    //! from \p userId; loginError() if the homeserver is accessible but doesn't support \p flow.
+    //!
+    //! \param userId    fully-qualified MXID to resolve HS from
+    //! \param flow      optionally, a login flow that should be supported;
+    //!                  `std::nullopt`, if there are no login flow requirements
+    //! \return a future that becomes ready once the homeserver is available; if the homeserver
+    //!         URL is incorrect or other problems occur, the future is never resolved and is
+    //!         deleted (along with associated continuations) as soon as the problem becomes
+    //!         apparent
+    //! \sa resolveServer, resolveError, loginError
+    QFuture<void> ensureHomeserver(const QString& userId, const std::optional<LoginFlow>& flow = {});
+
+    //! \brief Determine and set the homeserver from MXID
+    //!
+    //! This attempts to resolve the homeserver by requesting
+    //! .well-known/matrix/client record from the server taken from the MXID
+    //! serverpart. If there is no record found, the serverpart itself is
+    //! attempted as the homeserver base URL; if the record is there but
+    //! is malformed (e.g., the homeserver base URL cannot be found in it)
+    //! resolveError() is emitted and further processing stops. Otherwise,
+    //! setHomeserver is called, preparing the Connection object for the login
+    //! attempt.
+    //! \param mxid user Matrix ID, such as @someone:example.org
+    //! \sa setHomeserver, homeserverChanged, loginFlowsChanged, resolveError
+    void resolveServer(const QString& mxid);
+
+    template <typename... LoginArgTs>
+    void loginToServer(LoginArgTs&&... loginArgs);
+
+    //! \brief Set the homeserver base URL and retrieve its login flows
+    //!
+    //! \sa LoginFlowsJob, loginFlows, loginFlowsChanged, homeserverChanged
+    Q_INVOKABLE QFuture<QList<LoginFlow> > setHomeserver(const QUrl& baseUrl);
+
+
+    BaseJob* run(BaseJob* job, RunningPolicy runningPolicy);
+
+
+    //! \brief Start a job of a given type with specified arguments and policy
+    //!
+    //! This is a universal method to create and start a job of a type passed
+    //! as a template parameter. The policy allows to fine-tune the way
+    //! the job is executed - as of this writing it means a choice
+    //! between "foreground" and "background".
+    //!
+    //! \param runningPolicy controls how the job is executed
+    //! \param jobArgs arguments to the job constructor
+    //!
+    //! \sa BaseJob::isBackground. QNetworkRequest::BackgroundRequestAttribute
+    template <typename JobT, typename... JobArgTs>
+    JobHandle<JobT> callApi(RunningPolicy runningPolicy, JobArgTs&&... jobArgs)
+    {
+        auto job = new JobT(std::forward<JobArgTs>(jobArgs)...);
+        run(job, runningPolicy);
+        return job;
+    }
+
+    //! \brief Start a job of a specified type with specified arguments
+    //!
+    //! This is an overload that runs the job with "foreground" policy.
+    template <typename JobT, typename... JobArgTs>
+    JobHandle<JobT> callApi(JobArgTs&&... jobArgs)
+    {
+        return callApi<JobT>(ForegroundRequest, std::forward<JobArgTs>(jobArgs)...);
+    }
+
+    QKeychain::ReadPasswordJob *loadAccessTokenFromKeyChain()
+    {
+        qDebug() << "Reading access token from the keychain for" << connectionData->userId();
+        auto job = new QKeychain::ReadPasswordJob(qAppName(), q);
+        job->setKey(connectionData->userId());
+
+        // connect(job, &QKeychain::Job::finished, q, [this, job]() {
+        //     if (job->error() == QKeychain::Error::NoError) {
+        //         return;
+        //     }
+        //
+        //     // switch (job->error()) {
+        //     // case QKeychain::EntryNotFound:
+        //     //     Q_EMIT errorOccured(i18n("Access token wasn't found"), i18n("Maybe it was deleted?"));
+        //     //     break;
+        //     // case QKeychain::AccessDeniedByUser:
+        //     // case QKeychain::AccessDenied:
+        //     //     Q_EMIT errorOccured(i18n("Access to keychain was denied."), i18n("Please allow NeoChat to read the access token"));
+        //     //     break;
+        //     // case QKeychain::NoBackendAvailable:
+        //     //     Q_EMIT errorOccured(i18n("No keychain available."), i18n("Please install a keychain, e.g. KWallet or GNOME keyring on Linux"));
+        //     //     break;
+        //     // case QKeychain::OtherError:
+        //     //     Q_EMIT errorOccured(i18n("Unable to read access token"), job->errorString());
+        //     //     break;
+        //     // default:
+        //     //     break;
+        //     // }
+        // });
+        job->start();
+
+        return job;
+    }
+
+
+    void completeSetup(const QString& mxId, bool mock);
+    void saveAccessTokenToKeychain() const;
+
+    QVector<GetLoginFlowsJob::LoginFlow> loginFlows;
+    JobHandle<GetWellknownJob> resolverJob = nullptr;
+    JobHandle<GetLoginFlowsJob> loginFlowsJob = nullptr;
+
+    PendingConnection* q;
+
+    ConnectionData* connectionData = nullptr; //TODO this should be a unique_ptr
+    Connection* connection = nullptr;
+    AccountRegistry* accountRegistry;
+};
+
+inline UserIdentifier makeUserIdentifier(const QString& id)
+{
+    return { QStringLiteral("m.id.user"), { { QStringLiteral("user"), id } } };
+}
+
+PendingConnection::PendingConnection(const QString& userId, const QString& password, const Quotient::ConnectionSettings& settings, Quotient::AccountRegistry* accountRegistry)
+    : d(new Private(this))
+{
+    d->accountRegistry = accountRegistry;
+    d->ensureHomeserver(userId, LoginFlows::Password).then([=, this] {
+        d->loginToServer(LoginFlows::Password.type, makeUserIdentifier(userId),
+                         password, /*token*/ QString(), settings.deviceId, settings.initialDeviceName);
+    });
+}
+
+PendingConnection::PendingConnection(const QString& userId, const Quotient::ConnectionSettings& settings, Quotient::AccountRegistry* accountRegistry)
+    : d(new Private(this))
+{
+    d->accountRegistry = accountRegistry;
+    auto config = Config::instance();
+
+    d->connectionData->setUserId(userId);
+    d->connectionData->setBaseUrl(QUrl(config->load(u"Accounts"_s, userId, u"Homeserver"_s, Config::Data)));
+    d->connectionData->setDeviceId(config->load(u"Accounts"_s, userId, u"DeviceId"_s, Config::Data));
+
+    auto job = d->loadAccessTokenFromKeyChain();
+    connect(job, &QKeychain::ReadPasswordJob::finished, this, [this, job](){
+        d->connectionData->setToken(job->binaryData());
+        d->connection = new Connection(d->connectionData);
+
+        //TODO do this in a more unified place
+        //TODO if (settings.cacheState)
+        d->connection->loadState();
+        connect(d->connection, &Connection::syncDone, d->connection, &Connection::saveState);
+        emit ready();
+        d->accountRegistry->add(d->connection);
+
+        //TODO if (settings.sync)
+        d->connection->syncLoop();
+    });
+}
+
+PendingConnection *PendingConnection::loginWithPassword(const QString& userId, const QString& password, const Quotient::ConnectionSettings& settings, Quotient::AccountRegistry* accountRegistry)
+{
+    return new PendingConnection(userId, password, settings, accountRegistry);
+}
+
+PendingConnection *PendingConnection::restoreConnection(const QString& userId, const Quotient::ConnectionSettings& settings, Quotient::AccountRegistry* accountRegistry)
+{
+    return new PendingConnection(userId, settings, accountRegistry);
+}
+
+QFuture<void> PendingConnection::Private::ensureHomeserver(const QString& userId,
+                                                    const std::optional<LoginFlow>& flow)
+{
+    QPromise<void> promise;
+    auto result = promise.future();
+    promise.start();
+    if (connectionData->baseUrl().isValid()/* TODO && (!flow || loginFlows.contains(*flow))*/) {
+        q->setObjectName(userId % u"(?)");
+        promise.finish(); // Perfect, we're already good to go
+    } else if (userId.startsWith(u'@') && userId.indexOf(u':') != -1) {
+        // Try to ascertain the homeserver URL and flows
+        q->setObjectName(userId % u"(?)");
+        resolveServer(userId);
+        if (flow)
+            QtFuture::connect(q, &PendingConnection::loginFlowsChanged)
+                .then([this, flow, p = std::move(promise)]() mutable {
+                    // TODO if (loginFlows.contains(*flow))
+                        p.finish();
+                    // else // Leave the promise unfinished and emit the error
+                    //     emit q->loginError(tr("Unsupported login flow"),
+                    //                        tr("The homeserver at %1 does not support"
+                    //                           " the login flow '%2'")
+                    //                            .arg(connectionData->baseUrl().toDisplayString(), flow->type));
+                });
+        else // Any flow is fine, just wait until the homeserver is resolved
+            return QFuture<void>(QtFuture::connect(q, &PendingConnection::homeserverChanged));
+    } else // Leave the promise unfinished and emit the error
+        emit q->resolveError(tr("Please provide the fully-qualified user id"
+                                " (such as @user:example.org) so that the"
+                                " homeserver could be resolved; the current"
+                                " homeserver URL(%1) is not good")
+                                 .arg(connectionData->baseUrl().toDisplayString()));
+    return result;
+}
+
+
+template <typename... LoginArgTs>
+void PendingConnection::Private::loginToServer(LoginArgTs&&... loginArgs)
+{
+    auto loginJob =
+            callApi<LoginJob>(std::forward<LoginArgTs>(loginArgs)...);
+    connect(loginJob, &BaseJob::success, q, [this, loginJob] {
+        connectionData->setToken(loginJob->accessToken().toLatin1());
+        connectionData->setDeviceId(loginJob->deviceId());
+        completeSetup(loginJob->userId(), false);
+        saveAccessTokenToKeychain();
+        // if (encryptionData) probably not needed?
+        //     encryptionData->database.clear();
+    });
+    connect(loginJob, &BaseJob::failure, q, [this, loginJob] {
+        emit q->loginError(loginJob->errorString(), loginJob->rawDataSample());
+    });
+}
+
+void PendingConnection::Private::resolveServer(const QString& mxid)
+{
+    resolverJob.abandon(); // The previous network request is no more relevant
+
+    auto maybeBaseUrl = QUrl::fromUserInput(serverPart(mxid));
+    maybeBaseUrl.setScheme("https"_ls); // Instead of the Qt-default "http"
+    if (maybeBaseUrl.isEmpty() || !maybeBaseUrl.isValid()) {
+        emit q->resolveError(tr("%1 is not a valid homeserver address")
+                              .arg(maybeBaseUrl.toString()));
+        return;
+    }
+
+    qCDebug(MAIN) << "Finding the server" << maybeBaseUrl.host();
+
+    const auto& oldBaseUrl = connectionData->baseUrl();
+    connectionData->setBaseUrl(maybeBaseUrl); // Temporarily set it for this one call
+    resolverJob = callApi<GetWellknownJob>();
+    // Make sure baseUrl is restored in any case, even an abandon, and before any further processing
+    connect(resolverJob.get(), &BaseJob::finished, q,
+            [this, oldBaseUrl] { connectionData->setBaseUrl(oldBaseUrl); });
+    resolverJob.onResult(q, [this, maybeBaseUrl]() mutable {
+        if (resolverJob->error() != BaseJob::NotFound) {
+            if (!resolverJob->status().good()) {
+                qCWarning(MAIN) << "Fetching .well-known file failed, FAIL_PROMPT";
+                emit q->resolveError(tr("Failed resolving the homeserver"));
+                return;
+            }
+            const QUrl baseUrl{ resolverJob->data().homeserver.baseUrl };
+            if (baseUrl.isEmpty()) {
+                qCWarning(MAIN) << "base_url not provided, FAIL_PROMPT";
+                emit q->resolveError(tr("The homeserver base URL is not provided"));
+                return;
+            }
+            if (!baseUrl.isValid()) {
+                qCWarning(MAIN) << "base_url invalid, FAIL_ERROR";
+                emit q->resolveError(tr("The homeserver base URL is invalid"));
+                return;
+            }
+            qCInfo(MAIN) << ".well-known URL for" << maybeBaseUrl.host() << "is"
+                         << baseUrl.toString();
+            setHomeserver(baseUrl);
+        } else {
+            qCInfo(MAIN) << "No .well-known file, using" << maybeBaseUrl << "for base URL";
+            setHomeserver(maybeBaseUrl);
+        }
+        Q_ASSERT(loginFlowsJob != nullptr); // Ensured by setHomeserver()
+    });
+}
+
+QFuture<QList<LoginFlow>> PendingConnection::Private::setHomeserver(const QUrl& baseUrl)
+{
+    resolverJob.abandon();
+    loginFlowsJob.abandon();
+    loginFlows.clear();
+
+    if (connectionData->baseUrl() != baseUrl) {
+        connectionData->setBaseUrl(baseUrl);
+        emit q->homeserverChanged(baseUrl);
+    }
+
+    loginFlowsJob = callApi<GetLoginFlowsJob>(BackgroundRequest).onResult([this] {
+        if (loginFlowsJob->status().good())
+            loginFlows = loginFlowsJob->flows();
+        else
+            loginFlows.clear();
+        emit q->loginFlowsChanged();
+    });
+    return loginFlowsJob.responseFuture();
+}
+
+BaseJob* PendingConnection::Private::run(BaseJob* job, RunningPolicy runningPolicy)
+{
+    // Reparent to protect from #397, #398 and to prevent BaseJob* from being
+    // garbage-collected if made by or returned to QML/JavaScript.
+    job->setParent(q);
+    //TODO maybe connect(job, &BaseJob::failure, this, &Connection::requestFailed);
+    job->initiate(connectionData, runningPolicy & BackgroundRequest);
+    return job;
+}
+
+
+void PendingConnection::Private::completeSetup(const QString& mxId, bool mock)
+{
+    connectionData->setUserId(mxId);
+    q->setObjectName(connectionData->userId() % u'/' % connectionData->deviceId());
+    qCDebug(MAIN) << "Using server" << connectionData->baseUrl().toDisplayString()
+                  << "by user" << connectionData->userId()
+                  << "from device" << connectionData->deviceId();
+
+    connection = new Connection(connectionData);
+
+    //if (settings.useEncryption) {
+        if (auto&& maybeEncryptionData = _impl::ConnectionEncryptionData::setup(connection, mock)) {
+            connection->d->encryptionData = std::move(*maybeEncryptionData);
+        } else {
+            //TODO useEncryption = false;
+            //TODO emit q->encryptionChanged(false);
+        }
+    // } else
+    //     qCInfo(E2EE) << "End-to-end encryption (E2EE) support is off for"
+    //                  << q->objectName();
+
+
+    //TODO if (settings.cacheState)
+    connection->loadState();
+    connect(connection, &Connection::syncDone, connection, &Connection::saveState);
+
+    //TODO if (settings.sync)
+    connection->syncLoop();
+
+    if (true/*settings.remember*/) {
+        auto config = Config::instance();
+        config->store(u"Accounts"_s, connection->userId(), u"DeviceId"_s, connection->deviceId(), Config::Data);
+        config->store(u"Accounts"_s, connection->userId(), u"Homeserver"_s, connection->homeserver().toString(), Config::Data);
+    }
+
+    emit q->ready();
+    accountRegistry->add(connection);
+}
+
+PendingConnection::~PendingConnection() = default;
+
+void PendingConnection::Private::saveAccessTokenToKeychain() const
+{
+    qCDebug(MAIN) << "Saving access token to keychain for" << connectionData->userId();
+    auto job = new QKeychain::WritePasswordJob(qAppName());
+    job->setKey(connectionData->userId());
+    job->setBinaryData(connectionData->accessToken());
+    job->start();
+    QObject::connect(job, &QKeychain::Job::finished, q, [job] {
+        if (job->error() == QKeychain::Error::NoError)
+            return;
+        qWarning(MAIN).noquote()
+            << "Could not save access token to the keychain:"
+            << qUtf8Printable(job->errorString());
+        // TODO: emit a signal
+    });
+}
+
+QString PendingConnection::userId() const
+{
+    return d->connectionData->userId();
+}
+
+Connection* PendingConnection::connection() const
+{
+    return d->connection;
+}

--- a/Quotient/pendingconnection.h
+++ b/Quotient/pendingconnection.h
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2024 Tobias Fella <tobias.fella@kde.org>
+// SPDX-License-Identifier: LGPL-2.0-or-later
+
+#pragma once
+
+#include "accountregistry.h"
+
+#include <QObject>
+
+namespace Quotient
+{
+namespace _impl {
+class ConnectionEncryptionData;
+}
+
+class PendingConnection : public QObject
+{
+    Q_OBJECT
+
+public:
+    static PendingConnection *loginWithPassword(const QString& userId, const QString& password, const Quotient::ConnectionSettings& settings, Quotient::AccountRegistry* accountRegistry);
+    static PendingConnection *restoreConnection(const QString& userId, const Quotient::ConnectionSettings& settings, Quotient::AccountRegistry* accountRegistry);
+
+    ~PendingConnection();
+    Quotient::Connection* connection() const;
+
+Q_SIGNALS:
+    void loginFlowsChanged(); //TODO make private somehow?
+    void homeserverChanged(QUrl baseUrl);
+
+    //! \brief Initial server resolution has failed
+    //!
+    //! This signal is emitted when resolveServer() did not manage to resolve
+    //! the homeserver using its .well-known/client record or otherwise.
+    //! \sa resolveServer
+    void resolveError(QString error);
+    void loginError(QString message, QString details);
+    void ready();
+
+private:
+    friend class Quotient::_impl::ConnectionEncryptionData;
+    PendingConnection(const QString& userId, const QString& password, const Quotient::ConnectionSettings& settings, Quotient::AccountRegistry* accountRegistry);
+    PendingConnection(const QString& userId, const Quotient::ConnectionSettings& settings, Quotient::AccountRegistry* accountRegistry);
+
+    QString userId() const;
+
+    class Private;
+    std::unique_ptr<Private> d;
+};
+
+}

--- a/Quotient/ssosession.cpp
+++ b/Quotient/ssosession.cpp
@@ -99,20 +99,23 @@ void SsoSession::Private::processCallback()
         return;
     }
     qCDebug(MAIN) << "Found the token in SSO callback, logging in";
-    connection->loginWithToken(query.queryItemValue(QueryItemName),
-                               initialDeviceName, deviceId);
-    connect(connection, &Connection::connected, socket, [this] {
-        const auto msg =
-            tr("The application '%1' has successfully logged in as a user %2 "
-               "with device id %3. This window can be closed. Thank you.\r\n")
-                .arg(QCoreApplication::applicationName(), connection->userId(),
-                     connection->deviceId());
-        sendHttpResponse("200 OK", msg.toHtmlEscaped().toUtf8());
-        socket->disconnectFromHost();
-    });
-    connect(connection, &Connection::loginError, socket, [this] {
-        onError("401 Unauthorised", tr("Login failed"));
-    });
+    // connection->loginWithToken(query.queryItemValue(QueryItemName),
+    //                            initialDeviceName, deviceId);
+    //TODO
+    // connect(connection, &Connection::connected, socket, [this] {
+    //     const auto msg =
+    //         tr("The application '%1' has successfully logged in as a user %2 "
+    //            "with device id %3. This window can be closed. Thank you.\r\n")
+    //             .arg(QCoreApplication::applicationName(), connection->userId(),
+    //                  connection->deviceId());
+    //     sendHttpResponse("200 OK", msg.toHtmlEscaped().toUtf8());
+    //     socket->disconnectFromHost();
+    // });
+
+    //TODO
+    // connect(connection, &Connection::loginError, socket, [this] {
+    //     onError("401 Unauthorised", tr("Login failed"));
+    // });
 }
 
 void SsoSession::Private::sendHttpResponse(const QByteArray& code,
@@ -134,6 +137,6 @@ void SsoSession::Private::onError(const QByteArray& code,
     sendHttpResponse(code, "<h3>" + errorMsg.toUtf8() + "</h3>");
     // [kitsune] Yeah, I know, dirty. Maybe the "right" way would be to have
     // an intermediate signal but that seems just a fight for purity.
-    emit connection->loginError(errorMsg, QString::fromUtf8(requestData));
+    //TODO emit connection->loginError(errorMsg, QString::fromUtf8(requestData));
     socket->disconnectFromHost();
 }

--- a/autotests/testcrosssigning.cpp
+++ b/autotests/testcrosssigning.cpp
@@ -5,6 +5,9 @@
 
 #include <QTest>
 #include <Quotient/connection_p.h>
+#include <Quotient/accountregistry.h>
+#include <Quotient/pendingconnection.h>
+
 #include "testutils.h"
 
 using namespace Quotient;
@@ -27,7 +30,7 @@ private Q_SLOTS:
         jobMock.setResult(QJsonDocument::fromJson(data));
         auto mockKeys = collectResponse(&jobMock);
 
-        auto connection = Connection::makeMockConnection("@tobiasfella:kde.org"_ls, true);
+        auto connection = (new AccountRegistry())->mockConnection("@tobiasfella:kde.org"_ls)->connection();
         connection->d->encryptionData->handleQueryKeys(mockKeys);
 
         QVERIFY(!connection->isUserVerified("@tobiasfella:kde.org"_ls));

--- a/autotests/testcryptoutils.cpp
+++ b/autotests/testcryptoutils.cpp
@@ -6,7 +6,8 @@
 #include <Quotient/database.h>
 #include <Quotient/e2ee/cryptoutils.h>
 #include <Quotient/e2ee/e2ee_common.h>
-
+#include <Quotient/accountregistry.h>
+#include <Quotient/pendingconnection.h>
 #include <Quotient/events/filesourceinfo.h>
 
 #include <QTest>
@@ -102,7 +103,7 @@ void TestCryptoUtils::testEncrypted()
 {
     QByteArray key(32, '\0');
     auto text = QByteArrayLiteral("This is a message");
-    auto connection = Connection::makeMockConnection("@foo:bar.com"_ls, true);
+    auto connection = (new AccountRegistry())->mockConnection("@foo:bar.com"_ls)->connection();
     connection->database()->storeEncrypted("testKey"_ls, text);
     auto decrypted = connection->database()->loadEncrypted("testKey"_ls);
     QCOMPARE(text, decrypted);

--- a/autotests/testkeyverification.cpp
+++ b/autotests/testkeyverification.cpp
@@ -9,6 +9,8 @@
 
 #include <Quotient/connection.h>
 #include <Quotient/e2ee/qolmaccount.h>
+#include <Quotient/accountregistry.h>
+#include <Quotient/pendingconnection.h>
 
 using namespace Quotient;
 
@@ -21,7 +23,8 @@ private Q_SLOTS:
     {
         auto userId = QStringLiteral("@bob:localhost");
         auto deviceId = QStringLiteral("DEFABC");
-        auto connection = Connection::makeMockConnection("@carl:localhost"_ls);
+
+        auto connection = (new AccountRegistry())->mockConnection("@carl:localhost"_ls)->connection();
         const auto transactionId = "other_transaction_id"_ls;
         auto session = connection->startKeyVerificationSession("@alice:localhost"_ls, "ABCDEF"_ls);
         session->sendRequest();
@@ -40,7 +43,7 @@ private Q_SLOTS:
         auto userId = QStringLiteral("@bob:localhost");
         auto deviceId = QStringLiteral("DEFABC");
         const auto transactionId = "trans123action123id"_ls;
-        auto connection = Connection::makeMockConnection("@carl:localhost"_ls);
+        auto connection = (new AccountRegistry())->mockConnection("@carl:localhost"_ls)->connection();
         auto session = new KeyVerificationSession(userId, KeyVerificationRequestEvent(transactionId, deviceId, {SasV1Method}, QDateTime::currentDateTime()), connection, false);
         QVERIFY(session->state() == KeyVerificationSession::INCOMING);
         session->sendReady();

--- a/autotests/testutils.cpp
+++ b/autotests/testutils.cpp
@@ -26,22 +26,22 @@ std::shared_ptr<Quotient::Connection> Quotient::createTestConnection(
     QObject::connect(nam, &QNetworkAccessManager::sslErrors, nam,
                      [](QNetworkReply* reply) { reply->ignoreSslErrors(); });
 
-    auto c = std::make_shared<Connection>();
-    c->enableEncryption(true);
-    const QString userId{ u'@' % localUserName % u':' % homeserverAddr };
-    c->setHomeserver(QUrl(u"https://" % homeserverAddr));
-    if (!waitForSignal(c, &Connection::loginFlowsChanged)
-        || !c->supportsPasswordAuth()) {
-        qCritical().noquote() << "Can't use password login at" << homeserverAddr
-                              << "- check that the homeserver is running";
-        return nullptr;
-    }
-    c->loginWithPassword(localUserName, secret, deviceName);
-    if (!waitForSignal(c, &Connection::connected)) {
-        qCritical().noquote()
-            << "Could not achieve the logged in state for" << userId
-            << "- check the credentials in the test code and at the homeserver";
-        return nullptr;
-    }
-    return c;
+    // auto c = std::make_shared<Connection>();
+    // c->enableEncryption(true);
+    // const QString userId{ u'@' % localUserName % u':' % homeserverAddr };
+    // // c->setHomeserver(QUrl(u"https://" % homeserverAddr));
+    // // if (!waitForSignal(c, &Connection::loginFlowsChanged)
+    // //     || !c->supportsPasswordAuth()) {
+    // //     qCritical().noquote() << "Can't use password login at" << homeserverAddr
+    // //                           << "- check that the homeserver is running";
+    // //     return nullptr;
+    // // }
+    // //c->loginWithPassword(localUserName, secret, deviceName);
+    // if (!waitForSignal(c, &Connection::connected)) {
+    //     qCritical().noquote()
+    //         << "Could not achieve the logged in state for" << userId
+    //         << "- check the credentials in the test code and at the homeserver";
+    //     return nullptr;
+    // }
+    return nullptr;//c;
 }

--- a/quotest/quotest.cpp
+++ b/quotest/quotest.cpp
@@ -35,7 +35,7 @@ class TestSuite;
 
 class TestManager : public QCoreApplication {
 public:
-    TestManager(int& argc, char** argv);
+    //TestManager(int& argc, char** argv);
 
 private:
     void setupAndRun();
@@ -180,15 +180,15 @@ void TestSuite::finishTest(const TestToken& token, bool condition,
 
     emit finishedItem(item, condition);
 }
-
+/*
 TestManager::TestManager(int& argc, char** argv)
     : QCoreApplication(argc, argv), c(new Connection(this))
 {
     Q_ASSERT(argc >= 5);
     // NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     clog << "Connecting to Matrix as " << argv[1] << endl;
-    c->loginWithPassword(QString::fromUtf8(argv[1]), QString::fromUtf8(argv[2]),
-                         QString::fromUtf8(argv[3]));
+    // c->loginWithPassword(QString::fromUtf8(argv[1]), QString::fromUtf8(argv[2]),
+    //                      QString::fromUtf8(argv[3]));
     targetRoomName = QString::fromUtf8(argv[4]);
     clog << "Test room name: " << argv[4] << '\n';
     if (argc > 5) {
@@ -199,20 +199,20 @@ TestManager::TestManager(int& argc, char** argv)
     // NOLINTEND(cppcoreguidelines-pro-bounds-pointer-arithmetic)
 
     connect(c, &Connection::connected, this, &TestManager::setupAndRun);
-    connect(c, &Connection::resolveError, this,
-        [](const QString& error) {
-            clog << "Failed to resolve the server: " << error.toStdString() << endl;
-            QCoreApplication::exit(-2);
-        },
-        Qt::QueuedConnection);
-    connect(c, &Connection::loginError, this,
-        [this](const QString& message, const QString& details) {
-            clog << "Failed to login to " << c->homeserver().toDisplayString().toStdString() << ": "
-                 << message.toStdString() << "\nDetails:\n"
-                 << details.toStdString() << endl;
-            QCoreApplication::exit(-2);
-        },
-        Qt::QueuedConnection);
+    // connect(c, &Connection::resolveError, this,
+    //     [](const QString& error) {
+    //         clog << "Failed to resolve the server: " << error.toStdString() << endl;
+    //         QCoreApplication::exit(-2);
+    //     },
+    //     Qt::QueuedConnection);
+    // connect(c, &Connection::loginError, this,
+    //     [this](const QString& message, const QString& details) {
+    //         clog << "Failed to login to " << c->homeserver().toDisplayString().toStdString() << ": "
+    //              << message.toStdString() << "\nDetails:\n"
+    //              << details.toStdString() << endl;
+    //         QCoreApplication::exit(-2);
+    //     },
+    //     Qt::QueuedConnection);
     connect(c, &Connection::loadedRoomState, this, &TestManager::onNewRoom);
 
     // Big countdown watchdog
@@ -268,6 +268,7 @@ void TestManager::setupAndRun()
         });
     });
 }
+*/
 
 void TestManager::onNewRoom(Room* r)
 {
@@ -915,11 +916,11 @@ void TestManager::conclude()
 
 void TestManager::finalize(const QString& lastWords)
 {
-    if (!c->isUsable() || !c->isLoggedIn()) {
-        clog << "No usable connection reached" << endl;
-        QCoreApplication::exit(-2);
-        return; // NB: QCoreApplication::exit() does return to the caller
-    }
+    // if (!c->isUsable() || !c->isLoggedIn()) {
+    //     clog << "No usable connection reached" << endl;
+    //     QCoreApplication::exit(-2);
+    //     return; // NB: QCoreApplication::exit() does return to the caller
+    // }
     clog << "Logging out" << endl;
     c->logout().then(
         this, [this, lastWords] {
@@ -941,7 +942,7 @@ int main(int argc, char* argv[])
         return -1;
     }
     // NOLINTNEXTLINE(readability-static-accessed-through-instance)
-    return TestManager(argc, argv).exec();
+    return 0;//TestManager(argc, argv).exec();
 }
 
 #include "quotest.moc"


### PR DESCRIPTION
As described in #781

Roughly:
- Turn Connection into a type that only exists in an initiated state (from the API user's perspective, at least)
- To do this, pull connection setup, etc. out into a new PendingConnection type
- Add easy-to-use account login and restoration functions to AccountRegistry
- Make connections do the expected things (cache, sync loop, etc.) by default

Still an early draft. Rough list of missing things:
- SSO login
- Registration
- Error handling during login
- Implementation of mockConnection
- Putting back some things that were hacked out
- Make sure that tests still work
- Homeserver class