### PR TITLE
Event iD Display

### DIFF
--- a/Quotient/events/roomevent.cpp
+++ b/Quotient/events/roomevent.cpp
@@ -19,6 +19,8 @@ RoomEvent::RoomEvent(const QJsonObject& json) : Event(json)
 
 RoomEvent::~RoomEvent() = default; // Let the smart pointer do its job
 
+QString RoomEvent::displayId() const { return id().isEmpty() ? transactionId() : id(); }
+
 QString RoomEvent::id() const { return fullJson()[EventIdKey].toString(); }
 
 QDateTime RoomEvent::originTimestamp() const

--- a/Quotient/events/roomevent.h
+++ b/Quotient/events/roomevent.h
@@ -28,10 +28,8 @@ public:
     ~RoomEvent() override; // Don't inline this - see the private section
 
     //! \brief A convenience function to get a display string for an event ID.
-    //!
-    //! The aim is to give something that can be shown in a UI. Will return id() if not empty,
-    //! otherwise transactionId() will be returned. This is useful when dealing with
-    //! pending events that don't have an event_id yet.
+    //! \return id() if the event id is not empty, otherwise transactionId();
+    //!              this is useful to deal with pending and normal events uniformly.
     //! \sa id(), transactionId()
     QString displayId() const;
 

--- a/Quotient/events/roomevent.h
+++ b/Quotient/events/roomevent.h
@@ -27,7 +27,17 @@ public:
 
     ~RoomEvent() override; // Don't inline this - see the private section
 
+    //! \brief A convenience function to get a display string for an event ID.
+    //!
+    //! The aim is to give something that can be shown in a UI. Will return id() if not empty,
+    //! otherwise transactionId() will be returned. This is useful when dealing with
+    //! pending events that don't have an event_id yet.
+    //! \sa id(), transactionId()
+    QString displayId() const;
+
+    //! The event_id JSON value for the event.
     QString id() const;
+
     QDateTime originTimestamp() const;
     QString roomId() const;
     QString senderId() const;
@@ -37,7 +47,10 @@ public:
         return _redactedBecause;
     }
     QString redactionReason() const;
+
+    //! The transaction_id JSON value for the event.
     QString transactionId() const;
+
     QString stateKey() const;
 
     //! \brief Fill the pending event object with the room id


### PR DESCRIPTION
Create a new convenience function to return a string to display an id for an event in a UI.

The aim is to always return something that can be used even when an event is pending and an event_id has not been assigned yet.

This is something we use in NeoChat and I thought I'd upstream.