### PR TITLE
Add helper functions for replies and threads to RoomMessageEvent

### DIFF
--- a/Quotient/events/eventrelation.cpp
+++ b/Quotient/events/eventrelation.cpp
@@ -26,7 +26,7 @@ void JsonObjectConverter<EventRelation>::dumpTo(QJsonObject& jo,
     if (pod.type == EventRelation::AnnotationType)
         jo.insert("key"_L1, pod.key);
     if (pod.type == EventRelation::ThreadType) {
-        jo.insert(EventRelation::ReplyType, {{EventIdKey, pod.fallbackEventId}});
+        jo.insert(EventRelation::ReplyType, {{EventIdKey, pod.inThreadReplyEventId}});
     }
     jo.insert(IsFallingBackKey, pod.isFallingBack);
 }
@@ -47,7 +47,7 @@ void JsonObjectConverter<EventRelation>::fillFrom(const QJsonObject& jo,
     if (pod.type == EventRelation::AnnotationType)
         fromJson(jo["key"_L1], pod.key);
     if (pod.type == EventRelation::ThreadType) {
-        fromJson(replyJson[EventIdKey], pod.fallbackEventId);
+        fromJson(replyJson[EventIdKey], pod.inThreadReplyEventId);
     }
     fromJson(jo[IsFallingBackKey], pod.isFallingBack);
 }

--- a/Quotient/events/eventrelation.cpp
+++ b/Quotient/events/eventrelation.cpp
@@ -4,6 +4,7 @@
 #include "eventrelation.h"
 
 #include "../logging_categories_p.h"
+#include "converters.h"
 #include "roomevent.h"
 
 using namespace Quotient;
@@ -15,24 +16,39 @@ void JsonObjectConverter<EventRelation>::dumpTo(QJsonObject& jo,
         qCWarning(MAIN) << "Empty relation type; won't dump to JSON";
         return;
     }
+
+    if (pod.type == EventRelation::ReplyType) {
+        jo.insert(RelTypeKey, {{EventIdKey, pod.eventId}});
+        return;
+    }
+
     jo.insert(RelTypeKey, pod.type);
     jo.insert(EventIdKey, pod.eventId);
     if (pod.type == EventRelation::AnnotationType)
         jo.insert("key"_L1, pod.key);
