### PR TITLE
Fix GCC -Wattributes warnings

### DIFF
--- a/Quotient/jobs/jobhandle.h
+++ b/Quotient/jobs/jobhandle.h
@@ -70,7 +70,7 @@ concept ResultHandler = BoundResultHandler<FnT, JobT> || std::is_member_function
 //! - otherwise, the return value is wrapped in a "normal" QFuture, JobHandle waves you good-bye and
 //!   further continuations will follow pristine QFuture rules.
 template <class JobT>
-class JobHandle : public QPointer<JobT>, public QFuture<JobT*> {
+class QUOTIENT_API JobHandle : public QPointer<JobT>, public QFuture<JobT*> {
 public:
     using pointer_type = QPointer<JobT>;
     using future_value_type = JobT*;


### PR DESCRIPTION
GCC gets concerned that `JobHandle<>::BoundFn<>` is not exported by the library although lambdas it carries are (because they are created in `Connection` that is tagged with `QUOTIENT_API`). `JobHandle` is an inline class template but it's not too bad (and from what I gather, _is_ correct) to add `QUOTIENT_API` on it, too.