+    if (pod.type == EventRelation::ThreadType) {
+        jo.insert(RelTypeKey, {{EventIdKey, pod.fallbackEventId}});
+    }
+    jo.insert(IsFallingBackKey, pod.isFallingBack);
 }
 
 void JsonObjectConverter<EventRelation>::fillFrom(const QJsonObject& jo,
                                                   EventRelation& pod)
 {
-    if (const auto replyJson = jo.value(EventRelation::ReplyType).toObject();
-        !replyJson.isEmpty()) {
+    const auto replyJson = jo.value(EventRelation::ReplyType).toObject();
+    if (!replyJson.isEmpty() && jo.value(RelTypeKey).isUndefined()) {
         pod.type = EventRelation::ReplyType;
         fromJson(replyJson[EventIdKey], pod.eventId);
-    } else {
-        // The experimental logic for generic relationships (MSC1849)
-        fromJson(jo[RelTypeKey], pod.type);
-        fromJson(jo[EventIdKey], pod.eventId);
-        if (pod.type == EventRelation::AnnotationType)
-            fromJson(jo["key"_L1], pod.key);
+        return;
     }
+
+    // The experimental logic for generic relationships (MSC1849)
+    fromJson(jo[RelTypeKey], pod.type);
+    fromJson(jo[EventIdKey], pod.eventId);
+    if (pod.type == EventRelation::AnnotationType)
+        fromJson(jo["key"_L1], pod.key);
+    if (pod.type == EventRelation::ThreadType) {
+        fromJson(replyJson[EventIdKey], pod.fallbackEventId);
+    }
+    fromJson(jo[IsFallingBackKey], pod.isFallingBack);
 }

--- a/Quotient/events/eventrelation.cpp
+++ b/Quotient/events/eventrelation.cpp
@@ -4,7 +4,6 @@
 #include "eventrelation.h"
 
 #include "../logging_categories_p.h"
-#include "converters.h"
 #include "roomevent.h"
 
 using namespace Quotient;

--- a/Quotient/events/eventrelation.cpp
+++ b/Quotient/events/eventrelation.cpp
@@ -17,7 +17,7 @@ void JsonObjectConverter<EventRelation>::dumpTo(QJsonObject& jo,
     }
 
     if (pod.type == EventRelation::ReplyType) {
-        jo.insert(RelTypeKey, {{EventIdKey, pod.eventId}});
+        jo.insert(EventRelation::ReplyType, {{EventIdKey, pod.eventId}});
         return;
     }
 
@@ -26,7 +26,7 @@ void JsonObjectConverter<EventRelation>::dumpTo(QJsonObject& jo,
     if (pod.type == EventRelation::AnnotationType)
         jo.insert("key"_L1, pod.key);
     if (pod.type == EventRelation::ThreadType) {
-        jo.insert(RelTypeKey, {{EventIdKey, pod.fallbackEventId}});
+        jo.insert(EventRelation::ReplyType, {{EventIdKey, pod.fallbackEventId}});
     }
     jo.insert(IsFallingBackKey, pod.isFallingBack);
 }

--- a/Quotient/events/eventrelation.h
+++ b/Quotient/events/eventrelation.h
@@ -8,6 +8,7 @@
 namespace Quotient {
 
 constexpr inline auto RelTypeKey = "rel_type"_L1;
+constexpr inline auto IsFallingBackKey = "is_falling_back"_L1;
 
 struct QUOTIENT_API EventRelation {
     using reltypeid_t = QLatin1String;
@@ -15,10 +16,15 @@ struct QUOTIENT_API EventRelation {
     QString type;
     QString eventId;
     QString key = {}; // Only used for m.annotation for now
+    bool isFallingBack = false;
+    // Only used for m.thread to provide the reply event fallback for non-threaded clients
+    // or to allow a reply within the thread.
+    QString fallbackEventId = {};
 
     static constexpr auto ReplyType = "m.in_reply_to"_L1;
     static constexpr auto AnnotationType = "m.annotation"_L1;
     static constexpr auto ReplacementType = "m.replace"_L1;
+    static constexpr auto ThreadType = "m.thread"_L1;
 
     static EventRelation replyTo(QString eventId)
     {
@@ -31,6 +37,10 @@ struct QUOTIENT_API EventRelation {
     static EventRelation replace(QString eventId)
     {
         return { ReplacementType, std::move(eventId) };
+    }
+    static EventRelation replyThread(QString threadRoot, bool isFallingBack, QString fallbackEventId)
+    {
+        return { ReplacementType, std::move(threadRoot), {}, std::move(isFallingBack), std::move(fallbackEventId) };
     }
 };
 

--- a/Quotient/events/eventrelation.h
+++ b/Quotient/events/eventrelation.h
@@ -40,7 +40,7 @@ struct QUOTIENT_API EventRelation {
     }
     static EventRelation replyThread(QString threadRoot, bool isFallingBack, QString fallbackEventId)
     {
-        return { ReplacementType, std::move(threadRoot), {}, std::move(isFallingBack), std::move(fallbackEventId) };
+        return { ThreadType, std::move(threadRoot), {}, std::move(isFallingBack), std::move(fallbackEventId) };
     }
 };
 

--- a/Quotient/events/eventrelation.h
+++ b/Quotient/events/eventrelation.h
@@ -19,7 +19,7 @@ struct QUOTIENT_API EventRelation {
     bool isFallingBack = false;
     // Only used for m.thread to provide the reply event fallback for non-threaded clients
     // or to allow a reply within the thread.
-    QString fallbackEventId = {};
+    QString inThreadReplyEventId = {};
 
     static constexpr auto ReplyType = "m.in_reply_to"_L1;
     static constexpr auto AnnotationType = "m.annotation"_L1;
@@ -38,9 +38,9 @@ struct QUOTIENT_API EventRelation {
     {
         return { ReplacementType, std::move(eventId) };
     }
-    static EventRelation replyThread(QString threadRoot, bool isFallingBack, QString fallbackEventId)
+    static EventRelation replyInThread(QString threadRootId, bool isFallingBack, QString inThreadReplyEventId)
     {
-        return { ThreadType, std::move(threadRoot), {}, std::move(isFallingBack), std::move(fallbackEventId) };
+        return { ThreadType, std::move(threadRootId), {}, std::move(isFallingBack), std::move(inThreadReplyEventId) };
     }
 };
 

--- a/Quotient/events/roommessageevent.cpp
+++ b/Quotient/events/roommessageevent.cpp
@@ -229,7 +229,7 @@ QString RoomMessageEvent::replacedBy() const
 bool RoomMessageEvent::isReply() const
 {
     const auto relation = relatesTo();
-    return relation.has_value() && relation.value().type == EventRelation::ReplyType;
+    return relation.has_value() && (relation.value().type == EventRelation::ReplyType || (relation.value().type == EventRelation::ThreadType && relation.value().isFallingBack == false));
 }
 
 bool RoomMessageEvent::isReplyIncludingFallbacks() const
@@ -240,6 +240,19 @@ bool RoomMessageEvent::isReplyIncludingFallbacks() const
 }
 
 QString RoomMessageEvent::replyEventId() const
+{
+    const auto relation = relatesTo();
+    if (relation.has_value()) {
+        if (relation.value().type == EventRelation::ReplyType) {
+            return relation.value().eventId;
+        } else if (relation.value().type == EventRelation::ThreadType && relation.value().isFallingBack == false) {
+            return relation.value().fallbackEventId;
+        }
+    }
+    return {};
+}
+
+QString RoomMessageEvent::replyEventIdIncludingFallbacks()const
 {
     const auto relation = relatesTo();
     if (relation.has_value()) {

--- a/Quotient/events/roommessageevent.h
+++ b/Quotient/events/roommessageevent.h
@@ -102,6 +102,10 @@ public:
     //!
     //! \return true if this event is a reply, i.e. it has `"m.in_reply_to"`
     //!         event ID and is not a thread fallback; false otherwise.
+    //!
+    //! \note It's possible to reply to another message in a thread so this function
+    //!       will return true for a `"rel_type"` of `"m.thread"` if `"is_falling_back"`
+    //!       is false.
     bool isReply() const;
 
     //! \brief Determine whether the event is a reply to another message including fallbacks.
@@ -112,9 +116,15 @@ public:
 
     //! \brief The ID for the event being replied to.
     //!
+    //! \return The event ID for a reply, this includes threaded replies where `"rel_type"`
+    //!         is `"m.thread"` and `"is_falling_back"` is false.
+    QString replyEventId()const;
+
+    //! \brief The ID for the event being replied to.
+    //!
     //! \return The event ID for a reply or the fallback event ID for a threaded message,
     //!         an empty string otherwise.
-    QString replyEventId()const;
+    QString replyEventIdIncludingFallbacks()const;
 
     //! \brief Determine whether the event is part of a thread.
     //!

--- a/Quotient/events/roommessageevent.h
+++ b/Quotient/events/roommessageevent.h
@@ -82,6 +82,35 @@ public:
 
     QString replacedBy() const;
 
+    //! \brief Determine whether the event is a reply to another message.
+    //!
+    //! \return true if this event is a reply, i.e. it has `"m.in_reply_to"`
+    //!         event ID and is not a thread fallback; false otherwise.
+    bool isReply() const;
+
+    //! \brief Determine whether the event is a reply to another message including fallbacks.
+    //!
+    //! \return true if this event is part of a thread, i.e. it has `"m.in_reply_to"`
+    //!         event ID this includes thread fallback; false otherwise.
+    bool isReplyIncludingFallbacks() const;
+
+    //! \brief The ID for the event being replied to.
+    //!
+    //! Returns an empty string if the message is not a reply.
+    QString replyEventId()const;
+
+    //! \brief Determine whether the event is part of a thread.
+    //!
+    //! \return true if this event is part of a thread, i.e. it has
+    //!         `"rel_type": "m.thread"` or  `"m.relations": { "m.thread": {}}`;
+    //!         false otherwise.
+    bool isThreaded() const;
+
+    //! \brief The event ID for the thread root event.
+    //!
+    //! Returns an empty string if the message is not part of a thread.
+    QString threadRootEventId()const;
+
     QString fileNameToDownload() const;
 
     static QString rawMsgTypeForUrl(const QUrl& url);

--- a/Quotient/events/roommessageevent.h
+++ b/Quotient/events/roommessageevent.h
@@ -100,31 +100,25 @@ public:
 
     //! \brief Determine whether the event is a reply to another message.
     //!
+    //! \param includeFallbacks include thread fallback replies for non-threaded clients.
+    //!
     //! \return true if this event is a reply, i.e. it has `"m.in_reply_to"`
-    //!         event ID and is not a thread fallback; false otherwise.
+    //!         event ID and is not a thread fallback (except where \p includeFallbacks is true);
+    //!         false otherwise.
     //!
     //! \note It's possible to reply to another message in a thread so this function
     //!       will return true for a `"rel_type"` of `"m.thread"` if `"is_falling_back"`
     //!       is false.
-    bool isReply() const;
-
-    //! \brief Determine whether the event is a reply to another message including fallbacks.
-    //!
-    //! \return true if this event is a reply, i.e. it has `"m.in_reply_to"`
-    //!         event ID, this includes thread fallback; false otherwise.
-    bool isReplyIncludingFallbacks() const;
+    bool isReply(bool includeFallbacks = false) const;
 
     //! \brief The ID for the event being replied to.
+    //!
+    //! \param includeFallbacks include thread fallback replies for non-threaded clients.
+    //!
     //!
     //! \return The event ID for a reply, this includes threaded replies where `"rel_type"`
-    //!         is `"m.thread"` and `"is_falling_back"` is false.
-    QString replyEventId()const;
-
-    //! \brief The ID for the event being replied to.
-    //!
-    //! \return The event ID for a reply or the fallback event ID for a threaded message,
-    //!         an empty string otherwise.
-    QString replyEventIdIncludingFallbacks()const;
+    //!         is `"m.thread"` and `"is_falling_back"` is false (except where \p includeFallbacks is true).
+    QString replyEventId(bool includeFallbacks = false)const;
 
     //! \brief Determine whether the event is part of a thread.
     //!

--- a/Quotient/events/roommessageevent.h
+++ b/Quotient/events/roommessageevent.h
@@ -106,8 +106,8 @@ public:
 
     //! \brief Determine whether the event is a reply to another message including fallbacks.
     //!
-    //! \return true if this event is part of a thread, i.e. it has `"m.in_reply_to"`
-    //!         event ID this includes thread fallback; false otherwise.
+    //! \return true if this event is a reply, i.e. it has `"m.in_reply_to"`
+    //!         event ID, this includes thread fallback; false otherwise.
     bool isReplyIncludingFallbacks() const;
 
     //! \brief The ID for the event being replied to.

--- a/Quotient/events/roommessageevent.h
+++ b/Quotient/events/roommessageevent.h
@@ -70,6 +70,22 @@ public:
     //!         false otherwise
     bool hasThumbnail() const;
 
+    //! \brief The EventRelation for this event.
+    //!
+    //! \return an EventRelation object which can be checked for type if it exists,
+    //!         std::nullopt otherwise.
+    std::optional<EventRelation> relatesTo() const;
+
+    //! \brief The upstream event ID for the relation.
+    //!
+    //! \warning If your client is not thread aware use replyEventId() as this will
+    //!          return the fallback reply ID so you can treat a threaded reply like a normal one.
+    //!
+    //! \warning If your client is thread aware use threadRootEventId() to get the
+    //!          thread root ID as this will return an empty string on the root event.
+    //!          threadRootEventId() will return the root messages ID on itself.
+    QString upstreamEventId() const;
+
     //! \brief Obtain id of an event replaced by the current one
     //! \sa RoomEvent::isReplaced, RoomEvent::replacedBy
     QString replacedEvent() const;
@@ -96,7 +112,8 @@ public:
 
     //! \brief The ID for the event being replied to.
     //!
-    //! Returns an empty string if the message is not a reply.
+    //! \return The event ID for a reply or the fallback event ID for a threaded message,
+    //!         an empty string otherwise.
     QString replyEventId()const;
 
     //! \brief Determine whether the event is part of a thread.
@@ -108,7 +125,9 @@ public:
 
     //! \brief The event ID for the thread root event.
     //!
-    //! Returns an empty string if the message is not part of a thread.
+    //! \note This will return the ID of the event if it is the thread root.
+    //!
+    //! \return The event ID of the thread root if threaded, an empty string otherwise.
     QString threadRootEventId()const;
 
     QString fileNameToDownload() const;

--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -58,6 +58,7 @@
 #include "events/typingevent.h"
 #include "jobs/downloadfilejob.h"
 #include "jobs/mediathumbnailjob.h"
+#include <Quotient/events/roommessageevent.h>
 
 // NB: since Qt 6, moc_room.cpp needs User fully defined
 #include "moc_room.cpp" // NOLINT(bugprone-suspicious-include)
@@ -264,6 +265,15 @@ public:
      */
     Timeline::size_type moveEventsToTimeline(RoomEventsRange events,
                                              EventsPlacement placement);
+
+    //! \brief Update an event's data with the latest from the server.
+    //!
+    //! This is mainly designed for threads where the server aggregates the root event
+    //! with the other thread messages and places this in the unsigned value but doesn't
+    //! doesn't automatically download the updated event.
+    //!
+    //! Does nothing if the event is not in the timeline.
+    void updateEventFromServer(const QString& eventId);
 
     /**
      * Remove events from the passed container that are already in the timeline
@@ -1735,6 +1745,12 @@ Room::Private::moveEventsToTimeline(RoomEventsRange events,
             !eventsIndex.contains(eId), __FUNCTION__,
             makeErrorStr(*e, "Event is already in the timeline; "
                              "incoming events were not properly deduplicated"));
+
+        const auto messageE = eventCast<const RoomMessageEvent>(e);
+        if (messageE != nullptr && messageE->isThreaded()) {
+            updateEventFromServer(messageE->threadRootEventId());
+        }
+
         const auto& ti = placement == Older
                              ? timeline.emplace_front(std::move(e), --index)
                              : timeline.emplace_back(std::move(e), ++index);


### PR DESCRIPTION
These can be used to check if the message is a reply or part of a thread and then get the relevant event ID.

For replies there are 2 functions because threads uses replies as the fallback for non-threaded clients. The function `isReplyIncludingFallbacks` should be used for a non-thread aware client.

This is more upstream based on NeoChat that we've found useful.