### PR TITLE
Modernize string literals

### DIFF
--- a/CODE_GENERATION.md
+++ b/CODE_GENERATION.md
@@ -109,8 +109,7 @@ It uses the following type attributes aside from pretty obvious `imports:`:
 * `initializer` - this is a _partial_ (see GTAD and Mustache documentation for
   explanations but basically it's a variable that is a Mustache template itself)
   that specifies how exactly a default value should be passed to the parameter.
-  E.g., the default value for a `QString` parameter is enclosed into
-  `QStringLiteral`.
+  E.g., the default value for a `QString` parameter is transformed as `u"{{defaultValue}}"_s`.
 
 Instead of relying on the event structure definition in the OpenAPI files,
 `gtad.yaml` uses pointers to libQuotient's event structures: `EventPtr`,

--- a/Quotient/accountregistry.cpp
+++ b/Quotient/accountregistry.cpp
@@ -91,7 +91,7 @@ Connection* AccountRegistry::get(const QString& userId) const
 
 void AccountRegistry::invokeLogin()
 {
-    const auto accounts = SettingsGroup("Accounts"_ls).childGroups();
+    const auto accounts = SettingsGroup("Accounts"_L1).childGroups();
     for (const auto& accountId : accounts) {
         AccountSettings account { accountId };
 

--- a/Quotient/application-service/definitions/location.h
+++ b/Quotient/application-service/definitions/location.h
@@ -21,15 +21,15 @@ template <>
 struct JsonObjectConverter<ThirdPartyLocation> {
     static void dumpTo(QJsonObject& jo, const ThirdPartyLocation& pod)
     {
-        addParam<>(jo, QStringLiteral("alias"), pod.alias);
-        addParam<>(jo, QStringLiteral("protocol"), pod.protocol);
-        addParam<>(jo, QStringLiteral("fields"), pod.fields);
+        addParam<>(jo, "alias"_L1, pod.alias);
+        addParam<>(jo, "protocol"_L1, pod.protocol);
+        addParam<>(jo, "fields"_L1, pod.fields);
     }
     static void fillFrom(const QJsonObject& jo, ThirdPartyLocation& pod)
     {
-        fillFromJson(jo.value("alias"_ls), pod.alias);
-        fillFromJson(jo.value("protocol"_ls), pod.protocol);
-        fillFromJson(jo.value("fields"_ls), pod.fields);
+        fillFromJson(jo.value("alias"_L1), pod.alias);
+        fillFromJson(jo.value("protocol"_L1), pod.protocol);
+        fillFromJson(jo.value("fields"_L1), pod.fields);
     }
 };
 

--- a/Quotient/application-service/definitions/protocol.h
+++ b/Quotient/application-service/definitions/protocol.h
@@ -20,13 +20,13 @@ template <>
 struct JsonObjectConverter<FieldType> {
     static void dumpTo(QJsonObject& jo, const FieldType& pod)
     {
-        addParam<>(jo, QStringLiteral("regexp"), pod.regexp);
-        addParam<>(jo, QStringLiteral("placeholder"), pod.placeholder);
+        addParam<>(jo, "regexp"_L1, pod.regexp);
+        addParam<>(jo, "placeholder"_L1, pod.placeholder);
     }
     static void fillFrom(const QJsonObject& jo, FieldType& pod)
     {
-        fillFromJson(jo.value("regexp"_ls), pod.regexp);
-        fillFromJson(jo.value("placeholder"_ls), pod.placeholder);
+        fillFromJson(jo.value("regexp"_L1), pod.regexp);
+        fillFromJson(jo.value("placeholder"_L1), pod.placeholder);
     }
 };
 
@@ -49,17 +49,17 @@ template <>
 struct JsonObjectConverter<ProtocolInstance> {
     static void dumpTo(QJsonObject& jo, const ProtocolInstance& pod)
     {
-        addParam<>(jo, QStringLiteral("desc"), pod.desc);
-        addParam<>(jo, QStringLiteral("fields"), pod.fields);
-        addParam<>(jo, QStringLiteral("network_id"), pod.networkId);
-        addParam<IfNotEmpty>(jo, QStringLiteral("icon"), pod.icon);
+        addParam<>(jo, "desc"_L1, pod.desc);
+        addParam<>(jo, "fields"_L1, pod.fields);
+        addParam<>(jo, "network_id"_L1, pod.networkId);
+        addParam<IfNotEmpty>(jo, "icon"_L1, pod.icon);
     }
     static void fillFrom(const QJsonObject& jo, ProtocolInstance& pod)
     {
-        fillFromJson(jo.value("desc"_ls), pod.desc);
-        fillFromJson(jo.value("fields"_ls), pod.fields);
-        fillFromJson(jo.value("network_id"_ls), pod.networkId);
-        fillFromJson(jo.value("icon"_ls), pod.icon);
+        fillFromJson(jo.value("desc"_L1), pod.desc);
+        fillFromJson(jo.value("fields"_L1), pod.fields);
+        fillFromJson(jo.value("network_id"_L1), pod.networkId);
+        fillFromJson(jo.value("icon"_L1), pod.icon);
     }
 };
 
@@ -96,19 +96,19 @@ template <>
 struct JsonObjectConverter<ThirdPartyProtocol> {
     static void dumpTo(QJsonObject& jo, const ThirdPartyProtocol& pod)
     {
-        addParam<>(jo, QStringLiteral("user_fields"), pod.userFields);
-        addParam<>(jo, QStringLiteral("location_fields"), pod.locationFields);
-        addParam<>(jo, QStringLiteral("icon"), pod.icon);
-        addParam<>(jo, QStringLiteral("field_types"), pod.fieldTypes);
-        addParam<>(jo, QStringLiteral("instances"), pod.instances);
+        addParam<>(jo, "user_fields"_L1, pod.userFields);
+        addParam<>(jo, "location_fields"_L1, pod.locationFields);
+        addParam<>(jo, "icon"_L1, pod.icon);
+        addParam<>(jo, "field_types"_L1, pod.fieldTypes);
+        addParam<>(jo, "instances"_L1, pod.instances);
     }
     static void fillFrom(const QJsonObject& jo, ThirdPartyProtocol& pod)
     {
-        fillFromJson(jo.value("user_fields"_ls), pod.userFields);
-        fillFromJson(jo.value("location_fields"_ls), pod.locationFields);
-        fillFromJson(jo.value("icon"_ls), pod.icon);
-        fillFromJson(jo.value("field_types"_ls), pod.fieldTypes);
-        fillFromJson(jo.value("instances"_ls), pod.instances);
+        fillFromJson(jo.value("user_fields"_L1), pod.userFields);
+        fillFromJson(jo.value("location_fields"_L1), pod.locationFields);
+        fillFromJson(jo.value("icon"_L1), pod.icon);
+        fillFromJson(jo.value("field_types"_L1), pod.fieldTypes);
+        fillFromJson(jo.value("instances"_L1), pod.instances);
     }
 };
 

--- a/Quotient/application-service/definitions/user.h
+++ b/Quotient/application-service/definitions/user.h
@@ -21,15 +21,15 @@ template <>
 struct JsonObjectConverter<ThirdPartyUser> {
     static void dumpTo(QJsonObject& jo, const ThirdPartyUser& pod)
     {
-        addParam<>(jo, QStringLiteral("userid"), pod.userid);
-        addParam<>(jo, QStringLiteral("protocol"), pod.protocol);
-        addParam<>(jo, QStringLiteral("fields"), pod.fields);
+        addParam<>(jo, "userid"_L1, pod.userid);
+        addParam<>(jo, "protocol"_L1, pod.protocol);
+        addParam<>(jo, "fields"_L1, pod.fields);
     }
     static void fillFrom(const QJsonObject& jo, ThirdPartyUser& pod)
     {
-        fillFromJson(jo.value("userid"_ls), pod.userid);
-        fillFromJson(jo.value("protocol"_ls), pod.protocol);
-        fillFromJson(jo.value("fields"_ls), pod.fields);
+        fillFromJson(jo.value("userid"_L1), pod.userid);
+        fillFromJson(jo.value("protocol"_L1), pod.protocol);
+        fillFromJson(jo.value("fields"_L1), pod.fields);
     }
 };
 

--- a/Quotient/avatar.cpp
+++ b/Quotient/avatar.cpp
@@ -179,7 +179,7 @@ bool Avatar::Private::checkUrl(const QUrl& url) const
 
     // FIXME: Make "mxc" a library-wide constant and maybe even make
     // the URL checker a Connection(?) method.
-    if (!url.isValid() || url.scheme() != "mxc"_ls || url.path().count(u'/') != 1) {
+    if (!url.isValid() || url.scheme() != "mxc"_L1 || url.path().count(u'/') != 1) {
         qCWarning(MAIN) << "Avatar URL is invalid or not mxc-based:"
                         << url.toDisplayString();
         _imageSource = Invalid;
@@ -190,7 +190,7 @@ bool Avatar::Private::checkUrl(const QUrl& url) const
 QString Avatar::Private::localFile() const
 {
     static const auto cachePath = cacheLocation(QStringLiteral("avatars"));
-    return cachePath % _url.authority() % u'_' % _url.fileName() % ".png"_ls;
+    return cachePath % _url.authority() % u'_' % _url.fileName() % ".png"_L1;
 }
 
 QUrl Avatar::url() const { return d->_url; }

--- a/Quotient/avatar.cpp
+++ b/Quotient/avatar.cpp
@@ -189,7 +189,7 @@ bool Avatar::Private::checkUrl(const QUrl& url) const
 
 QString Avatar::Private::localFile() const
 {
-    static const auto cachePath = cacheLocation(QStringLiteral("avatars"));
+    static const auto cachePath = cacheLocation(u"avatars");
     return cachePath % _url.authority() % u'_' % _url.fileName() % ".png"_L1;
 }
 

--- a/Quotient/connection.cpp
+++ b/Quotient/connection.cpp
@@ -1596,10 +1596,9 @@ QStringList Connection::stableRoomVersions() const
 {
     QStringList l;
     if (d->capabilities.roomVersions) {
-        const auto& allVersions = d->capabilities.roomVersions->available;
-        for (auto it = allVersions.begin(); it != allVersions.end(); ++it)
-            if (it.value() == SupportedRoomVersion::StableTag)
-                l.push_back(it.key());
+        for (const auto& [v, isStable] : d->capabilities.roomVersions->available.asKeyValueRange())
+            if (isStable == SupportedRoomVersion::StableTag)
+                l.push_back(v);
     }
     return l;
 }

--- a/Quotient/connection.cpp
+++ b/Quotient/connection.cpp
@@ -87,7 +87,7 @@ void Connection::resolveServer(const QString& mxid)
     d->resolverJob.abandon(); // The previous network request is no more relevant
 
     auto maybeBaseUrl = QUrl::fromUserInput(serverPart(mxid));
-    maybeBaseUrl.setScheme("https"_ls); // Instead of the Qt-default "http"
+    maybeBaseUrl.setScheme("https"_L1); // Instead of the Qt-default "http"
     if (maybeBaseUrl.isEmpty() || !maybeBaseUrl.isValid()) {
         emit resolveError(tr("%1 is not a valid homeserver address")
                               .arg(maybeBaseUrl.toString()));
@@ -271,7 +271,7 @@ void Connection::Private::dropAccessToken()
     });
 
     auto pickleJob = new DeletePasswordJob(qAppName());
-    pickleJob->setKey(q->userId() + "-Pickle"_ls);
+    pickleJob->setKey(q->userId() + "-Pickle"_L1);
     pickleJob->start();
     QObject::connect(job, &Job::finished, q, [job] {
         if (job->error() == Error::NoError
@@ -393,7 +393,7 @@ QFuture<void> Connection::logout()
             || d->logoutJob->error() == BaseJob::ContentAccessError) {
             if (d->syncLoopConnection)
                 disconnect(d->syncLoopConnection);
-            SettingsGroup("Accounts"_ls).remove(userId());
+            SettingsGroup("Accounts"_L1).remove(userId());
             d->dropAccessToken();
             emit loggedOut();
             deleteLater();
@@ -693,14 +693,13 @@ inline auto splitMediaId(const QString& mediaId)
 {
     auto idParts = mediaId.split(u'/');
     Q_ASSERT_X(idParts.size() == 2, __FUNCTION__,
-               qPrintable("'"_ls % mediaId
-                          % "' doesn't look like 'serverName/localMediaId'"_ls));
+               qPrintable(u'\'' % mediaId % "' doesn't look like 'serverName/localMediaId'"_L1));
     return idParts;
 }
 
 QUrl Connection::makeMediaUrl(QUrl mxcUrl) const
 {
-    Q_ASSERT(mxcUrl.scheme() == "mxc"_ls);
+    Q_ASSERT(mxcUrl.scheme() == "mxc"_L1);
     QUrlQuery q(mxcUrl.query());
     q.addQueryItem(QStringLiteral("user_id"), userId());
     mxcUrl.setQuery(q);
@@ -1487,7 +1486,7 @@ void Connection::saveState() const
                 continue;
             (r->joinState() == JoinState::Invite ? inviteRoomsJson : roomsJson)
                 .insert(r->id(),
-                        QJsonObject{ { "$ref"_ls,
+                        QJsonObject{ { "$ref"_L1,
                                        SyncData::fileNameForRoom(r->id()) } });
         }
 
@@ -1716,14 +1715,14 @@ QFuture<QByteArray> Connection::requestKeyFromDevices(event_type_t name)
 
     UsersToDevicesToContent content;
     const auto& requestId = generateTxnId();
-    const QJsonObject eventContent{ { "action"_ls, "request"_ls },
-                                    { "name"_ls, name },
-                                    { "request_id"_ls, requestId },
-                                    { "requesting_device_id"_ls, deviceId() } };
+    const QJsonObject eventContent{ { "action"_L1, "request"_L1 },
+                                    { "name"_L1, name },
+                                    { "request_id"_L1, requestId },
+                                    { "requesting_device_id"_L1, deviceId() } };
     for (const auto& deviceId : devicesForUser(userId())) {
         content[userId()][deviceId] = eventContent;
     }
-    sendToDevices("m.secret.request"_ls, content);
+    sendToDevices("m.secret.request"_L1, content);
     auto futureKey = keyPromise.future();
     keyPromise.setProgressValue(5); // Already sent the request, now it's only to get the result
     connectUntil(this, &Connection::secretReceived, this,
@@ -1745,7 +1744,7 @@ QJsonObject Connection::decryptNotification(const QJsonObject& notification)
 {
     if (auto r = room(notification[RoomIdKey].toString()))
         if (auto event =
-                loadEvent<EncryptedEvent>(notification["event"_ls].toObject()))
+                loadEvent<EncryptedEvent>(notification["event"_L1].toObject()))
             if (const auto decrypted = r->decryptMessage(*event))
                 return decrypted->fullJson();
     return {};
@@ -1776,7 +1775,7 @@ QString Connection::edKeyForUserDevice(const QString& userId,
                                        const QString& deviceId) const
 {
     return d->encryptionData->deviceKeys[userId][deviceId]
-        .keys["ed25519:"_ls + deviceId];
+        .keys["ed25519:"_L1 + deviceId];
 }
 
 QString Connection::curveKeyForUserDevice(
@@ -1833,70 +1832,70 @@ void Connection::sendToDevice(const QString& targetUserId,
 
 bool Connection::isVerifiedSession(const QByteArray& megolmSessionId) const
 {
-    auto query = database()->prepareQuery("SELECT olmSessionId FROM inbound_megolm_sessions WHERE sessionId=:sessionId;"_ls);
-    query.bindValue(":sessionId"_ls, megolmSessionId);
+    auto query = database()->prepareQuery("SELECT olmSessionId FROM inbound_megolm_sessions WHERE sessionId=:sessionId;"_L1);
+    query.bindValue(":sessionId"_L1, megolmSessionId);
     database()->execute(query);
     if (!query.next()) {
         return false;
     }
-    const auto olmSessionId = query.value("olmSessionId"_ls).toString();
-    if (olmSessionId == "BACKUP_VERIFIED"_ls) {
+    const auto olmSessionId = query.value("olmSessionId"_L1).toString();
+    if (olmSessionId == "BACKUP_VERIFIED"_L1) {
         return true;
     }
-    if (olmSessionId == "SELF"_ls) {
+    if (olmSessionId == "SELF"_L1) {
         return true;
     }
-    query.prepare("SELECT senderKey FROM olm_sessions WHERE sessionId=:sessionId;"_ls);
-    query.bindValue(":sessionId"_ls, olmSessionId.toLatin1());
+    query.prepare("SELECT senderKey FROM olm_sessions WHERE sessionId=:sessionId;"_L1);
+    query.bindValue(":sessionId"_L1, olmSessionId.toLatin1());
     database()->execute(query);
     if (!query.next()) {
         return false;
     }
-    const auto curveKey = query.value("senderKey"_ls).toString();
+    const auto curveKey = query.value("senderKey"_L1).toString();
 
-    query.prepare("SELECT matrixId, selfVerified, verified FROM tracked_devices WHERE curveKey=:curveKey;"_ls);
-    query.bindValue(":curveKey"_ls, curveKey);
+    query.prepare("SELECT matrixId, selfVerified, verified FROM tracked_devices WHERE curveKey=:curveKey;"_L1);
+    query.bindValue(":curveKey"_L1, curveKey);
     database()->execute(query);
     if (!query.next()) {
         return false;
     }
-    const auto userId = query.value("matrixId"_ls).toString();
-    return query.value("verified"_ls).toBool() || (isUserVerified(userId) && query.value("selfVerified"_ls).toBool());
+    const auto userId = query.value("matrixId"_L1).toString();
+    return query.value("verified"_L1).toBool() || (isUserVerified(userId) && query.value("selfVerified"_L1).toBool());
 }
 
 QString Connection::masterKeyForUser(const QString& userId) const
 {
-    auto query = database()->prepareQuery("SELECT key FROM master_keys WHERE userId=:userId"_ls);
-    query.bindValue(":userId"_ls, userId);
+    auto query = database()->prepareQuery("SELECT key FROM master_keys WHERE userId=:userId"_L1);
+    query.bindValue(":userId"_L1, userId);
     database()->execute(query);
-    return query.next() ? query.value("key"_ls).toString() : QString();
+    return query.next() ? query.value("key"_L1).toString() : QString();
 }
 
 bool Connection::isUserVerified(const QString& userId) const
 {
-    auto query = database()->prepareQuery("SELECT verified FROM master_keys WHERE userId=:userId"_ls);
-    query.bindValue(":userId"_ls, userId);
+    auto query = database()->prepareQuery("SELECT verified FROM master_keys WHERE userId=:userId"_L1);
+    query.bindValue(":userId"_L1, userId);
     database()->execute(query);
-    return query.next() && query.value("verified"_ls).toBool();
+    return query.next() && query.value("verified"_L1).toBool();
 }
 
 bool Connection::isVerifiedDevice(const QString& userId, const QString& deviceId) const
 {
-    auto query = database()->prepareQuery("SELECT verified, selfVerified FROM tracked_devices WHERE deviceId=:deviceId AND matrixId=:matrixId;"_ls);
-    query.bindValue(":deviceId"_ls, deviceId);
-    query.bindValue(":matrixId"_ls, userId);
+    auto query = database()->prepareQuery("SELECT verified, selfVerified FROM tracked_devices WHERE deviceId=:deviceId AND matrixId=:matrixId;"_L1);
+    query.bindValue(":deviceId"_L1, deviceId);
+    query.bindValue(":matrixId"_L1, userId);
     database()->execute(query);
     if (!query.next()) {
         return false;
     }
-    return query.value("verified"_ls).toBool() || (isUserVerified(userId) && query.value("selfVerified"_ls).toBool());
+    return query.value("verified"_L1).toBool() || (isUserVerified(userId) && query.value("selfVerified"_L1).toBool());
 }
 
 bool Connection::isKnownE2eeCapableDevice(const QString& userId, const QString& deviceId) const
 {
-    auto query = database()->prepareQuery("SELECT verified FROM tracked_devices WHERE deviceId=:deviceId AND matrixId=:matrixId;"_ls);
-    query.bindValue(":deviceId"_ls, deviceId);
-    query.bindValue(":matrixId"_ls, userId);
+    auto query = database()->prepareQuery("SELECT verified FROM tracked_devices WHERE deviceId=:deviceId AND matrixId=:matrixId;"_L1);
+    query.bindValue(":deviceId"_L1, deviceId);
+    query.bindValue(":matrixId"_L1, userId);
     database()->execute(query);
     return query.next();
 }
@@ -1937,12 +1936,12 @@ QStringList Connection::accountDataEventTypes() const
 
 void Connection::startSelfVerification()
 {
-    auto query = database()->prepareQuery("SELECT deviceId FROM tracked_devices WHERE matrixId=:matrixId AND selfVerified=1;"_ls);
-    query.bindValue(":matrixId"_ls, userId());
+    auto query = database()->prepareQuery("SELECT deviceId FROM tracked_devices WHERE matrixId=:matrixId AND selfVerified=1;"_L1);
+    query.bindValue(":matrixId"_L1, userId());
     database()->execute(query);
     QStringList devices;
     while(query.next()) {
-        auto id = query.value("deviceId"_ls).toString();
+        auto id = query.value("deviceId"_L1).toString();
         if (id != deviceId()) {
             devices += id;
         }
@@ -1965,8 +1964,8 @@ void Connection::startSelfVerification()
 
 bool Connection::allSessionsSelfVerified(const QString& userId) const
 {
-    auto query = database()->prepareQuery("SELECT deviceId FROM tracked_devices WHERE matrixId=:matrixId AND selfVerified=0;"_ls);
-    query.bindValue(":matrixId"_ls, userId);
+    auto query = database()->prepareQuery("SELECT deviceId FROM tracked_devices WHERE matrixId=:matrixId AND selfVerified=0;"_L1);
+    query.bindValue(":matrixId"_L1, userId);
     database()->execute(query);
     return !query.next();
 }

--- a/Quotient/connection.h
+++ b/Quotient/connection.h
@@ -61,9 +61,9 @@ using LoginFlow = GetLoginFlowsJob::LoginFlow;
 
 //! Predefined login flows
 namespace LoginFlows {
-    inline const LoginFlow Password { "m.login.password"_ls };
-    inline const LoginFlow SSO { "m.login.sso"_ls };
-    inline const LoginFlow Token { "m.login.token"_ls };
+    inline const LoginFlow Password { "m.login.password"_L1 };
+    inline const LoginFlow SSO { "m.login.sso"_L1 };
+    inline const LoginFlow Token { "m.login.token"_L1 };
 }
 
 // To simplify comparisons of LoginFlows

--- a/Quotient/connection.h
+++ b/Quotient/connection.h
@@ -389,7 +389,7 @@ public:
         QString id;
         QString status;
 
-        static const QString StableTag; // "stable", as of CS API 0.5
+        static constexpr QStringView StableTag = u"stable";
         bool isStable() const { return status == StableTag; }
 
         friend QDebug operator<<(QDebug dbg, const SupportedRoomVersion& v)

--- a/Quotient/connection_p.h
+++ b/Quotient/connection_p.h
@@ -71,9 +71,9 @@ public:
 
     bool cacheState = true;
     bool cacheToBinary =
-        SettingsGroup("libQuotient"_ls).get("cache_type"_ls,
-                                            SettingsGroup("libQMatrixClient"_ls).get<QString>("cache_type"_ls))
-        != "json"_ls;
+        SettingsGroup("libQuotient"_L1).get("cache_type"_L1,
+                                            SettingsGroup("libQMatrixClient"_L1).get<QString>("cache_type"_L1))
+        != "json"_L1;
     bool lazyLoading = false;
 
     //! \brief Check the homeserver and resolve it if needed, before connecting
@@ -118,7 +118,7 @@ public:
     }
     QString topLevelStatePath() const
     {
-        return q->stateCacheDir().filePath("state.json"_ls);
+        return q->stateCacheDir().filePath("state.json"_L1);
     }
 
     void saveAccessTokenToKeychain() const;

--- a/Quotient/connectionencryptiondata_p.cpp
+++ b/Quotient/connectionencryptiondata_p.cpp
@@ -135,40 +135,37 @@ QFuture<bool> ConnectionEncryptionData::setup(Connection* connection, bool mock,
 void ConnectionEncryptionData::saveDevicesList()
 {
     database.transaction();
-    auto query =
-        database.prepareQuery(QStringLiteral("DELETE FROM tracked_users"));
+    auto query = database.prepareQuery(u"DELETE FROM tracked_users"_s);
     database.execute(query);
-    query.prepare(QStringLiteral(
-        "INSERT INTO tracked_users(matrixId) VALUES(:matrixId);"));
+    query.prepare(u"INSERT INTO tracked_users(matrixId) VALUES(:matrixId);"_s);
     for (const auto& user : trackedUsers) {
-        query.bindValue(":matrixId"_L1, user);
+        query.bindValue(u":matrixId"_s, user);
         database.execute(query);
     }
 
-    query.prepare(QStringLiteral("DELETE FROM outdated_users"));
+    query.prepare(u"DELETE FROM outdated_users"_s);
     database.execute(query);
-    query.prepare(QStringLiteral(
-        "INSERT INTO outdated_users(matrixId) VALUES(:matrixId);"));
+    query.prepare(u"INSERT INTO outdated_users(matrixId) VALUES(:matrixId);"_s);
     for (const auto& user : outdatedUsers) {
-        query.bindValue(":matrixId"_L1, user);
+        query.bindValue(u":matrixId"_s, user);
         database.execute(query);
     }
 
-    query.prepare(QStringLiteral(
-        "INSERT INTO tracked_devices"
+    query.prepare(
+        u"INSERT INTO tracked_devices"
         "(matrixId, deviceId, curveKeyId, curveKey, edKeyId, edKey, verified, selfVerified) "
-        "VALUES (:matrixId, :deviceId, :curveKeyId, :curveKey, :edKeyId, :edKey, :verified, :selfVerified);"));
+        "VALUES (:matrixId, :deviceId, :curveKeyId, :curveKey, :edKeyId, :edKey, :verified, :selfVerified);"_s);
     for (const auto& [user, devices] : deviceKeys.asKeyValueRange()) {
-        auto deleteQuery = database.prepareQuery(
-            QStringLiteral("DELETE FROM tracked_devices WHERE matrixId=:matrixId;"));
-        deleteQuery.bindValue(":matrixId"_L1, user);
+        auto deleteQuery =
+            database.prepareQuery(u"DELETE FROM tracked_devices WHERE matrixId=:matrixId;"_s);
+        deleteQuery.bindValue(u":matrixId"_s, user);
         database.execute(deleteQuery);
         for (const auto& device : devices) {
             const auto keys = device.keys.asKeyValueRange();
             deleteQuery.prepare(
-                "DELETE FROM tracked_devices WHERE matrixId=:matrixId AND deviceId=:deviceId;"_L1);
-            deleteQuery.bindValue(":matrixId"_L1, user);
-            deleteQuery.bindValue(":deviceId"_L1, device.deviceId);
+                u"DELETE FROM tracked_devices WHERE matrixId=:matrixId AND deviceId=:deviceId;"_s);
+            deleteQuery.bindValue(u":matrixId"_s, user);
+            deleteQuery.bindValue(u":deviceId"_s, device.deviceId);
             database.execute(deleteQuery);
 
             const auto curveKeyIt = std::ranges::find_if(keys, [](const auto& p) {
@@ -180,15 +177,15 @@ void ConnectionEncryptionData::saveDevicesList()
             });
             Q_ASSERT(edKeyIt != keys.end());
 
-            query.bindValue(":matrixId"_L1, user);
-            query.bindValue(":deviceId"_L1, device.deviceId);
-            query.bindValue(":curveKeyId"_L1, curveKeyIt->first);
-            query.bindValue(":curveKey"_L1, curveKeyIt->second);
-            query.bindValue(":edKeyId"_L1, edKeyIt->first);
-            query.bindValue(":edKey"_L1, edKeyIt->second);
+            query.bindValue(u":matrixId"_s, user);
+            query.bindValue(u":deviceId"_s, device.deviceId);
+            query.bindValue(u":curveKeyId"_s, curveKeyIt->first);
+            query.bindValue(u":curveKey"_s, curveKeyIt->second);
+            query.bindValue(u":edKeyId"_s, edKeyIt->first);
+            query.bindValue(u":edKey"_s, edKeyIt->second);
             // If the device gets saved here, it can't be verified
-            query.bindValue(":verified"_L1, verifiedDevices[user][device.deviceId]);
-            query.bindValue(":selfVerified"_L1, selfVerifiedDevices[user][device.deviceId]);
+            query.bindValue(u":verified"_s, verifiedDevices[user][device.deviceId]);
+            query.bindValue(u":selfVerified"_s, selfVerifiedDevices[user][device.deviceId]);
 
             database.execute(query);
         }

--- a/Quotient/csapi/account-data.cpp
+++ b/Quotient/csapi/account-data.cpp
@@ -6,7 +6,7 @@ using namespace Quotient;
 
 SetAccountDataJob::SetAccountDataJob(const QString& userId, const QString& type,
                                      const QJsonObject& content)
-    : BaseJob(HttpVerb::Put, QStringLiteral("SetAccountDataJob"),
+    : BaseJob(HttpVerb::Put, u"SetAccountDataJob"_s,
               makePath("/_matrix/client/v3", "/user/", userId, "/account_data/", type))
 {
     setRequestData({ toJson(content) });
@@ -20,13 +20,13 @@ QUrl GetAccountDataJob::makeRequestUrl(const HomeserverData& hsData, const QStri
 }
 
 GetAccountDataJob::GetAccountDataJob(const QString& userId, const QString& type)
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetAccountDataJob"),
+    : BaseJob(HttpVerb::Get, u"GetAccountDataJob"_s,
               makePath("/_matrix/client/v3", "/user/", userId, "/account_data/", type))
 {}
 
 SetAccountDataPerRoomJob::SetAccountDataPerRoomJob(const QString& userId, const QString& roomId,
                                                    const QString& type, const QJsonObject& content)
-    : BaseJob(HttpVerb::Put, QStringLiteral("SetAccountDataPerRoomJob"),
+    : BaseJob(HttpVerb::Put, u"SetAccountDataPerRoomJob"_s,
               makePath("/_matrix/client/v3", "/user/", userId, "/rooms/", roomId, "/account_data/",
                        type))
 {
@@ -42,7 +42,7 @@ QUrl GetAccountDataPerRoomJob::makeRequestUrl(const HomeserverData& hsData, cons
 
 GetAccountDataPerRoomJob::GetAccountDataPerRoomJob(const QString& userId, const QString& roomId,
                                                    const QString& type)
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetAccountDataPerRoomJob"),
+    : BaseJob(HttpVerb::Get, u"GetAccountDataPerRoomJob"_s,
               makePath("/_matrix/client/v3", "/user/", userId, "/rooms/", roomId, "/account_data/",
                        type))
 {}

--- a/Quotient/csapi/admin.cpp
+++ b/Quotient/csapi/admin.cpp
@@ -10,6 +10,6 @@ QUrl GetWhoIsJob::makeRequestUrl(const HomeserverData& hsData, const QString& us
 }
 
 GetWhoIsJob::GetWhoIsJob(const QString& userId)
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetWhoIsJob"),
+    : BaseJob(HttpVerb::Get, u"GetWhoIsJob"_s,
               makePath("/_matrix/client/v3", "/admin/whois/", userId))
 {}

--- a/Quotient/csapi/admin.h
+++ b/Quotient/csapi/admin.h
@@ -53,12 +53,12 @@ public:
     // Result properties
 
     //! The Matrix user ID of the user.
-    QString userId() const { return loadFromJson<QString>("user_id"_ls); }
+    QString userId() const { return loadFromJson<QString>("user_id"_L1); }
 
     //! Each key is an identifier for one of the user's devices.
     QHash<QString, DeviceInfo> devices() const
     {
-        return loadFromJson<QHash<QString, DeviceInfo>>("devices"_ls);
+        return loadFromJson<QHash<QString, DeviceInfo>>("devices"_L1);
     }
 
     struct Response {
@@ -78,9 +78,9 @@ template <>
 struct QUOTIENT_API JsonObjectConverter<GetWhoIsJob::ConnectionInfo> {
     static void fillFrom(const QJsonObject& jo, GetWhoIsJob::ConnectionInfo& result)
     {
-        fillFromJson(jo.value("ip"_ls), result.ip);
-        fillFromJson(jo.value("last_seen"_ls), result.lastSeen);
-        fillFromJson(jo.value("user_agent"_ls), result.userAgent);
+        fillFromJson(jo.value("ip"_L1), result.ip);
+        fillFromJson(jo.value("last_seen"_L1), result.lastSeen);
+        fillFromJson(jo.value("user_agent"_L1), result.userAgent);
     }
 };
 
@@ -88,7 +88,7 @@ template <>
 struct QUOTIENT_API JsonObjectConverter<GetWhoIsJob::SessionInfo> {
     static void fillFrom(const QJsonObject& jo, GetWhoIsJob::SessionInfo& result)
     {
-        fillFromJson(jo.value("connections"_ls), result.connections);
+        fillFromJson(jo.value("connections"_L1), result.connections);
     }
 };
 
@@ -96,7 +96,7 @@ template <>
 struct QUOTIENT_API JsonObjectConverter<GetWhoIsJob::DeviceInfo> {
     static void fillFrom(const QJsonObject& jo, GetWhoIsJob::DeviceInfo& result)
     {
-        fillFromJson(jo.value("sessions"_ls), result.sessions);
+        fillFromJson(jo.value("sessions"_L1), result.sessions);
     }
 };
 

--- a/Quotient/csapi/administrative_contact.cpp
+++ b/Quotient/csapi/administrative_contact.cpp
@@ -10,79 +10,76 @@ QUrl GetAccount3PIDsJob::makeRequestUrl(const HomeserverData& hsData)
 }
 
 GetAccount3PIDsJob::GetAccount3PIDsJob()
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetAccount3PIDsJob"),
+    : BaseJob(HttpVerb::Get, u"GetAccount3PIDsJob"_s,
               makePath("/_matrix/client/v3", "/account/3pid"))
 {}
 
 Post3PIDsJob::Post3PIDsJob(const ThreePidCredentials& threePidCreds)
-    : BaseJob(HttpVerb::Post, QStringLiteral("Post3PIDsJob"),
-              makePath("/_matrix/client/v3", "/account/3pid"))
+    : BaseJob(HttpVerb::Post, u"Post3PIDsJob"_s, makePath("/_matrix/client/v3", "/account/3pid"))
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, QStringLiteral("three_pid_creds"), threePidCreds);
+    addParam<>(_dataJson, "three_pid_creds"_L1, threePidCreds);
     setRequestData({ _dataJson });
 }
 
 Add3PIDJob::Add3PIDJob(const QString& clientSecret, const QString& sid,
                        const std::optional<AuthenticationData>& auth)
-    : BaseJob(HttpVerb::Post, QStringLiteral("Add3PIDJob"),
-              makePath("/_matrix/client/v3", "/account/3pid/add"))
+    : BaseJob(HttpVerb::Post, u"Add3PIDJob"_s, makePath("/_matrix/client/v3", "/account/3pid/add"))
 {
     QJsonObject _dataJson;
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("auth"), auth);
-    addParam<>(_dataJson, QStringLiteral("client_secret"), clientSecret);
-    addParam<>(_dataJson, QStringLiteral("sid"), sid);
+    addParam<IfNotEmpty>(_dataJson, "auth"_L1, auth);
+    addParam<>(_dataJson, "client_secret"_L1, clientSecret);
+    addParam<>(_dataJson, "sid"_L1, sid);
     setRequestData({ _dataJson });
 }
 
 Bind3PIDJob::Bind3PIDJob(const QString& clientSecret, const QString& idServer,
                          const QString& idAccessToken, const QString& sid)
-    : BaseJob(HttpVerb::Post, QStringLiteral("Bind3PIDJob"),
-              makePath("/_matrix/client/v3", "/account/3pid/bind"))
+    : BaseJob(HttpVerb::Post, u"Bind3PIDJob"_s, makePath("/_matrix/client/v3", "/account/3pid/bind"))
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, QStringLiteral("client_secret"), clientSecret);
-    addParam<>(_dataJson, QStringLiteral("id_server"), idServer);
-    addParam<>(_dataJson, QStringLiteral("id_access_token"), idAccessToken);
-    addParam<>(_dataJson, QStringLiteral("sid"), sid);
+    addParam<>(_dataJson, "client_secret"_L1, clientSecret);
+    addParam<>(_dataJson, "id_server"_L1, idServer);
+    addParam<>(_dataJson, "id_access_token"_L1, idAccessToken);
+    addParam<>(_dataJson, "sid"_L1, sid);
     setRequestData({ _dataJson });
 }
 
 Delete3pidFromAccountJob::Delete3pidFromAccountJob(const QString& medium, const QString& address,
                                                    const QString& idServer)
-    : BaseJob(HttpVerb::Post, QStringLiteral("Delete3pidFromAccountJob"),
+    : BaseJob(HttpVerb::Post, u"Delete3pidFromAccountJob"_s,
               makePath("/_matrix/client/v3", "/account/3pid/delete"))
 {
     QJsonObject _dataJson;
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("id_server"), idServer);
-    addParam<>(_dataJson, QStringLiteral("medium"), medium);
-    addParam<>(_dataJson, QStringLiteral("address"), address);
+    addParam<IfNotEmpty>(_dataJson, "id_server"_L1, idServer);
+    addParam<>(_dataJson, "medium"_L1, medium);
+    addParam<>(_dataJson, "address"_L1, address);
     setRequestData({ _dataJson });
     addExpectedKey("id_server_unbind_result");
 }
 
 Unbind3pidFromAccountJob::Unbind3pidFromAccountJob(const QString& medium, const QString& address,
                                                    const QString& idServer)
-    : BaseJob(HttpVerb::Post, QStringLiteral("Unbind3pidFromAccountJob"),
+    : BaseJob(HttpVerb::Post, u"Unbind3pidFromAccountJob"_s,
               makePath("/_matrix/client/v3", "/account/3pid/unbind"))
 {
     QJsonObject _dataJson;
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("id_server"), idServer);
-    addParam<>(_dataJson, QStringLiteral("medium"), medium);
-    addParam<>(_dataJson, QStringLiteral("address"), address);
+    addParam<IfNotEmpty>(_dataJson, "id_server"_L1, idServer);
+    addParam<>(_dataJson, "medium"_L1, medium);
+    addParam<>(_dataJson, "address"_L1, address);
     setRequestData({ _dataJson });
     addExpectedKey("id_server_unbind_result");
 }
 
 RequestTokenTo3PIDEmailJob::RequestTokenTo3PIDEmailJob(const EmailValidationData& data)
-    : BaseJob(HttpVerb::Post, QStringLiteral("RequestTokenTo3PIDEmailJob"),
+    : BaseJob(HttpVerb::Post, u"RequestTokenTo3PIDEmailJob"_s,
               makePath("/_matrix/client/v3", "/account/3pid/email/requestToken"), false)
 {
     setRequestData({ toJson(data) });
 }
 
 RequestTokenTo3PIDMSISDNJob::RequestTokenTo3PIDMSISDNJob(const MsisdnValidationData& data)
-    : BaseJob(HttpVerb::Post, QStringLiteral("RequestTokenTo3PIDMSISDNJob"),
+    : BaseJob(HttpVerb::Post, u"RequestTokenTo3PIDMSISDNJob"_s,
               makePath("/_matrix/client/v3", "/account/3pid/msisdn/requestToken"), false)
 {
     setRequestData({ toJson(data) });

--- a/Quotient/csapi/administrative_contact.h
+++ b/Quotient/csapi/administrative_contact.h
@@ -55,7 +55,7 @@ public:
 
     QVector<ThirdPartyIdentifier> threepids() const
     {
-        return loadFromJson<QVector<ThirdPartyIdentifier>>("threepids"_ls);
+        return loadFromJson<QVector<ThirdPartyIdentifier>>("threepids"_L1);
     }
 };
 
@@ -65,10 +65,10 @@ template <>
 struct QUOTIENT_API JsonObjectConverter<GetAccount3PIDsJob::ThirdPartyIdentifier> {
     static void fillFrom(const QJsonObject& jo, GetAccount3PIDsJob::ThirdPartyIdentifier& result)
     {
-        fillFromJson(jo.value("medium"_ls), result.medium);
-        fillFromJson(jo.value("address"_ls), result.address);
-        fillFromJson(jo.value("validated_at"_ls), result.validatedAt);
-        fillFromJson(jo.value("added_at"_ls), result.addedAt);
+        fillFromJson(jo.value("medium"_L1), result.medium);
+        fillFromJson(jo.value("address"_L1), result.address);
+        fillFromJson(jo.value("validated_at"_L1), result.validatedAt);
+        fillFromJson(jo.value("added_at"_L1), result.addedAt);
     }
 };
 
@@ -126,7 +126,7 @@ public:
     //! verification will happen without the client's involvement
     //! provided the homeserver advertises this specification version
     //! in the `/versions` response (ie: r0.5.0).
-    QUrl submitUrl() const { return loadFromJson<QUrl>("submit_url"_ls); }
+    QUrl submitUrl() const { return loadFromJson<QUrl>("submit_url"_L1); }
 };
 
 QT_WARNING_PUSH
@@ -140,10 +140,10 @@ template <>
 struct QUOTIENT_API JsonObjectConverter<Post3PIDsJob::ThreePidCredentials> {
     static void dumpTo(QJsonObject& jo, const Post3PIDsJob::ThreePidCredentials& pod)
     {
-        addParam<>(jo, QStringLiteral("client_secret"), pod.clientSecret);
-        addParam<>(jo, QStringLiteral("id_server"), pod.idServer);
-        addParam<>(jo, QStringLiteral("id_access_token"), pod.idAccessToken);
-        addParam<>(jo, QStringLiteral("sid"), pod.sid);
+        addParam<>(jo, "client_secret"_L1, pod.clientSecret);
+        addParam<>(jo, "id_server"_L1, pod.idServer);
+        addParam<>(jo, "id_access_token"_L1, pod.idAccessToken);
+        addParam<>(jo, "sid"_L1, pod.sid);
     }
 };
 QT_WARNING_POP
@@ -233,7 +233,7 @@ public:
     //! unbind from.
     QString idServerUnbindResult() const
     {
-        return loadFromJson<QString>("id_server_unbind_result"_ls);
+        return loadFromJson<QString>("id_server_unbind_result"_L1);
     }
 };
 
@@ -275,7 +275,7 @@ public:
     //! an identity server to unbind from.
     QString idServerUnbindResult() const
     {
-        return loadFromJson<QString>("id_server_unbind_result"_ls);
+        return loadFromJson<QString>("id_server_unbind_result"_L1);
     }
 };
 

--- a/Quotient/csapi/appservice_room_directory.cpp
+++ b/Quotient/csapi/appservice_room_directory.cpp
@@ -6,11 +6,11 @@ using namespace Quotient;
 
 UpdateAppserviceRoomDirectoryVisibilityJob::UpdateAppserviceRoomDirectoryVisibilityJob(
     const QString& networkId, const QString& roomId, const QString& visibility)
-    : BaseJob(HttpVerb::Put, QStringLiteral("UpdateAppserviceRoomDirectoryVisibilityJob"),
+    : BaseJob(HttpVerb::Put, u"UpdateAppserviceRoomDirectoryVisibilityJob"_s,
               makePath("/_matrix/client/v3", "/directory/list/appservice/", networkId, "/", roomId),
               false)
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, QStringLiteral("visibility"), visibility);
+    addParam<>(_dataJson, "visibility"_L1, visibility);
     setRequestData({ _dataJson });
 }

--- a/Quotient/csapi/authed-content-repo.cpp
+++ b/Quotient/csapi/authed-content-repo.cpp
@@ -7,7 +7,7 @@ using namespace Quotient;
 auto queryToGetContentAuthed(qint64 timeoutMs)
 {
     QUrlQuery _q;
-    addParam<IfNotEmpty>(_q, QStringLiteral("timeout_ms"), timeoutMs);
+    addParam<IfNotEmpty>(_q, u"timeout_ms"_s, timeoutMs);
     return _q;
 }
 
@@ -22,7 +22,7 @@ QUrl GetContentAuthedJob::makeRequestUrl(const HomeserverData& hsData, const QSt
 
 GetContentAuthedJob::GetContentAuthedJob(const QString& serverName, const QString& mediaId,
                                          qint64 timeoutMs)
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetContentAuthedJob"),
+    : BaseJob(HttpVerb::Get, u"GetContentAuthedJob"_s,
               makePath("/_matrix/client/v1", "/media/download/", serverName, "/", mediaId),
               queryToGetContentAuthed(timeoutMs))
 {
@@ -32,7 +32,7 @@ GetContentAuthedJob::GetContentAuthedJob(const QString& serverName, const QStrin
 auto queryToGetContentOverrideNameAuthed(qint64 timeoutMs)
 {
     QUrlQuery _q;
-    addParam<IfNotEmpty>(_q, QStringLiteral("timeout_ms"), timeoutMs);
+    addParam<IfNotEmpty>(_q, u"timeout_ms"_s, timeoutMs);
     return _q;
 }
 
@@ -51,7 +51,7 @@ GetContentOverrideNameAuthedJob::GetContentOverrideNameAuthedJob(const QString& 
                                                                  const QString& mediaId,
                                                                  const QString& fileName,
                                                                  qint64 timeoutMs)
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetContentOverrideNameAuthedJob"),
+    : BaseJob(HttpVerb::Get, u"GetContentOverrideNameAuthedJob"_s,
               makePath("/_matrix/client/v1", "/media/download/", serverName, "/", mediaId, "/",
                        fileName),
               queryToGetContentOverrideNameAuthed(timeoutMs))
@@ -63,11 +63,11 @@ auto queryToGetContentThumbnailAuthed(int width, int height, const QString& meth
                                       qint64 timeoutMs, std::optional<bool> animated)
 {
     QUrlQuery _q;
-    addParam<>(_q, QStringLiteral("width"), width);
-    addParam<>(_q, QStringLiteral("height"), height);
-    addParam<IfNotEmpty>(_q, QStringLiteral("method"), method);
-    addParam<IfNotEmpty>(_q, QStringLiteral("timeout_ms"), timeoutMs);
-    addParam<IfNotEmpty>(_q, QStringLiteral("animated"), animated);
+    addParam<>(_q, u"width"_s, width);
+    addParam<>(_q, u"height"_s, height);
+    addParam<IfNotEmpty>(_q, u"method"_s, method);
+    addParam<IfNotEmpty>(_q, u"timeout_ms"_s, timeoutMs);
+    addParam<IfNotEmpty>(_q, u"animated"_s, animated);
     return _q;
 }
 
@@ -86,7 +86,7 @@ GetContentThumbnailAuthedJob::GetContentThumbnailAuthedJob(const QString& server
                                                            int height, const QString& method,
                                                            qint64 timeoutMs,
                                                            std::optional<bool> animated)
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetContentThumbnailAuthedJob"),
+    : BaseJob(HttpVerb::Get, u"GetContentThumbnailAuthedJob"_s,
               makePath("/_matrix/client/v1", "/media/thumbnail/", serverName, "/", mediaId),
               queryToGetContentThumbnailAuthed(width, height, method, timeoutMs, animated))
 {
@@ -96,8 +96,8 @@ GetContentThumbnailAuthedJob::GetContentThumbnailAuthedJob(const QString& server
 auto queryToGetUrlPreviewAuthed(const QUrl& url, std::optional<qint64> ts)
 {
     QUrlQuery _q;
-    addParam<>(_q, QStringLiteral("url"), url);
-    addParam<IfNotEmpty>(_q, QStringLiteral("ts"), ts);
+    addParam<>(_q, u"url"_s, url);
+    addParam<IfNotEmpty>(_q, u"ts"_s, ts);
     return _q;
 }
 
@@ -109,7 +109,7 @@ QUrl GetUrlPreviewAuthedJob::makeRequestUrl(const HomeserverData& hsData, const 
 }
 
 GetUrlPreviewAuthedJob::GetUrlPreviewAuthedJob(const QUrl& url, std::optional<qint64> ts)
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetUrlPreviewAuthedJob"),
+    : BaseJob(HttpVerb::Get, u"GetUrlPreviewAuthedJob"_s,
               makePath("/_matrix/client/v1", "/media/preview_url"),
               queryToGetUrlPreviewAuthed(url, ts))
 {}
@@ -120,6 +120,6 @@ QUrl GetConfigAuthedJob::makeRequestUrl(const HomeserverData& hsData)
 }
 
 GetConfigAuthedJob::GetConfigAuthedJob()
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetConfigAuthedJob"),
+    : BaseJob(HttpVerb::Get, u"GetConfigAuthedJob"_s,
               makePath("/_matrix/client/v1", "/media/config"))
 {}

--- a/Quotient/csapi/authed-content-repo.h
+++ b/Quotient/csapi/authed-content-repo.h
@@ -227,12 +227,12 @@ public:
     //! The byte-size of the image. Omitted if there is no image attached.
     std::optional<qint64> matrixImageSize() const
     {
-        return loadFromJson<std::optional<qint64>>("matrix:image:size"_ls);
+        return loadFromJson<std::optional<qint64>>("matrix:image:size"_L1);
     }
 
     //! An [`mxc://` URI](/client-server-api/#matrix-content-mxc-uris) to the image. Omitted if
     //! there is no image.
-    QUrl ogImage() const { return loadFromJson<QUrl>("og:image"_ls); }
+    QUrl ogImage() const { return loadFromJson<QUrl>("og:image"_L1); }
 
     struct Response {
         //! The byte-size of the image. Omitted if there is no image attached.
@@ -279,7 +279,7 @@ public:
     //! If not listed or null, the size limit should be treated as unknown.
     std::optional<qint64> uploadSize() const
     {
-        return loadFromJson<std::optional<qint64>>("m.upload.size"_ls);
+        return loadFromJson<std::optional<qint64>>("m.upload.size"_L1);
     }
 };
 

--- a/Quotient/csapi/banning.cpp
+++ b/Quotient/csapi/banning.cpp
@@ -5,21 +5,20 @@
 using namespace Quotient;
 
 BanJob::BanJob(const QString& roomId, const QString& userId, const QString& reason)
-    : BaseJob(HttpVerb::Post, QStringLiteral("BanJob"),
-              makePath("/_matrix/client/v3", "/rooms/", roomId, "/ban"))
+    : BaseJob(HttpVerb::Post, u"BanJob"_s, makePath("/_matrix/client/v3", "/rooms/", roomId, "/ban"))
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, QStringLiteral("user_id"), userId);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("reason"), reason);
+    addParam<>(_dataJson, "user_id"_L1, userId);
+    addParam<IfNotEmpty>(_dataJson, "reason"_L1, reason);
     setRequestData({ _dataJson });
 }
 
 UnbanJob::UnbanJob(const QString& roomId, const QString& userId, const QString& reason)
-    : BaseJob(HttpVerb::Post, QStringLiteral("UnbanJob"),
+    : BaseJob(HttpVerb::Post, u"UnbanJob"_s,
               makePath("/_matrix/client/v3", "/rooms/", roomId, "/unban"))
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, QStringLiteral("user_id"), userId);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("reason"), reason);
+    addParam<>(_dataJson, "user_id"_L1, userId);
+    addParam<IfNotEmpty>(_dataJson, "reason"_L1, reason);
     setRequestData({ _dataJson });
 }

--- a/Quotient/csapi/capabilities.cpp
+++ b/Quotient/csapi/capabilities.cpp
@@ -10,7 +10,7 @@ QUrl GetCapabilitiesJob::makeRequestUrl(const HomeserverData& hsData)
 }
 
 GetCapabilitiesJob::GetCapabilitiesJob()
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetCapabilitiesJob"),
+    : BaseJob(HttpVerb::Get, u"GetCapabilitiesJob"_s,
               makePath("/_matrix/client/v3", "/capabilities"))
 {
     addExpectedKey("capabilities");

--- a/Quotient/csapi/capabilities.h
+++ b/Quotient/csapi/capabilities.h
@@ -55,7 +55,7 @@ public:
 
     //! The custom capabilities the server supports, using the
     //! Java package naming convention.
-    Capabilities capabilities() const { return loadFromJson<Capabilities>("capabilities"_ls); }
+    Capabilities capabilities() const { return loadFromJson<Capabilities>("capabilities"_L1); }
 };
 
 inline auto collectResponse(const GetCapabilitiesJob* job) { return job->capabilities(); }
@@ -64,7 +64,7 @@ template <>
 struct QUOTIENT_API JsonObjectConverter<GetCapabilitiesJob::ChangePasswordCapability> {
     static void fillFrom(const QJsonObject& jo, GetCapabilitiesJob::ChangePasswordCapability& result)
     {
-        fillFromJson(jo.value("enabled"_ls), result.enabled);
+        fillFromJson(jo.value("enabled"_L1), result.enabled);
     }
 };
 
@@ -72,8 +72,8 @@ template <>
 struct QUOTIENT_API JsonObjectConverter<GetCapabilitiesJob::RoomVersionsCapability> {
     static void fillFrom(const QJsonObject& jo, GetCapabilitiesJob::RoomVersionsCapability& result)
     {
-        fillFromJson(jo.value("default"_ls), result.defaultVersion);
-        fillFromJson(jo.value("available"_ls), result.available);
+        fillFromJson(jo.value("default"_L1), result.defaultVersion);
+        fillFromJson(jo.value("available"_L1), result.available);
     }
 };
 
@@ -81,8 +81,8 @@ template <>
 struct QUOTIENT_API JsonObjectConverter<GetCapabilitiesJob::Capabilities> {
     static void fillFrom(QJsonObject jo, GetCapabilitiesJob::Capabilities& result)
     {
-        fillFromJson(jo.take("m.change_password"_ls), result.changePassword);
-        fillFromJson(jo.take("m.room_versions"_ls), result.roomVersions);
+        fillFromJson(jo.take("m.change_password"_L1), result.changePassword);
+        fillFromJson(jo.take("m.room_versions"_L1), result.roomVersions);
         fromJson(jo, result.additionalProperties);
     }
 };

--- a/Quotient/csapi/content-repo.cpp
+++ b/Quotient/csapi/content-repo.cpp
@@ -7,14 +7,14 @@ using namespace Quotient;
 auto queryToUploadContent(const QString& filename)
 {
     QUrlQuery _q;
-    addParam<IfNotEmpty>(_q, QStringLiteral("filename"), filename);
+    addParam<IfNotEmpty>(_q, u"filename"_s, filename);
     return _q;
 }
 
 UploadContentJob::UploadContentJob(QIODevice* content, const QString& filename,
                                    const QString& contentType)
-    : BaseJob(HttpVerb::Post, QStringLiteral("UploadContentJob"),
-              makePath("/_matrix", "/media/v3/upload"), queryToUploadContent(filename))
+    : BaseJob(HttpVerb::Post, u"UploadContentJob"_s, makePath("/_matrix", "/media/v3/upload"),
+              queryToUploadContent(filename))
 {
     setRequestHeader("Content-Type", contentType.toLatin1());
     setRequestData({ content });
@@ -24,14 +24,14 @@ UploadContentJob::UploadContentJob(QIODevice* content, const QString& filename,
 auto queryToUploadContentToMXC(const QString& filename)
 {
     QUrlQuery _q;
-    addParam<IfNotEmpty>(_q, QStringLiteral("filename"), filename);
+    addParam<IfNotEmpty>(_q, u"filename"_s, filename);
     return _q;
 }
 
 UploadContentToMXCJob::UploadContentToMXCJob(const QString& serverName, const QString& mediaId,
                                              QIODevice* content, const QString& filename,
                                              const QString& contentType)
-    : BaseJob(HttpVerb::Put, QStringLiteral("UploadContentToMXCJob"),
+    : BaseJob(HttpVerb::Put, u"UploadContentToMXCJob"_s,
               makePath("/_matrix", "/media/v3/upload/", serverName, "/", mediaId),
               queryToUploadContentToMXC(filename))
 {
@@ -45,8 +45,7 @@ QUrl CreateContentJob::makeRequestUrl(const HomeserverData& hsData)
 }
 
 CreateContentJob::CreateContentJob()
-    : BaseJob(HttpVerb::Post, QStringLiteral("CreateContentJob"),
-              makePath("/_matrix", "/media/v1/create"))
+    : BaseJob(HttpVerb::Post, u"CreateContentJob"_s, makePath("/_matrix", "/media/v1/create"))
 {
     addExpectedKey("content_uri");
 }
@@ -54,9 +53,9 @@ CreateContentJob::CreateContentJob()
 auto queryToGetContent(bool allowRemote, qint64 timeoutMs, bool allowRedirect)
 {
     QUrlQuery _q;
-    addParam<IfNotEmpty>(_q, QStringLiteral("allow_remote"), allowRemote);
-    addParam<IfNotEmpty>(_q, QStringLiteral("timeout_ms"), timeoutMs);
-    addParam<IfNotEmpty>(_q, QStringLiteral("allow_redirect"), allowRedirect);
+    addParam<IfNotEmpty>(_q, u"allow_remote"_s, allowRemote);
+    addParam<IfNotEmpty>(_q, u"timeout_ms"_s, timeoutMs);
+    addParam<IfNotEmpty>(_q, u"allow_redirect"_s, allowRedirect);
     return _q;
 }
 
@@ -72,7 +71,7 @@ QUrl GetContentJob::makeRequestUrl(const HomeserverData& hsData, const QString& 
 
 GetContentJob::GetContentJob(const QString& serverName, const QString& mediaId, bool allowRemote,
                              qint64 timeoutMs, bool allowRedirect)
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetContentJob"),
+    : BaseJob(HttpVerb::Get, u"GetContentJob"_s,
               makePath("/_matrix", "/media/v3/download/", serverName, "/", mediaId),
               queryToGetContent(allowRemote, timeoutMs, allowRedirect), {}, false)
 {
@@ -82,9 +81,9 @@ GetContentJob::GetContentJob(const QString& serverName, const QString& mediaId, 
 auto queryToGetContentOverrideName(bool allowRemote, qint64 timeoutMs, bool allowRedirect)
 {
     QUrlQuery _q;
-    addParam<IfNotEmpty>(_q, QStringLiteral("allow_remote"), allowRemote);
-    addParam<IfNotEmpty>(_q, QStringLiteral("timeout_ms"), timeoutMs);
-    addParam<IfNotEmpty>(_q, QStringLiteral("allow_redirect"), allowRedirect);
+    addParam<IfNotEmpty>(_q, u"allow_remote"_s, allowRemote);
+    addParam<IfNotEmpty>(_q, u"timeout_ms"_s, timeoutMs);
+    addParam<IfNotEmpty>(_q, u"allow_redirect"_s, allowRedirect);
     return _q;
 }
 
@@ -102,7 +101,7 @@ GetContentOverrideNameJob::GetContentOverrideNameJob(const QString& serverName,
                                                      const QString& mediaId,
                                                      const QString& fileName, bool allowRemote,
                                                      qint64 timeoutMs, bool allowRedirect)
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetContentOverrideNameJob"),
+    : BaseJob(HttpVerb::Get, u"GetContentOverrideNameJob"_s,
               makePath("/_matrix", "/media/v3/download/", serverName, "/", mediaId, "/", fileName),
               queryToGetContentOverrideName(allowRemote, timeoutMs, allowRedirect), {}, false)
 {
@@ -113,13 +112,13 @@ auto queryToGetContentThumbnail(int width, int height, const QString& method, bo
                                 qint64 timeoutMs, bool allowRedirect, std::optional<bool> animated)
 {
     QUrlQuery _q;
-    addParam<>(_q, QStringLiteral("width"), width);
-    addParam<>(_q, QStringLiteral("height"), height);
-    addParam<IfNotEmpty>(_q, QStringLiteral("method"), method);
-    addParam<IfNotEmpty>(_q, QStringLiteral("allow_remote"), allowRemote);
-    addParam<IfNotEmpty>(_q, QStringLiteral("timeout_ms"), timeoutMs);
-    addParam<IfNotEmpty>(_q, QStringLiteral("allow_redirect"), allowRedirect);
-    addParam<IfNotEmpty>(_q, QStringLiteral("animated"), animated);
+    addParam<>(_q, u"width"_s, width);
+    addParam<>(_q, u"height"_s, height);
+    addParam<IfNotEmpty>(_q, u"method"_s, method);
+    addParam<IfNotEmpty>(_q, u"allow_remote"_s, allowRemote);
+    addParam<IfNotEmpty>(_q, u"timeout_ms"_s, timeoutMs);
+    addParam<IfNotEmpty>(_q, u"allow_redirect"_s, allowRedirect);
+    addParam<IfNotEmpty>(_q, u"animated"_s, animated);
     return _q;
 }
 
@@ -140,7 +139,7 @@ GetContentThumbnailJob::GetContentThumbnailJob(const QString& serverName, const 
                                                int width, int height, const QString& method,
                                                bool allowRemote, qint64 timeoutMs,
                                                bool allowRedirect, std::optional<bool> animated)
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetContentThumbnailJob"),
+    : BaseJob(HttpVerb::Get, u"GetContentThumbnailJob"_s,
               makePath("/_matrix", "/media/v3/thumbnail/", serverName, "/", mediaId),
               queryToGetContentThumbnail(width, height, method, allowRemote, timeoutMs,
                                          allowRedirect, animated),
@@ -152,8 +151,8 @@ GetContentThumbnailJob::GetContentThumbnailJob(const QString& serverName, const 
 auto queryToGetUrlPreview(const QUrl& url, std::optional<qint64> ts)
 {
     QUrlQuery _q;
-    addParam<>(_q, QStringLiteral("url"), url);
-    addParam<IfNotEmpty>(_q, QStringLiteral("ts"), ts);
+    addParam<>(_q, u"url"_s, url);
+    addParam<IfNotEmpty>(_q, u"ts"_s, ts);
     return _q;
 }
 
@@ -165,8 +164,8 @@ QUrl GetUrlPreviewJob::makeRequestUrl(const HomeserverData& hsData, const QUrl& 
 }
 
 GetUrlPreviewJob::GetUrlPreviewJob(const QUrl& url, std::optional<qint64> ts)
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetUrlPreviewJob"),
-              makePath("/_matrix", "/media/v3/preview_url"), queryToGetUrlPreview(url, ts))
+    : BaseJob(HttpVerb::Get, u"GetUrlPreviewJob"_s, makePath("/_matrix", "/media/v3/preview_url"),
+              queryToGetUrlPreview(url, ts))
 {}
 
 QUrl GetConfigJob::makeRequestUrl(const HomeserverData& hsData)
@@ -175,6 +174,5 @@ QUrl GetConfigJob::makeRequestUrl(const HomeserverData& hsData)
 }
 
 GetConfigJob::GetConfigJob()
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetConfigJob"),
-              makePath("/_matrix", "/media/v3/config"))
+    : BaseJob(HttpVerb::Get, u"GetConfigJob"_s, makePath("/_matrix", "/media/v3/config"))
 {}

--- a/Quotient/csapi/content-repo.h
+++ b/Quotient/csapi/content-repo.h
@@ -24,7 +24,7 @@ public:
     // Result properties
 
     //! The [`mxc://` URI](/client-server-api/#matrix-content-mxc-uris) to the uploaded content.
-    QUrl contentUri() const { return loadFromJson<QUrl>("content_uri"_ls); }
+    QUrl contentUri() const { return loadFromJson<QUrl>("content_uri"_L1); }
 };
 
 inline auto collectResponse(const UploadContentJob* job) { return job->contentUri(); }
@@ -88,13 +88,13 @@ public:
 
     //! The [`mxc://` URI](/client-server-api/#matrix-content-mxc-uris) at
     //! which the content will be available, once it is uploaded.
-    QUrl contentUri() const { return loadFromJson<QUrl>("content_uri"_ls); }
+    QUrl contentUri() const { return loadFromJson<QUrl>("content_uri"_L1); }
 
     //! The timestamp (in milliseconds since the unix epoch) when the
     //! generated media id will expire, if media is not uploaded.
     std::optional<qint64> unusedExpiresAt() const
     {
-        return loadFromJson<std::optional<qint64>>("unused_expires_at"_ls);
+        return loadFromJson<std::optional<qint64>>("unused_expires_at"_L1);
     }
 
     struct Response {
@@ -385,12 +385,12 @@ public:
     //! The byte-size of the image. Omitted if there is no image attached.
     std::optional<qint64> matrixImageSize() const
     {
-        return loadFromJson<std::optional<qint64>>("matrix:image:size"_ls);
+        return loadFromJson<std::optional<qint64>>("matrix:image:size"_L1);
     }
 
     //! An [`mxc://` URI](/client-server-api/#matrix-content-mxc-uris) to the image. Omitted if
     //! there is no image.
-    QUrl ogImage() const { return loadFromJson<QUrl>("og:image"_ls); }
+    QUrl ogImage() const { return loadFromJson<QUrl>("og:image"_L1); }
 
     struct Response {
         //! The byte-size of the image. Omitted if there is no image attached.
@@ -443,7 +443,7 @@ public:
     //! If not listed or null, the size limit should be treated as unknown.
     std::optional<qint64> uploadSize() const
     {
-        return loadFromJson<std::optional<qint64>>("m.upload.size"_ls);
+        return loadFromJson<std::optional<qint64>>("m.upload.size"_L1);
     }
 };
 

--- a/Quotient/csapi/create_room.cpp
+++ b/Quotient/csapi/create_room.cpp
@@ -11,23 +11,21 @@ CreateRoomJob::CreateRoomJob(const QString& visibility, const QString& roomAlias
                              const QVector<StateEvent>& initialState, const QString& preset,
                              std::optional<bool> isDirect,
                              const QJsonObject& powerLevelContentOverride)
-    : BaseJob(HttpVerb::Post, QStringLiteral("CreateRoomJob"),
-              makePath("/_matrix/client/v3", "/createRoom"))
+    : BaseJob(HttpVerb::Post, u"CreateRoomJob"_s, makePath("/_matrix/client/v3", "/createRoom"))
 {
     QJsonObject _dataJson;
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("visibility"), visibility);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("room_alias_name"), roomAliasName);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("name"), name);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("topic"), topic);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("invite"), invite);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("invite_3pid"), invite3pid);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("room_version"), roomVersion);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("creation_content"), creationContent);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("initial_state"), initialState);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("preset"), preset);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("is_direct"), isDirect);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("power_level_content_override"),
-                         powerLevelContentOverride);
+    addParam<IfNotEmpty>(_dataJson, "visibility"_L1, visibility);
+    addParam<IfNotEmpty>(_dataJson, "room_alias_name"_L1, roomAliasName);
+    addParam<IfNotEmpty>(_dataJson, "name"_L1, name);
+    addParam<IfNotEmpty>(_dataJson, "topic"_L1, topic);
+    addParam<IfNotEmpty>(_dataJson, "invite"_L1, invite);
+    addParam<IfNotEmpty>(_dataJson, "invite_3pid"_L1, invite3pid);
+    addParam<IfNotEmpty>(_dataJson, "room_version"_L1, roomVersion);
+    addParam<IfNotEmpty>(_dataJson, "creation_content"_L1, creationContent);
+    addParam<IfNotEmpty>(_dataJson, "initial_state"_L1, initialState);
+    addParam<IfNotEmpty>(_dataJson, "preset"_L1, preset);
+    addParam<IfNotEmpty>(_dataJson, "is_direct"_L1, isDirect);
+    addParam<IfNotEmpty>(_dataJson, "power_level_content_override"_L1, powerLevelContentOverride);
     setRequestData({ _dataJson });
     addExpectedKey("room_id");
 }

--- a/Quotient/csapi/create_room.h
+++ b/Quotient/csapi/create_room.h
@@ -177,7 +177,7 @@ public:
     // Result properties
 
     //! The created room's ID.
-    QString roomId() const { return loadFromJson<QString>("room_id"_ls); }
+    QString roomId() const { return loadFromJson<QString>("room_id"_L1); }
 };
 
 inline auto collectResponse(const CreateRoomJob* job) { return job->roomId(); }
@@ -186,10 +186,10 @@ template <>
 struct QUOTIENT_API JsonObjectConverter<CreateRoomJob::Invite3pid> {
     static void dumpTo(QJsonObject& jo, const CreateRoomJob::Invite3pid& pod)
     {
-        addParam<>(jo, QStringLiteral("id_server"), pod.idServer);
-        addParam<>(jo, QStringLiteral("id_access_token"), pod.idAccessToken);
-        addParam<>(jo, QStringLiteral("medium"), pod.medium);
-        addParam<>(jo, QStringLiteral("address"), pod.address);
+        addParam<>(jo, "id_server"_L1, pod.idServer);
+        addParam<>(jo, "id_access_token"_L1, pod.idAccessToken);
+        addParam<>(jo, "medium"_L1, pod.medium);
+        addParam<>(jo, "address"_L1, pod.address);
     }
 };
 
@@ -197,9 +197,9 @@ template <>
 struct QUOTIENT_API JsonObjectConverter<CreateRoomJob::StateEvent> {
     static void dumpTo(QJsonObject& jo, const CreateRoomJob::StateEvent& pod)
     {
-        addParam<>(jo, QStringLiteral("type"), pod.type);
-        addParam<>(jo, QStringLiteral("content"), pod.content);
-        addParam<IfNotEmpty>(jo, QStringLiteral("state_key"), pod.stateKey);
+        addParam<>(jo, "type"_L1, pod.type);
+        addParam<>(jo, "content"_L1, pod.content);
+        addParam<IfNotEmpty>(jo, "state_key"_L1, pod.stateKey);
     }
 };
 

--- a/Quotient/csapi/cross_signing.cpp
+++ b/Quotient/csapi/cross_signing.cpp
@@ -9,20 +9,20 @@ UploadCrossSigningKeysJob::UploadCrossSigningKeysJob(
     const std::optional<CrossSigningKey>& selfSigningKey,
     const std::optional<CrossSigningKey>& userSigningKey,
     const std::optional<AuthenticationData>& auth)
-    : BaseJob(HttpVerb::Post, QStringLiteral("UploadCrossSigningKeysJob"),
+    : BaseJob(HttpVerb::Post, u"UploadCrossSigningKeysJob"_s,
               makePath("/_matrix/client/v3", "/keys/device_signing/upload"))
 {
     QJsonObject _dataJson;
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("master_key"), masterKey);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("self_signing_key"), selfSigningKey);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("user_signing_key"), userSigningKey);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("auth"), auth);
+    addParam<IfNotEmpty>(_dataJson, "master_key"_L1, masterKey);
+    addParam<IfNotEmpty>(_dataJson, "self_signing_key"_L1, selfSigningKey);
+    addParam<IfNotEmpty>(_dataJson, "user_signing_key"_L1, userSigningKey);
+    addParam<IfNotEmpty>(_dataJson, "auth"_L1, auth);
     setRequestData({ _dataJson });
 }
 
 UploadCrossSigningSignaturesJob::UploadCrossSigningSignaturesJob(
     const QHash<UserId, QHash<QString, QJsonObject>>& signatures)
-    : BaseJob(HttpVerb::Post, QStringLiteral("UploadCrossSigningSignaturesJob"),
+    : BaseJob(HttpVerb::Post, u"UploadCrossSigningSignaturesJob"_s,
               makePath("/_matrix/client/v3", "/keys/signatures/upload"))
 {
     setRequestData({ toJson(signatures) });

--- a/Quotient/csapi/cross_signing.h
+++ b/Quotient/csapi/cross_signing.h
@@ -77,7 +77,7 @@ public:
     //! be set to `M_INVALID_SIGNATURE`.
     QHash<UserId, QHash<QString, QJsonObject>> failures() const
     {
-        return loadFromJson<QHash<UserId, QHash<QString, QJsonObject>>>("failures"_ls);
+        return loadFromJson<QHash<UserId, QHash<QString, QJsonObject>>>("failures"_L1);
     }
 };
 

--- a/Quotient/csapi/definitions/auth_data.h
+++ b/Quotient/csapi/definitions/auth_data.h
@@ -25,13 +25,13 @@ struct JsonObjectConverter<AuthenticationData> {
     static void dumpTo(QJsonObject& jo, const AuthenticationData& pod)
     {
         fillJson(jo, pod.authInfo);
-        addParam<IfNotEmpty>(jo, QStringLiteral("type"), pod.type);
-        addParam<IfNotEmpty>(jo, QStringLiteral("session"), pod.session);
+        addParam<IfNotEmpty>(jo, "type"_L1, pod.type);
+        addParam<IfNotEmpty>(jo, "session"_L1, pod.session);
     }
     static void fillFrom(QJsonObject jo, AuthenticationData& pod)
     {
-        fillFromJson(jo.take("type"_ls), pod.type);
-        fillFromJson(jo.take("session"_ls), pod.session);
+        fillFromJson(jo.take("type"_L1), pod.type);
+        fillFromJson(jo.take("session"_L1), pod.session);
         fromJson(jo, pod.authInfo);
     }
 };

--- a/Quotient/csapi/definitions/client_device.h
+++ b/Quotient/csapi/definitions/client_device.h
@@ -28,17 +28,17 @@ template <>
 struct JsonObjectConverter<Device> {
     static void dumpTo(QJsonObject& jo, const Device& pod)
     {
-        addParam<>(jo, QStringLiteral("device_id"), pod.deviceId);
-        addParam<IfNotEmpty>(jo, QStringLiteral("display_name"), pod.displayName);
-        addParam<IfNotEmpty>(jo, QStringLiteral("last_seen_ip"), pod.lastSeenIp);
-        addParam<IfNotEmpty>(jo, QStringLiteral("last_seen_ts"), pod.lastSeenTs);
+        addParam<>(jo, "device_id"_L1, pod.deviceId);
+        addParam<IfNotEmpty>(jo, "display_name"_L1, pod.displayName);
+        addParam<IfNotEmpty>(jo, "last_seen_ip"_L1, pod.lastSeenIp);
+        addParam<IfNotEmpty>(jo, "last_seen_ts"_L1, pod.lastSeenTs);
     }
     static void fillFrom(const QJsonObject& jo, Device& pod)
     {
-        fillFromJson(jo.value("device_id"_ls), pod.deviceId);
-        fillFromJson(jo.value("display_name"_ls), pod.displayName);
-        fillFromJson(jo.value("last_seen_ip"_ls), pod.lastSeenIp);
-        fillFromJson(jo.value("last_seen_ts"_ls), pod.lastSeenTs);
+        fillFromJson(jo.value("device_id"_L1), pod.deviceId);
+        fillFromJson(jo.value("display_name"_L1), pod.displayName);
+        fillFromJson(jo.value("last_seen_ip"_L1), pod.lastSeenIp);
+        fillFromJson(jo.value("last_seen_ts"_L1), pod.lastSeenTs);
     }
 };
 

--- a/Quotient/csapi/definitions/cross_signing_key.h
+++ b/Quotient/csapi/definitions/cross_signing_key.h
@@ -28,17 +28,17 @@ template <>
 struct JsonObjectConverter<CrossSigningKey> {
     static void dumpTo(QJsonObject& jo, const CrossSigningKey& pod)
     {
-        addParam<>(jo, QStringLiteral("user_id"), pod.userId);
-        addParam<>(jo, QStringLiteral("usage"), pod.usage);
-        addParam<>(jo, QStringLiteral("keys"), pod.keys);
-        addParam<IfNotEmpty>(jo, QStringLiteral("signatures"), pod.signatures);
+        addParam<>(jo, "user_id"_L1, pod.userId);
+        addParam<>(jo, "usage"_L1, pod.usage);
+        addParam<>(jo, "keys"_L1, pod.keys);
+        addParam<IfNotEmpty>(jo, "signatures"_L1, pod.signatures);
     }
     static void fillFrom(const QJsonObject& jo, CrossSigningKey& pod)
     {
-        fillFromJson(jo.value("user_id"_ls), pod.userId);
-        fillFromJson(jo.value("usage"_ls), pod.usage);
-        fillFromJson(jo.value("keys"_ls), pod.keys);
-        fillFromJson(jo.value("signatures"_ls), pod.signatures);
+        fillFromJson(jo.value("user_id"_L1), pod.userId);
+        fillFromJson(jo.value("usage"_L1), pod.usage);
+        fillFromJson(jo.value("keys"_L1), pod.keys);
+        fillFromJson(jo.value("signatures"_L1), pod.signatures);
     }
 };
 

--- a/Quotient/csapi/definitions/device_keys.h
+++ b/Quotient/csapi/definitions/device_keys.h
@@ -35,19 +35,19 @@ template <>
 struct JsonObjectConverter<DeviceKeys> {
     static void dumpTo(QJsonObject& jo, const DeviceKeys& pod)
     {
-        addParam<>(jo, QStringLiteral("user_id"), pod.userId);
-        addParam<>(jo, QStringLiteral("device_id"), pod.deviceId);
-        addParam<>(jo, QStringLiteral("algorithms"), pod.algorithms);
-        addParam<>(jo, QStringLiteral("keys"), pod.keys);
-        addParam<>(jo, QStringLiteral("signatures"), pod.signatures);
+        addParam<>(jo, "user_id"_L1, pod.userId);
+        addParam<>(jo, "device_id"_L1, pod.deviceId);
+        addParam<>(jo, "algorithms"_L1, pod.algorithms);
+        addParam<>(jo, "keys"_L1, pod.keys);
+        addParam<>(jo, "signatures"_L1, pod.signatures);
     }
     static void fillFrom(const QJsonObject& jo, DeviceKeys& pod)
     {
-        fillFromJson(jo.value("user_id"_ls), pod.userId);
-        fillFromJson(jo.value("device_id"_ls), pod.deviceId);
-        fillFromJson(jo.value("algorithms"_ls), pod.algorithms);
-        fillFromJson(jo.value("keys"_ls), pod.keys);
-        fillFromJson(jo.value("signatures"_ls), pod.signatures);
+        fillFromJson(jo.value("user_id"_L1), pod.userId);
+        fillFromJson(jo.value("device_id"_L1), pod.deviceId);
+        fillFromJson(jo.value("algorithms"_L1), pod.algorithms);
+        fillFromJson(jo.value("keys"_L1), pod.keys);
+        fillFromJson(jo.value("signatures"_L1), pod.signatures);
     }
 };
 

--- a/Quotient/csapi/definitions/event_filter.h
+++ b/Quotient/csapi/definitions/event_filter.h
@@ -34,19 +34,19 @@ template <>
 struct JsonObjectConverter<EventFilter> {
     static void dumpTo(QJsonObject& jo, const EventFilter& pod)
     {
-        addParam<IfNotEmpty>(jo, QStringLiteral("limit"), pod.limit);
-        addParam<IfNotEmpty>(jo, QStringLiteral("not_senders"), pod.notSenders);
-        addParam<IfNotEmpty>(jo, QStringLiteral("not_types"), pod.notTypes);
-        addParam<IfNotEmpty>(jo, QStringLiteral("senders"), pod.senders);
-        addParam<IfNotEmpty>(jo, QStringLiteral("types"), pod.types);
+        addParam<IfNotEmpty>(jo, "limit"_L1, pod.limit);
+        addParam<IfNotEmpty>(jo, "not_senders"_L1, pod.notSenders);
+        addParam<IfNotEmpty>(jo, "not_types"_L1, pod.notTypes);
+        addParam<IfNotEmpty>(jo, "senders"_L1, pod.senders);
+        addParam<IfNotEmpty>(jo, "types"_L1, pod.types);
     }
     static void fillFrom(const QJsonObject& jo, EventFilter& pod)
     {
-        fillFromJson(jo.value("limit"_ls), pod.limit);
-        fillFromJson(jo.value("not_senders"_ls), pod.notSenders);
-        fillFromJson(jo.value("not_types"_ls), pod.notTypes);
-        fillFromJson(jo.value("senders"_ls), pod.senders);
-        fillFromJson(jo.value("types"_ls), pod.types);
+        fillFromJson(jo.value("limit"_L1), pod.limit);
+        fillFromJson(jo.value("not_senders"_L1), pod.notSenders);
+        fillFromJson(jo.value("not_types"_L1), pod.notTypes);
+        fillFromJson(jo.value("senders"_L1), pod.senders);
+        fillFromJson(jo.value("types"_L1), pod.types);
     }
 };
 

--- a/Quotient/csapi/definitions/key_backup_data.h
+++ b/Quotient/csapi/definitions/key_backup_data.h
@@ -27,17 +27,17 @@ template <>
 struct JsonObjectConverter<KeyBackupData> {
     static void dumpTo(QJsonObject& jo, const KeyBackupData& pod)
     {
-        addParam<>(jo, QStringLiteral("first_message_index"), pod.firstMessageIndex);
-        addParam<>(jo, QStringLiteral("forwarded_count"), pod.forwardedCount);
-        addParam<>(jo, QStringLiteral("is_verified"), pod.isVerified);
-        addParam<>(jo, QStringLiteral("session_data"), pod.sessionData);
+        addParam<>(jo, "first_message_index"_L1, pod.firstMessageIndex);
+        addParam<>(jo, "forwarded_count"_L1, pod.forwardedCount);
+        addParam<>(jo, "is_verified"_L1, pod.isVerified);
+        addParam<>(jo, "session_data"_L1, pod.sessionData);
     }
     static void fillFrom(const QJsonObject& jo, KeyBackupData& pod)
     {
-        fillFromJson(jo.value("first_message_index"_ls), pod.firstMessageIndex);
-        fillFromJson(jo.value("forwarded_count"_ls), pod.forwardedCount);
-        fillFromJson(jo.value("is_verified"_ls), pod.isVerified);
-        fillFromJson(jo.value("session_data"_ls), pod.sessionData);
+        fillFromJson(jo.value("first_message_index"_L1), pod.firstMessageIndex);
+        fillFromJson(jo.value("forwarded_count"_L1), pod.forwardedCount);
+        fillFromJson(jo.value("is_verified"_L1), pod.isVerified);
+        fillFromJson(jo.value("session_data"_L1), pod.sessionData);
     }
 };
 

--- a/Quotient/csapi/definitions/openid_token.h
+++ b/Quotient/csapi/definitions/openid_token.h
@@ -28,17 +28,17 @@ template <>
 struct JsonObjectConverter<OpenIdCredentials> {
     static void dumpTo(QJsonObject& jo, const OpenIdCredentials& pod)
     {
-        addParam<>(jo, QStringLiteral("access_token"), pod.accessToken);
-        addParam<>(jo, QStringLiteral("token_type"), pod.tokenType);
-        addParam<>(jo, QStringLiteral("matrix_server_name"), pod.matrixServerName);
-        addParam<>(jo, QStringLiteral("expires_in"), pod.expiresIn);
+        addParam<>(jo, "access_token"_L1, pod.accessToken);
+        addParam<>(jo, "token_type"_L1, pod.tokenType);
+        addParam<>(jo, "matrix_server_name"_L1, pod.matrixServerName);
+        addParam<>(jo, "expires_in"_L1, pod.expiresIn);
     }
     static void fillFrom(const QJsonObject& jo, OpenIdCredentials& pod)
     {
-        fillFromJson(jo.value("access_token"_ls), pod.accessToken);
-        fillFromJson(jo.value("token_type"_ls), pod.tokenType);
-        fillFromJson(jo.value("matrix_server_name"_ls), pod.matrixServerName);
-        fillFromJson(jo.value("expires_in"_ls), pod.expiresIn);
+        fillFromJson(jo.value("access_token"_L1), pod.accessToken);
+        fillFromJson(jo.value("token_type"_L1), pod.tokenType);
+        fillFromJson(jo.value("matrix_server_name"_L1), pod.matrixServerName);
+        fillFromJson(jo.value("expires_in"_L1), pod.expiresIn);
     }
 };
 

--- a/Quotient/csapi/definitions/public_rooms_response.h
+++ b/Quotient/csapi/definitions/public_rooms_response.h
@@ -47,29 +47,29 @@ template <>
 struct JsonObjectConverter<PublicRoomsChunk> {
     static void dumpTo(QJsonObject& jo, const PublicRoomsChunk& pod)
     {
-        addParam<>(jo, QStringLiteral("num_joined_members"), pod.numJoinedMembers);
-        addParam<>(jo, QStringLiteral("room_id"), pod.roomId);
-        addParam<>(jo, QStringLiteral("world_readable"), pod.worldReadable);
-        addParam<>(jo, QStringLiteral("guest_can_join"), pod.guestCanJoin);
-        addParam<IfNotEmpty>(jo, QStringLiteral("canonical_alias"), pod.canonicalAlias);
-        addParam<IfNotEmpty>(jo, QStringLiteral("name"), pod.name);
-        addParam<IfNotEmpty>(jo, QStringLiteral("topic"), pod.topic);
-        addParam<IfNotEmpty>(jo, QStringLiteral("avatar_url"), pod.avatarUrl);
-        addParam<IfNotEmpty>(jo, QStringLiteral("join_rule"), pod.joinRule);
-        addParam<IfNotEmpty>(jo, QStringLiteral("room_type"), pod.roomType);
+        addParam<>(jo, "num_joined_members"_L1, pod.numJoinedMembers);
+        addParam<>(jo, "room_id"_L1, pod.roomId);
+        addParam<>(jo, "world_readable"_L1, pod.worldReadable);
+        addParam<>(jo, "guest_can_join"_L1, pod.guestCanJoin);
+        addParam<IfNotEmpty>(jo, "canonical_alias"_L1, pod.canonicalAlias);
+        addParam<IfNotEmpty>(jo, "name"_L1, pod.name);
+        addParam<IfNotEmpty>(jo, "topic"_L1, pod.topic);
+        addParam<IfNotEmpty>(jo, "avatar_url"_L1, pod.avatarUrl);
+        addParam<IfNotEmpty>(jo, "join_rule"_L1, pod.joinRule);
+        addParam<IfNotEmpty>(jo, "room_type"_L1, pod.roomType);
     }
     static void fillFrom(const QJsonObject& jo, PublicRoomsChunk& pod)
     {
-        fillFromJson(jo.value("num_joined_members"_ls), pod.numJoinedMembers);
-        fillFromJson(jo.value("room_id"_ls), pod.roomId);
-        fillFromJson(jo.value("world_readable"_ls), pod.worldReadable);
-        fillFromJson(jo.value("guest_can_join"_ls), pod.guestCanJoin);
-        fillFromJson(jo.value("canonical_alias"_ls), pod.canonicalAlias);
-        fillFromJson(jo.value("name"_ls), pod.name);
-        fillFromJson(jo.value("topic"_ls), pod.topic);
-        fillFromJson(jo.value("avatar_url"_ls), pod.avatarUrl);
-        fillFromJson(jo.value("join_rule"_ls), pod.joinRule);
-        fillFromJson(jo.value("room_type"_ls), pod.roomType);
+        fillFromJson(jo.value("num_joined_members"_L1), pod.numJoinedMembers);
+        fillFromJson(jo.value("room_id"_L1), pod.roomId);
+        fillFromJson(jo.value("world_readable"_L1), pod.worldReadable);
+        fillFromJson(jo.value("guest_can_join"_L1), pod.guestCanJoin);
+        fillFromJson(jo.value("canonical_alias"_L1), pod.canonicalAlias);
+        fillFromJson(jo.value("name"_L1), pod.name);
+        fillFromJson(jo.value("topic"_L1), pod.topic);
+        fillFromJson(jo.value("avatar_url"_L1), pod.avatarUrl);
+        fillFromJson(jo.value("join_rule"_L1), pod.joinRule);
+        fillFromJson(jo.value("room_type"_L1), pod.roomType);
     }
 };
 

--- a/Quotient/csapi/definitions/push_condition.h
+++ b/Quotient/csapi/definitions/push_condition.h
@@ -40,19 +40,19 @@ template <>
 struct JsonObjectConverter<PushCondition> {
     static void dumpTo(QJsonObject& jo, const PushCondition& pod)
     {
-        addParam<>(jo, QStringLiteral("kind"), pod.kind);
-        addParam<IfNotEmpty>(jo, QStringLiteral("key"), pod.key);
-        addParam<IfNotEmpty>(jo, QStringLiteral("pattern"), pod.pattern);
-        addParam<IfNotEmpty>(jo, QStringLiteral("is"), pod.is);
-        addParam<IfNotEmpty>(jo, QStringLiteral("value"), pod.value);
+        addParam<>(jo, "kind"_L1, pod.kind);
+        addParam<IfNotEmpty>(jo, "key"_L1, pod.key);
+        addParam<IfNotEmpty>(jo, "pattern"_L1, pod.pattern);
+        addParam<IfNotEmpty>(jo, "is"_L1, pod.is);
+        addParam<IfNotEmpty>(jo, "value"_L1, pod.value);
     }
     static void fillFrom(const QJsonObject& jo, PushCondition& pod)
     {
-        fillFromJson(jo.value("kind"_ls), pod.kind);
-        fillFromJson(jo.value("key"_ls), pod.key);
-        fillFromJson(jo.value("pattern"_ls), pod.pattern);
-        fillFromJson(jo.value("is"_ls), pod.is);
-        fillFromJson(jo.value("value"_ls), pod.value);
+        fillFromJson(jo.value("kind"_L1), pod.kind);
+        fillFromJson(jo.value("key"_L1), pod.key);
+        fillFromJson(jo.value("pattern"_L1), pod.pattern);
+        fillFromJson(jo.value("is"_L1), pod.is);
+        fillFromJson(jo.value("value"_L1), pod.value);
     }
 };
 

--- a/Quotient/csapi/definitions/push_rule.h
+++ b/Quotient/csapi/definitions/push_rule.h
@@ -35,21 +35,21 @@ template <>
 struct JsonObjectConverter<PushRule> {
     static void dumpTo(QJsonObject& jo, const PushRule& pod)
     {
-        addParam<>(jo, QStringLiteral("actions"), pod.actions);
-        addParam<>(jo, QStringLiteral("default"), pod.isDefault);
-        addParam<>(jo, QStringLiteral("enabled"), pod.enabled);
-        addParam<>(jo, QStringLiteral("rule_id"), pod.ruleId);
-        addParam<IfNotEmpty>(jo, QStringLiteral("conditions"), pod.conditions);
-        addParam<IfNotEmpty>(jo, QStringLiteral("pattern"), pod.pattern);
+        addParam<>(jo, "actions"_L1, pod.actions);
+        addParam<>(jo, "default"_L1, pod.isDefault);
+        addParam<>(jo, "enabled"_L1, pod.enabled);
+        addParam<>(jo, "rule_id"_L1, pod.ruleId);
+        addParam<IfNotEmpty>(jo, "conditions"_L1, pod.conditions);
+        addParam<IfNotEmpty>(jo, "pattern"_L1, pod.pattern);
     }
     static void fillFrom(const QJsonObject& jo, PushRule& pod)
     {
-        fillFromJson(jo.value("actions"_ls), pod.actions);
-        fillFromJson(jo.value("default"_ls), pod.isDefault);
-        fillFromJson(jo.value("enabled"_ls), pod.enabled);
-        fillFromJson(jo.value("rule_id"_ls), pod.ruleId);
-        fillFromJson(jo.value("conditions"_ls), pod.conditions);
-        fillFromJson(jo.value("pattern"_ls), pod.pattern);
+        fillFromJson(jo.value("actions"_L1), pod.actions);
+        fillFromJson(jo.value("default"_L1), pod.isDefault);
+        fillFromJson(jo.value("enabled"_L1), pod.enabled);
+        fillFromJson(jo.value("rule_id"_L1), pod.ruleId);
+        fillFromJson(jo.value("conditions"_L1), pod.conditions);
+        fillFromJson(jo.value("pattern"_L1), pod.pattern);
     }
 };
 

--- a/Quotient/csapi/definitions/push_ruleset.h
+++ b/Quotient/csapi/definitions/push_ruleset.h
@@ -24,19 +24,19 @@ template <>
 struct JsonObjectConverter<PushRuleset> {
     static void dumpTo(QJsonObject& jo, const PushRuleset& pod)
     {
-        addParam<IfNotEmpty>(jo, QStringLiteral("content"), pod.content);
-        addParam<IfNotEmpty>(jo, QStringLiteral("override"), pod.override);
-        addParam<IfNotEmpty>(jo, QStringLiteral("room"), pod.room);
-        addParam<IfNotEmpty>(jo, QStringLiteral("sender"), pod.sender);
-        addParam<IfNotEmpty>(jo, QStringLiteral("underride"), pod.underride);
+        addParam<IfNotEmpty>(jo, "content"_L1, pod.content);
+        addParam<IfNotEmpty>(jo, "override"_L1, pod.override);
+        addParam<IfNotEmpty>(jo, "room"_L1, pod.room);
+        addParam<IfNotEmpty>(jo, "sender"_L1, pod.sender);
+        addParam<IfNotEmpty>(jo, "underride"_L1, pod.underride);
     }
     static void fillFrom(const QJsonObject& jo, PushRuleset& pod)
     {
-        fillFromJson(jo.value("content"_ls), pod.content);
-        fillFromJson(jo.value("override"_ls), pod.override);
-        fillFromJson(jo.value("room"_ls), pod.room);
-        fillFromJson(jo.value("sender"_ls), pod.sender);
-        fillFromJson(jo.value("underride"_ls), pod.underride);
+        fillFromJson(jo.value("content"_L1), pod.content);
+        fillFromJson(jo.value("override"_L1), pod.override);
+        fillFromJson(jo.value("room"_L1), pod.room);
+        fillFromJson(jo.value("sender"_L1), pod.sender);
+        fillFromJson(jo.value("underride"_L1), pod.underride);
     }
 };
 

--- a/Quotient/csapi/definitions/request_email_validation.h
+++ b/Quotient/csapi/definitions/request_email_validation.h
@@ -51,21 +51,21 @@ template <>
 struct JsonObjectConverter<EmailValidationData> {
     static void dumpTo(QJsonObject& jo, const EmailValidationData& pod)
     {
-        addParam<>(jo, QStringLiteral("client_secret"), pod.clientSecret);
-        addParam<>(jo, QStringLiteral("email"), pod.email);
-        addParam<>(jo, QStringLiteral("send_attempt"), pod.sendAttempt);
-        addParam<IfNotEmpty>(jo, QStringLiteral("next_link"), pod.nextLink);
-        addParam<IfNotEmpty>(jo, QStringLiteral("id_server"), pod.idServer);
-        addParam<IfNotEmpty>(jo, QStringLiteral("id_access_token"), pod.idAccessToken);
+        addParam<>(jo, "client_secret"_L1, pod.clientSecret);
+        addParam<>(jo, "email"_L1, pod.email);
+        addParam<>(jo, "send_attempt"_L1, pod.sendAttempt);
+        addParam<IfNotEmpty>(jo, "next_link"_L1, pod.nextLink);
+        addParam<IfNotEmpty>(jo, "id_server"_L1, pod.idServer);
+        addParam<IfNotEmpty>(jo, "id_access_token"_L1, pod.idAccessToken);
     }
     static void fillFrom(const QJsonObject& jo, EmailValidationData& pod)
     {
-        fillFromJson(jo.value("client_secret"_ls), pod.clientSecret);
-        fillFromJson(jo.value("email"_ls), pod.email);
-        fillFromJson(jo.value("send_attempt"_ls), pod.sendAttempt);
-        fillFromJson(jo.value("next_link"_ls), pod.nextLink);
-        fillFromJson(jo.value("id_server"_ls), pod.idServer);
-        fillFromJson(jo.value("id_access_token"_ls), pod.idAccessToken);
+        fillFromJson(jo.value("client_secret"_L1), pod.clientSecret);
+        fillFromJson(jo.value("email"_L1), pod.email);
+        fillFromJson(jo.value("send_attempt"_L1), pod.sendAttempt);
+        fillFromJson(jo.value("next_link"_L1), pod.nextLink);
+        fillFromJson(jo.value("id_server"_L1), pod.idServer);
+        fillFromJson(jo.value("id_access_token"_L1), pod.idAccessToken);
     }
 };
 

--- a/Quotient/csapi/definitions/request_msisdn_validation.h
+++ b/Quotient/csapi/definitions/request_msisdn_validation.h
@@ -54,23 +54,23 @@ template <>
 struct JsonObjectConverter<MsisdnValidationData> {
     static void dumpTo(QJsonObject& jo, const MsisdnValidationData& pod)
     {
-        addParam<>(jo, QStringLiteral("client_secret"), pod.clientSecret);
-        addParam<>(jo, QStringLiteral("country"), pod.country);
-        addParam<>(jo, QStringLiteral("phone_number"), pod.phoneNumber);
-        addParam<>(jo, QStringLiteral("send_attempt"), pod.sendAttempt);
-        addParam<IfNotEmpty>(jo, QStringLiteral("next_link"), pod.nextLink);
-        addParam<IfNotEmpty>(jo, QStringLiteral("id_server"), pod.idServer);
-        addParam<IfNotEmpty>(jo, QStringLiteral("id_access_token"), pod.idAccessToken);
+        addParam<>(jo, "client_secret"_L1, pod.clientSecret);
+        addParam<>(jo, "country"_L1, pod.country);
+        addParam<>(jo, "phone_number"_L1, pod.phoneNumber);
+        addParam<>(jo, "send_attempt"_L1, pod.sendAttempt);
+        addParam<IfNotEmpty>(jo, "next_link"_L1, pod.nextLink);
+        addParam<IfNotEmpty>(jo, "id_server"_L1, pod.idServer);
+        addParam<IfNotEmpty>(jo, "id_access_token"_L1, pod.idAccessToken);
     }
     static void fillFrom(const QJsonObject& jo, MsisdnValidationData& pod)
     {
-        fillFromJson(jo.value("client_secret"_ls), pod.clientSecret);
-        fillFromJson(jo.value("country"_ls), pod.country);
-        fillFromJson(jo.value("phone_number"_ls), pod.phoneNumber);
-        fillFromJson(jo.value("send_attempt"_ls), pod.sendAttempt);
-        fillFromJson(jo.value("next_link"_ls), pod.nextLink);
-        fillFromJson(jo.value("id_server"_ls), pod.idServer);
-        fillFromJson(jo.value("id_access_token"_ls), pod.idAccessToken);
+        fillFromJson(jo.value("client_secret"_L1), pod.clientSecret);
+        fillFromJson(jo.value("country"_L1), pod.country);
+        fillFromJson(jo.value("phone_number"_L1), pod.phoneNumber);
+        fillFromJson(jo.value("send_attempt"_L1), pod.sendAttempt);
+        fillFromJson(jo.value("next_link"_L1), pod.nextLink);
+        fillFromJson(jo.value("id_server"_L1), pod.idServer);
+        fillFromJson(jo.value("id_access_token"_L1), pod.idAccessToken);
     }
 };
 

--- a/Quotient/csapi/definitions/request_token_response.h
+++ b/Quotient/csapi/definitions/request_token_response.h
@@ -29,13 +29,13 @@ template <>
 struct JsonObjectConverter<RequestTokenResponse> {
     static void dumpTo(QJsonObject& jo, const RequestTokenResponse& pod)
     {
-        addParam<>(jo, QStringLiteral("sid"), pod.sid);
-        addParam<IfNotEmpty>(jo, QStringLiteral("submit_url"), pod.submitUrl);
+        addParam<>(jo, "sid"_L1, pod.sid);
+        addParam<IfNotEmpty>(jo, "submit_url"_L1, pod.submitUrl);
     }
     static void fillFrom(const QJsonObject& jo, RequestTokenResponse& pod)
     {
-        fillFromJson(jo.value("sid"_ls), pod.sid);
-        fillFromJson(jo.value("submit_url"_ls), pod.submitUrl);
+        fillFromJson(jo.value("sid"_L1), pod.sid);
+        fillFromJson(jo.value("submit_url"_L1), pod.submitUrl);
     }
 };
 

--- a/Quotient/csapi/definitions/room_event_filter.h
+++ b/Quotient/csapi/definitions/room_event_filter.h
@@ -42,24 +42,22 @@ struct JsonObjectConverter<RoomEventFilter> {
     static void dumpTo(QJsonObject& jo, const RoomEventFilter& pod)
     {
         fillJson<EventFilter>(jo, pod);
-        addParam<IfNotEmpty>(jo, QStringLiteral("unread_thread_notifications"),
-                             pod.unreadThreadNotifications);
-        addParam<IfNotEmpty>(jo, QStringLiteral("lazy_load_members"), pod.lazyLoadMembers);
-        addParam<IfNotEmpty>(jo, QStringLiteral("include_redundant_members"),
-                             pod.includeRedundantMembers);
-        addParam<IfNotEmpty>(jo, QStringLiteral("not_rooms"), pod.notRooms);
-        addParam<IfNotEmpty>(jo, QStringLiteral("rooms"), pod.rooms);
-        addParam<IfNotEmpty>(jo, QStringLiteral("contains_url"), pod.containsUrl);
+        addParam<IfNotEmpty>(jo, "unread_thread_notifications"_L1, pod.unreadThreadNotifications);
+        addParam<IfNotEmpty>(jo, "lazy_load_members"_L1, pod.lazyLoadMembers);
+        addParam<IfNotEmpty>(jo, "include_redundant_members"_L1, pod.includeRedundantMembers);
+        addParam<IfNotEmpty>(jo, "not_rooms"_L1, pod.notRooms);
+        addParam<IfNotEmpty>(jo, "rooms"_L1, pod.rooms);
+        addParam<IfNotEmpty>(jo, "contains_url"_L1, pod.containsUrl);
     }
     static void fillFrom(const QJsonObject& jo, RoomEventFilter& pod)
     {
         fillFromJson<EventFilter>(jo, pod);
-        fillFromJson(jo.value("unread_thread_notifications"_ls), pod.unreadThreadNotifications);
-        fillFromJson(jo.value("lazy_load_members"_ls), pod.lazyLoadMembers);
-        fillFromJson(jo.value("include_redundant_members"_ls), pod.includeRedundantMembers);
-        fillFromJson(jo.value("not_rooms"_ls), pod.notRooms);
-        fillFromJson(jo.value("rooms"_ls), pod.rooms);
-        fillFromJson(jo.value("contains_url"_ls), pod.containsUrl);
+        fillFromJson(jo.value("unread_thread_notifications"_L1), pod.unreadThreadNotifications);
+        fillFromJson(jo.value("lazy_load_members"_L1), pod.lazyLoadMembers);
+        fillFromJson(jo.value("include_redundant_members"_L1), pod.includeRedundantMembers);
+        fillFromJson(jo.value("not_rooms"_L1), pod.notRooms);
+        fillFromJson(jo.value("rooms"_L1), pod.rooms);
+        fillFromJson(jo.value("contains_url"_L1), pod.containsUrl);
     }
 };
 

--- a/Quotient/csapi/definitions/room_key_backup.h
+++ b/Quotient/csapi/definitions/room_key_backup.h
@@ -17,11 +17,11 @@ template <>
 struct JsonObjectConverter<RoomKeyBackup> {
     static void dumpTo(QJsonObject& jo, const RoomKeyBackup& pod)
     {
-        addParam<>(jo, QStringLiteral("sessions"), pod.sessions);
+        addParam<>(jo, "sessions"_L1, pod.sessions);
     }
     static void fillFrom(const QJsonObject& jo, RoomKeyBackup& pod)
     {
-        fillFromJson(jo.value("sessions"_ls), pod.sessions);
+        fillFromJson(jo.value("sessions"_L1), pod.sessions);
     }
 };
 

--- a/Quotient/csapi/definitions/sync_filter.h
+++ b/Quotient/csapi/definitions/sync_filter.h
@@ -40,23 +40,23 @@ template <>
 struct JsonObjectConverter<RoomFilter> {
     static void dumpTo(QJsonObject& jo, const RoomFilter& pod)
     {
-        addParam<IfNotEmpty>(jo, QStringLiteral("not_rooms"), pod.notRooms);
-        addParam<IfNotEmpty>(jo, QStringLiteral("rooms"), pod.rooms);
-        addParam<IfNotEmpty>(jo, QStringLiteral("ephemeral"), pod.ephemeral);
-        addParam<IfNotEmpty>(jo, QStringLiteral("include_leave"), pod.includeLeave);
-        addParam<IfNotEmpty>(jo, QStringLiteral("state"), pod.state);
-        addParam<IfNotEmpty>(jo, QStringLiteral("timeline"), pod.timeline);
-        addParam<IfNotEmpty>(jo, QStringLiteral("account_data"), pod.accountData);
+        addParam<IfNotEmpty>(jo, "not_rooms"_L1, pod.notRooms);
+        addParam<IfNotEmpty>(jo, "rooms"_L1, pod.rooms);
+        addParam<IfNotEmpty>(jo, "ephemeral"_L1, pod.ephemeral);
+        addParam<IfNotEmpty>(jo, "include_leave"_L1, pod.includeLeave);
+        addParam<IfNotEmpty>(jo, "state"_L1, pod.state);
+        addParam<IfNotEmpty>(jo, "timeline"_L1, pod.timeline);
+        addParam<IfNotEmpty>(jo, "account_data"_L1, pod.accountData);
     }
     static void fillFrom(const QJsonObject& jo, RoomFilter& pod)
     {
-        fillFromJson(jo.value("not_rooms"_ls), pod.notRooms);
-        fillFromJson(jo.value("rooms"_ls), pod.rooms);
-        fillFromJson(jo.value("ephemeral"_ls), pod.ephemeral);
-        fillFromJson(jo.value("include_leave"_ls), pod.includeLeave);
-        fillFromJson(jo.value("state"_ls), pod.state);
-        fillFromJson(jo.value("timeline"_ls), pod.timeline);
-        fillFromJson(jo.value("account_data"_ls), pod.accountData);
+        fillFromJson(jo.value("not_rooms"_L1), pod.notRooms);
+        fillFromJson(jo.value("rooms"_L1), pod.rooms);
+        fillFromJson(jo.value("ephemeral"_L1), pod.ephemeral);
+        fillFromJson(jo.value("include_leave"_L1), pod.includeLeave);
+        fillFromJson(jo.value("state"_L1), pod.state);
+        fillFromJson(jo.value("timeline"_L1), pod.timeline);
+        fillFromJson(jo.value("account_data"_L1), pod.accountData);
     }
 };
 
@@ -86,19 +86,19 @@ template <>
 struct JsonObjectConverter<Filter> {
     static void dumpTo(QJsonObject& jo, const Filter& pod)
     {
-        addParam<IfNotEmpty>(jo, QStringLiteral("event_fields"), pod.eventFields);
-        addParam<IfNotEmpty>(jo, QStringLiteral("event_format"), pod.eventFormat);
-        addParam<IfNotEmpty>(jo, QStringLiteral("presence"), pod.presence);
-        addParam<IfNotEmpty>(jo, QStringLiteral("account_data"), pod.accountData);
-        addParam<IfNotEmpty>(jo, QStringLiteral("room"), pod.room);
+        addParam<IfNotEmpty>(jo, "event_fields"_L1, pod.eventFields);
+        addParam<IfNotEmpty>(jo, "event_format"_L1, pod.eventFormat);
+        addParam<IfNotEmpty>(jo, "presence"_L1, pod.presence);
+        addParam<IfNotEmpty>(jo, "account_data"_L1, pod.accountData);
+        addParam<IfNotEmpty>(jo, "room"_L1, pod.room);
     }
     static void fillFrom(const QJsonObject& jo, Filter& pod)
     {
-        fillFromJson(jo.value("event_fields"_ls), pod.eventFields);
-        fillFromJson(jo.value("event_format"_ls), pod.eventFormat);
-        fillFromJson(jo.value("presence"_ls), pod.presence);
-        fillFromJson(jo.value("account_data"_ls), pod.accountData);
-        fillFromJson(jo.value("room"_ls), pod.room);
+        fillFromJson(jo.value("event_fields"_L1), pod.eventFields);
+        fillFromJson(jo.value("event_format"_L1), pod.eventFormat);
+        fillFromJson(jo.value("presence"_L1), pod.presence);
+        fillFromJson(jo.value("account_data"_L1), pod.accountData);
+        fillFromJson(jo.value("room"_L1), pod.room);
     }
 };
 

--- a/Quotient/csapi/definitions/tag.h
+++ b/Quotient/csapi/definitions/tag.h
@@ -16,11 +16,11 @@ template <>
 struct JsonObjectConverter<Tag> {
     static void dumpTo(QJsonObject& jo, const Tag& pod)
     {
-        addParam<IfNotEmpty>(jo, QStringLiteral("order"), pod.order);
+        addParam<IfNotEmpty>(jo, "order"_L1, pod.order);
     }
     static void fillFrom(const QJsonObject& jo, Tag& pod)
     {
-        fillFromJson(jo.value("order"_ls), pod.order);
+        fillFromJson(jo.value("order"_L1), pod.order);
     }
 };
 

--- a/Quotient/csapi/definitions/third_party_signed.h
+++ b/Quotient/csapi/definitions/third_party_signed.h
@@ -25,17 +25,17 @@ template <>
 struct JsonObjectConverter<ThirdPartySigned> {
     static void dumpTo(QJsonObject& jo, const ThirdPartySigned& pod)
     {
-        addParam<>(jo, QStringLiteral("sender"), pod.sender);
-        addParam<>(jo, QStringLiteral("mxid"), pod.mxid);
-        addParam<>(jo, QStringLiteral("token"), pod.token);
-        addParam<>(jo, QStringLiteral("signatures"), pod.signatures);
+        addParam<>(jo, "sender"_L1, pod.sender);
+        addParam<>(jo, "mxid"_L1, pod.mxid);
+        addParam<>(jo, "token"_L1, pod.token);
+        addParam<>(jo, "signatures"_L1, pod.signatures);
     }
     static void fillFrom(const QJsonObject& jo, ThirdPartySigned& pod)
     {
-        fillFromJson(jo.value("sender"_ls), pod.sender);
-        fillFromJson(jo.value("mxid"_ls), pod.mxid);
-        fillFromJson(jo.value("token"_ls), pod.token);
-        fillFromJson(jo.value("signatures"_ls), pod.signatures);
+        fillFromJson(jo.value("sender"_L1), pod.sender);
+        fillFromJson(jo.value("mxid"_L1), pod.mxid);
+        fillFromJson(jo.value("token"_L1), pod.token);
+        fillFromJson(jo.value("signatures"_L1), pod.signatures);
     }
 };
 

--- a/Quotient/csapi/definitions/user_identifier.h
+++ b/Quotient/csapi/definitions/user_identifier.h
@@ -19,11 +19,11 @@ struct JsonObjectConverter<UserIdentifier> {
     static void dumpTo(QJsonObject& jo, const UserIdentifier& pod)
     {
         fillJson(jo, pod.additionalProperties);
-        addParam<>(jo, QStringLiteral("type"), pod.type);
+        addParam<>(jo, "type"_L1, pod.type);
     }
     static void fillFrom(QJsonObject jo, UserIdentifier& pod)
     {
-        fillFromJson(jo.take("type"_ls), pod.type);
+        fillFromJson(jo.take("type"_L1), pod.type);
         fromJson(jo, pod.additionalProperties);
     }
 };

--- a/Quotient/csapi/definitions/wellknown/full.h
+++ b/Quotient/csapi/definitions/wellknown/full.h
@@ -24,13 +24,13 @@ struct JsonObjectConverter<DiscoveryInformation> {
     static void dumpTo(QJsonObject& jo, const DiscoveryInformation& pod)
     {
         fillJson(jo, pod.additionalProperties);
-        addParam<>(jo, QStringLiteral("m.homeserver"), pod.homeserver);
-        addParam<IfNotEmpty>(jo, QStringLiteral("m.identity_server"), pod.identityServer);
+        addParam<>(jo, "m.homeserver"_L1, pod.homeserver);
+        addParam<IfNotEmpty>(jo, "m.identity_server"_L1, pod.identityServer);
     }
     static void fillFrom(QJsonObject jo, DiscoveryInformation& pod)
     {
-        fillFromJson(jo.take("m.homeserver"_ls), pod.homeserver);
-        fillFromJson(jo.take("m.identity_server"_ls), pod.identityServer);
+        fillFromJson(jo.take("m.homeserver"_L1), pod.homeserver);
+        fillFromJson(jo.take("m.identity_server"_L1), pod.identityServer);
         fromJson(jo, pod.additionalProperties);
     }
 };

--- a/Quotient/csapi/definitions/wellknown/homeserver.h
+++ b/Quotient/csapi/definitions/wellknown/homeserver.h
@@ -15,11 +15,11 @@ template <>
 struct JsonObjectConverter<HomeserverInformation> {
     static void dumpTo(QJsonObject& jo, const HomeserverInformation& pod)
     {
-        addParam<>(jo, QStringLiteral("base_url"), pod.baseUrl);
+        addParam<>(jo, "base_url"_L1, pod.baseUrl);
     }
     static void fillFrom(const QJsonObject& jo, HomeserverInformation& pod)
     {
-        fillFromJson(jo.value("base_url"_ls), pod.baseUrl);
+        fillFromJson(jo.value("base_url"_L1), pod.baseUrl);
     }
 };
 

--- a/Quotient/csapi/definitions/wellknown/identity_server.h
+++ b/Quotient/csapi/definitions/wellknown/identity_server.h
@@ -15,11 +15,11 @@ template <>
 struct JsonObjectConverter<IdentityServerInformation> {
     static void dumpTo(QJsonObject& jo, const IdentityServerInformation& pod)
     {
-        addParam<>(jo, QStringLiteral("base_url"), pod.baseUrl);
+        addParam<>(jo, "base_url"_L1, pod.baseUrl);
     }
     static void fillFrom(const QJsonObject& jo, IdentityServerInformation& pod)
     {
-        fillFromJson(jo.value("base_url"_ls), pod.baseUrl);
+        fillFromJson(jo.value("base_url"_L1), pod.baseUrl);
     }
 };
 

--- a/Quotient/csapi/device_management.cpp
+++ b/Quotient/csapi/device_management.cpp
@@ -10,8 +10,7 @@ QUrl GetDevicesJob::makeRequestUrl(const HomeserverData& hsData)
 }
 
 GetDevicesJob::GetDevicesJob()
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetDevicesJob"),
-              makePath("/_matrix/client/v3", "/devices"))
+    : BaseJob(HttpVerb::Get, u"GetDevicesJob"_s, makePath("/_matrix/client/v3", "/devices"))
 {}
 
 QUrl GetDeviceJob::makeRequestUrl(const HomeserverData& hsData, const QString& deviceId)
@@ -20,36 +19,36 @@ QUrl GetDeviceJob::makeRequestUrl(const HomeserverData& hsData, const QString& d
 }
 
 GetDeviceJob::GetDeviceJob(const QString& deviceId)
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetDeviceJob"),
+    : BaseJob(HttpVerb::Get, u"GetDeviceJob"_s,
               makePath("/_matrix/client/v3", "/devices/", deviceId))
 {}
 
 UpdateDeviceJob::UpdateDeviceJob(const QString& deviceId, const QString& displayName)
-    : BaseJob(HttpVerb::Put, QStringLiteral("UpdateDeviceJob"),
+    : BaseJob(HttpVerb::Put, u"UpdateDeviceJob"_s,
               makePath("/_matrix/client/v3", "/devices/", deviceId))
 {
     QJsonObject _dataJson;
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("display_name"), displayName);
+    addParam<IfNotEmpty>(_dataJson, "display_name"_L1, displayName);
     setRequestData({ _dataJson });
 }
 
 DeleteDeviceJob::DeleteDeviceJob(const QString& deviceId,
                                  const std::optional<AuthenticationData>& auth)
-    : BaseJob(HttpVerb::Delete, QStringLiteral("DeleteDeviceJob"),
+    : BaseJob(HttpVerb::Delete, u"DeleteDeviceJob"_s,
               makePath("/_matrix/client/v3", "/devices/", deviceId))
 {
     QJsonObject _dataJson;
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("auth"), auth);
+    addParam<IfNotEmpty>(_dataJson, "auth"_L1, auth);
     setRequestData({ _dataJson });
 }
 
 DeleteDevicesJob::DeleteDevicesJob(const QStringList& devices,
                                    const std::optional<AuthenticationData>& auth)
-    : BaseJob(HttpVerb::Post, QStringLiteral("DeleteDevicesJob"),
+    : BaseJob(HttpVerb::Post, u"DeleteDevicesJob"_s,
               makePath("/_matrix/client/v3", "/delete_devices"))
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, QStringLiteral("devices"), devices);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("auth"), auth);
+    addParam<>(_dataJson, "devices"_L1, devices);
+    addParam<IfNotEmpty>(_dataJson, "auth"_L1, auth);
     setRequestData({ _dataJson });
 }

--- a/Quotient/csapi/device_management.h
+++ b/Quotient/csapi/device_management.h
@@ -25,7 +25,7 @@ public:
     // Result properties
 
     //! A list of all registered devices for this user.
-    QVector<Device> devices() const { return loadFromJson<QVector<Device>>("devices"_ls); }
+    QVector<Device> devices() const { return loadFromJson<QVector<Device>>("devices"_L1); }
 };
 
 inline auto collectResponse(const GetDevicesJob* job) { return job->devices(); }

--- a/Quotient/csapi/directory.cpp
+++ b/Quotient/csapi/directory.cpp
@@ -5,11 +5,11 @@
 using namespace Quotient;
 
 SetRoomAliasJob::SetRoomAliasJob(const QString& roomAlias, const QString& roomId)
-    : BaseJob(HttpVerb::Put, QStringLiteral("SetRoomAliasJob"),
+    : BaseJob(HttpVerb::Put, u"SetRoomAliasJob"_s,
               makePath("/_matrix/client/v3", "/directory/room/", roomAlias))
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, QStringLiteral("room_id"), roomId);
+    addParam<>(_dataJson, "room_id"_L1, roomId);
     setRequestData({ _dataJson });
 }
 
@@ -20,7 +20,7 @@ QUrl GetRoomIdByAliasJob::makeRequestUrl(const HomeserverData& hsData, const QSt
 }
 
 GetRoomIdByAliasJob::GetRoomIdByAliasJob(const QString& roomAlias)
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetRoomIdByAliasJob"),
+    : BaseJob(HttpVerb::Get, u"GetRoomIdByAliasJob"_s,
               makePath("/_matrix/client/v3", "/directory/room/", roomAlias), false)
 {}
 
@@ -31,7 +31,7 @@ QUrl DeleteRoomAliasJob::makeRequestUrl(const HomeserverData& hsData, const QStr
 }
 
 DeleteRoomAliasJob::DeleteRoomAliasJob(const QString& roomAlias)
-    : BaseJob(HttpVerb::Delete, QStringLiteral("DeleteRoomAliasJob"),
+    : BaseJob(HttpVerb::Delete, u"DeleteRoomAliasJob"_s,
               makePath("/_matrix/client/v3", "/directory/room/", roomAlias))
 {}
 
@@ -42,7 +42,7 @@ QUrl GetLocalAliasesJob::makeRequestUrl(const HomeserverData& hsData, const QStr
 }
 
 GetLocalAliasesJob::GetLocalAliasesJob(const QString& roomId)
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetLocalAliasesJob"),
+    : BaseJob(HttpVerb::Get, u"GetLocalAliasesJob"_s,
               makePath("/_matrix/client/v3", "/rooms/", roomId, "/aliases"))
 {
     addExpectedKey("aliases");

--- a/Quotient/csapi/directory.h
+++ b/Quotient/csapi/directory.h
@@ -41,10 +41,10 @@ public:
     // Result properties
 
     //! The room ID for this room alias.
-    QString roomId() const { return loadFromJson<QString>("room_id"_ls); }
+    QString roomId() const { return loadFromJson<QString>("room_id"_L1); }
 
     //! A list of servers that are aware of this room alias.
-    QStringList servers() const { return loadFromJson<QStringList>("servers"_ls); }
+    QStringList servers() const { return loadFromJson<QStringList>("servers"_L1); }
 
     struct Response {
         //! The room ID for this room alias.
@@ -119,7 +119,7 @@ public:
     // Result properties
 
     //! The server's local aliases on the room. Can be empty.
-    QStringList aliases() const { return loadFromJson<QStringList>("aliases"_ls); }
+    QStringList aliases() const { return loadFromJson<QStringList>("aliases"_L1); }
 };
 
 inline auto collectResponse(const GetLocalAliasesJob* job) { return job->aliases(); }

--- a/Quotient/csapi/event_context.cpp
+++ b/Quotient/csapi/event_context.cpp
@@ -7,8 +7,8 @@ using namespace Quotient;
 auto queryToGetEventContext(std::optional<int> limit, const QString& filter)
 {
     QUrlQuery _q;
-    addParam<IfNotEmpty>(_q, QStringLiteral("limit"), limit);
-    addParam<IfNotEmpty>(_q, QStringLiteral("filter"), filter);
+    addParam<IfNotEmpty>(_q, u"limit"_s, limit);
+    addParam<IfNotEmpty>(_q, u"filter"_s, filter);
     return _q;
 }
 
@@ -24,7 +24,7 @@ QUrl GetEventContextJob::makeRequestUrl(const HomeserverData& hsData, const QStr
 
 GetEventContextJob::GetEventContextJob(const QString& roomId, const QString& eventId,
                                        std::optional<int> limit, const QString& filter)
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetEventContextJob"),
+    : BaseJob(HttpVerb::Get, u"GetEventContextJob"_s,
               makePath("/_matrix/client/v3", "/rooms/", roomId, "/context/", eventId),
               queryToGetEventContext(limit, filter))
 {}

--- a/Quotient/csapi/event_context.h
+++ b/Quotient/csapi/event_context.h
@@ -52,24 +52,24 @@ public:
     // Result properties
 
     //! A token that can be used to paginate backwards with.
-    QString begin() const { return loadFromJson<QString>("start"_ls); }
+    QString begin() const { return loadFromJson<QString>("start"_L1); }
 
     //! A token that can be used to paginate forwards with.
-    QString end() const { return loadFromJson<QString>("end"_ls); }
+    QString end() const { return loadFromJson<QString>("end"_L1); }
 
     //! A list of room events that happened just before the
     //! requested event, in reverse-chronological order.
-    RoomEvents eventsBefore() { return takeFromJson<RoomEvents>("events_before"_ls); }
+    RoomEvents eventsBefore() { return takeFromJson<RoomEvents>("events_before"_L1); }
 
     //! Details of the requested event.
-    RoomEventPtr event() { return takeFromJson<RoomEventPtr>("event"_ls); }
+    RoomEventPtr event() { return takeFromJson<RoomEventPtr>("event"_L1); }
 
     //! A list of room events that happened just after the
     //! requested event, in chronological order.
-    RoomEvents eventsAfter() { return takeFromJson<RoomEvents>("events_after"_ls); }
+    RoomEvents eventsAfter() { return takeFromJson<RoomEvents>("events_after"_L1); }
 
     //! The state of the room at the last event returned.
-    StateEvents state() { return takeFromJson<StateEvents>("state"_ls); }
+    StateEvents state() { return takeFromJson<StateEvents>("state"_L1); }
 
     struct Response {
         //! A token that can be used to paginate backwards with.

--- a/Quotient/csapi/filter.cpp
+++ b/Quotient/csapi/filter.cpp
@@ -5,7 +5,7 @@
 using namespace Quotient;
 
 DefineFilterJob::DefineFilterJob(const QString& userId, const Filter& filter)
-    : BaseJob(HttpVerb::Post, QStringLiteral("DefineFilterJob"),
+    : BaseJob(HttpVerb::Post, u"DefineFilterJob"_s,
               makePath("/_matrix/client/v3", "/user/", userId, "/filter"))
 {
     setRequestData({ toJson(filter) });
@@ -20,6 +20,6 @@ QUrl GetFilterJob::makeRequestUrl(const HomeserverData& hsData, const QString& u
 }
 
 GetFilterJob::GetFilterJob(const QString& userId, const QString& filterId)
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetFilterJob"),
+    : BaseJob(HttpVerb::Get, u"GetFilterJob"_s,
               makePath("/_matrix/client/v3", "/user/", userId, "/filter/", filterId))
 {}

--- a/Quotient/csapi/filter.h
+++ b/Quotient/csapi/filter.h
@@ -29,7 +29,7 @@ public:
     //! with a `{` as this character is used to determine
     //! if the filter provided is inline JSON or a previously
     //! declared filter by homeservers on some APIs.
-    QString filterId() const { return loadFromJson<QString>("filter_id"_ls); }
+    QString filterId() const { return loadFromJson<QString>("filter_id"_L1); }
 };
 
 inline auto collectResponse(const DefineFilterJob* job) { return job->filterId(); }

--- a/Quotient/csapi/inviting.cpp
+++ b/Quotient/csapi/inviting.cpp
@@ -5,11 +5,11 @@
 using namespace Quotient;
 
 InviteUserJob::InviteUserJob(const QString& roomId, const QString& userId, const QString& reason)
-    : BaseJob(HttpVerb::Post, QStringLiteral("InviteUserJob"),
+    : BaseJob(HttpVerb::Post, u"InviteUserJob"_s,
               makePath("/_matrix/client/v3", "/rooms/", roomId, "/invite"))
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, QStringLiteral("user_id"), userId);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("reason"), reason);
+    addParam<>(_dataJson, "user_id"_L1, userId);
+    addParam<IfNotEmpty>(_dataJson, "reason"_L1, reason);
     setRequestData({ _dataJson });
 }

--- a/Quotient/csapi/joining.cpp
+++ b/Quotient/csapi/joining.cpp
@@ -7,12 +7,12 @@ using namespace Quotient;
 JoinRoomByIdJob::JoinRoomByIdJob(const QString& roomId,
                                  const std::optional<ThirdPartySigned>& thirdPartySigned,
                                  const QString& reason)
-    : BaseJob(HttpVerb::Post, QStringLiteral("JoinRoomByIdJob"),
+    : BaseJob(HttpVerb::Post, u"JoinRoomByIdJob"_s,
               makePath("/_matrix/client/v3", "/rooms/", roomId, "/join"))
 {
     QJsonObject _dataJson;
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("third_party_signed"), thirdPartySigned);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("reason"), reason);
+    addParam<IfNotEmpty>(_dataJson, "third_party_signed"_L1, thirdPartySigned);
+    addParam<IfNotEmpty>(_dataJson, "reason"_L1, reason);
     setRequestData({ _dataJson });
     addExpectedKey("room_id");
 }
@@ -20,19 +20,19 @@ JoinRoomByIdJob::JoinRoomByIdJob(const QString& roomId,
 auto queryToJoinRoom(const QStringList& serverName)
 {
     QUrlQuery _q;
-    addParam<IfNotEmpty>(_q, QStringLiteral("server_name"), serverName);
+    addParam<IfNotEmpty>(_q, u"server_name"_s, serverName);
     return _q;
 }
 
 JoinRoomJob::JoinRoomJob(const QString& roomIdOrAlias, const QStringList& serverName,
                          const std::optional<ThirdPartySigned>& thirdPartySigned,
                          const QString& reason)
-    : BaseJob(HttpVerb::Post, QStringLiteral("JoinRoomJob"),
+    : BaseJob(HttpVerb::Post, u"JoinRoomJob"_s,
               makePath("/_matrix/client/v3", "/join/", roomIdOrAlias), queryToJoinRoom(serverName))
 {
     QJsonObject _dataJson;
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("third_party_signed"), thirdPartySigned);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("reason"), reason);
+    addParam<IfNotEmpty>(_dataJson, "third_party_signed"_L1, thirdPartySigned);
+    addParam<IfNotEmpty>(_dataJson, "reason"_L1, reason);
     setRequestData({ _dataJson });
     addExpectedKey("room_id");
 }

--- a/Quotient/csapi/joining.h
+++ b/Quotient/csapi/joining.h
@@ -41,7 +41,7 @@ public:
     // Result properties
 
     //! The joined room ID.
-    QString roomId() const { return loadFromJson<QString>("room_id"_ls); }
+    QString roomId() const { return loadFromJson<QString>("room_id"_L1); }
 };
 
 inline auto collectResponse(const JoinRoomByIdJob* job) { return job->roomId(); }
@@ -82,7 +82,7 @@ public:
     // Result properties
 
     //! The joined room ID.
-    QString roomId() const { return loadFromJson<QString>("room_id"_ls); }
+    QString roomId() const { return loadFromJson<QString>("room_id"_L1); }
 };
 
 inline auto collectResponse(const JoinRoomJob* job) { return job->roomId(); }

--- a/Quotient/csapi/key_backup.cpp
+++ b/Quotient/csapi/key_backup.cpp
@@ -5,12 +5,12 @@
 using namespace Quotient;
 
 PostRoomKeysVersionJob::PostRoomKeysVersionJob(const QString& algorithm, const QJsonObject& authData)
-    : BaseJob(HttpVerb::Post, QStringLiteral("PostRoomKeysVersionJob"),
+    : BaseJob(HttpVerb::Post, u"PostRoomKeysVersionJob"_s,
               makePath("/_matrix/client/v3", "/room_keys/version"))
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, QStringLiteral("algorithm"), algorithm);
-    addParam<>(_dataJson, QStringLiteral("auth_data"), authData);
+    addParam<>(_dataJson, "algorithm"_L1, algorithm);
+    addParam<>(_dataJson, "auth_data"_L1, authData);
     setRequestData({ _dataJson });
     addExpectedKey("version");
 }
@@ -21,7 +21,7 @@ QUrl GetRoomKeysVersionCurrentJob::makeRequestUrl(const HomeserverData& hsData)
 }
 
 GetRoomKeysVersionCurrentJob::GetRoomKeysVersionCurrentJob()
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetRoomKeysVersionCurrentJob"),
+    : BaseJob(HttpVerb::Get, u"GetRoomKeysVersionCurrentJob"_s,
               makePath("/_matrix/client/v3", "/room_keys/version"))
 {
     addExpectedKey("algorithm");
@@ -38,7 +38,7 @@ QUrl GetRoomKeysVersionJob::makeRequestUrl(const HomeserverData& hsData, const Q
 }
 
 GetRoomKeysVersionJob::GetRoomKeysVersionJob(const QString& version)
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetRoomKeysVersionJob"),
+    : BaseJob(HttpVerb::Get, u"GetRoomKeysVersionJob"_s,
               makePath("/_matrix/client/v3", "/room_keys/version/", version))
 {
     addExpectedKey("algorithm");
@@ -50,12 +50,12 @@ GetRoomKeysVersionJob::GetRoomKeysVersionJob(const QString& version)
 
 PutRoomKeysVersionJob::PutRoomKeysVersionJob(const QString& version, const QString& algorithm,
                                              const QJsonObject& authData)
-    : BaseJob(HttpVerb::Put, QStringLiteral("PutRoomKeysVersionJob"),
+    : BaseJob(HttpVerb::Put, u"PutRoomKeysVersionJob"_s,
               makePath("/_matrix/client/v3", "/room_keys/version/", version))
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, QStringLiteral("algorithm"), algorithm);
-    addParam<>(_dataJson, QStringLiteral("auth_data"), authData);
+    addParam<>(_dataJson, "algorithm"_L1, algorithm);
+    addParam<>(_dataJson, "auth_data"_L1, authData);
     setRequestData({ _dataJson });
 }
 
@@ -66,20 +66,20 @@ QUrl DeleteRoomKeysVersionJob::makeRequestUrl(const HomeserverData& hsData, cons
 }
 
 DeleteRoomKeysVersionJob::DeleteRoomKeysVersionJob(const QString& version)
-    : BaseJob(HttpVerb::Delete, QStringLiteral("DeleteRoomKeysVersionJob"),
+    : BaseJob(HttpVerb::Delete, u"DeleteRoomKeysVersionJob"_s,
               makePath("/_matrix/client/v3", "/room_keys/version/", version))
 {}
 
 auto queryToPutRoomKeyBySessionId(const QString& version)
 {
     QUrlQuery _q;
-    addParam<>(_q, QStringLiteral("version"), version);
+    addParam<>(_q, u"version"_s, version);
     return _q;
 }
 
 PutRoomKeyBySessionIdJob::PutRoomKeyBySessionIdJob(const QString& roomId, const QString& sessionId,
                                                    const QString& version, const KeyBackupData& data)
-    : BaseJob(HttpVerb::Put, QStringLiteral("PutRoomKeyBySessionIdJob"),
+    : BaseJob(HttpVerb::Put, u"PutRoomKeyBySessionIdJob"_s,
               makePath("/_matrix/client/v3", "/room_keys/keys/", roomId, "/", sessionId),
               queryToPutRoomKeyBySessionId(version))
 {
@@ -91,7 +91,7 @@ PutRoomKeyBySessionIdJob::PutRoomKeyBySessionIdJob(const QString& roomId, const 
 auto queryToGetRoomKeyBySessionId(const QString& version)
 {
     QUrlQuery _q;
-    addParam<>(_q, QStringLiteral("version"), version);
+    addParam<>(_q, u"version"_s, version);
     return _q;
 }
 
@@ -106,7 +106,7 @@ QUrl GetRoomKeyBySessionIdJob::makeRequestUrl(const HomeserverData& hsData, cons
 
 GetRoomKeyBySessionIdJob::GetRoomKeyBySessionIdJob(const QString& roomId, const QString& sessionId,
                                                    const QString& version)
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetRoomKeyBySessionIdJob"),
+    : BaseJob(HttpVerb::Get, u"GetRoomKeyBySessionIdJob"_s,
               makePath("/_matrix/client/v3", "/room_keys/keys/", roomId, "/", sessionId),
               queryToGetRoomKeyBySessionId(version))
 {}
@@ -114,7 +114,7 @@ GetRoomKeyBySessionIdJob::GetRoomKeyBySessionIdJob(const QString& roomId, const 
 auto queryToDeleteRoomKeyBySessionId(const QString& version)
 {
     QUrlQuery _q;
-    addParam<>(_q, QStringLiteral("version"), version);
+    addParam<>(_q, u"version"_s, version);
     return _q;
 }
 
@@ -130,7 +130,7 @@ QUrl DeleteRoomKeyBySessionIdJob::makeRequestUrl(const HomeserverData& hsData, c
 DeleteRoomKeyBySessionIdJob::DeleteRoomKeyBySessionIdJob(const QString& roomId,
                                                          const QString& sessionId,
                                                          const QString& version)
-    : BaseJob(HttpVerb::Delete, QStringLiteral("DeleteRoomKeyBySessionIdJob"),
+    : BaseJob(HttpVerb::Delete, u"DeleteRoomKeyBySessionIdJob"_s,
               makePath("/_matrix/client/v3", "/room_keys/keys/", roomId, "/", sessionId),
               queryToDeleteRoomKeyBySessionId(version))
 {
@@ -141,13 +141,13 @@ DeleteRoomKeyBySessionIdJob::DeleteRoomKeyBySessionIdJob(const QString& roomId,
 auto queryToPutRoomKeysByRoomId(const QString& version)
 {
     QUrlQuery _q;
-    addParam<>(_q, QStringLiteral("version"), version);
+    addParam<>(_q, u"version"_s, version);
     return _q;
 }
 
 PutRoomKeysByRoomIdJob::PutRoomKeysByRoomIdJob(const QString& roomId, const QString& version,
                                                const RoomKeyBackup& backupData)
-    : BaseJob(HttpVerb::Put, QStringLiteral("PutRoomKeysByRoomIdJob"),
+    : BaseJob(HttpVerb::Put, u"PutRoomKeysByRoomIdJob"_s,
               makePath("/_matrix/client/v3", "/room_keys/keys/", roomId),
               queryToPutRoomKeysByRoomId(version))
 {
@@ -159,7 +159,7 @@ PutRoomKeysByRoomIdJob::PutRoomKeysByRoomIdJob(const QString& roomId, const QStr
 auto queryToGetRoomKeysByRoomId(const QString& version)
 {
     QUrlQuery _q;
-    addParam<>(_q, QStringLiteral("version"), version);
+    addParam<>(_q, u"version"_s, version);
     return _q;
 }
 
@@ -172,7 +172,7 @@ QUrl GetRoomKeysByRoomIdJob::makeRequestUrl(const HomeserverData& hsData, const 
 }
 
 GetRoomKeysByRoomIdJob::GetRoomKeysByRoomIdJob(const QString& roomId, const QString& version)
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetRoomKeysByRoomIdJob"),
+    : BaseJob(HttpVerb::Get, u"GetRoomKeysByRoomIdJob"_s,
               makePath("/_matrix/client/v3", "/room_keys/keys/", roomId),
               queryToGetRoomKeysByRoomId(version))
 {}
@@ -180,7 +180,7 @@ GetRoomKeysByRoomIdJob::GetRoomKeysByRoomIdJob(const QString& roomId, const QStr
 auto queryToDeleteRoomKeysByRoomId(const QString& version)
 {
     QUrlQuery _q;
-    addParam<>(_q, QStringLiteral("version"), version);
+    addParam<>(_q, u"version"_s, version);
     return _q;
 }
 
@@ -193,7 +193,7 @@ QUrl DeleteRoomKeysByRoomIdJob::makeRequestUrl(const HomeserverData& hsData, con
 }
 
 DeleteRoomKeysByRoomIdJob::DeleteRoomKeysByRoomIdJob(const QString& roomId, const QString& version)
-    : BaseJob(HttpVerb::Delete, QStringLiteral("DeleteRoomKeysByRoomIdJob"),
+    : BaseJob(HttpVerb::Delete, u"DeleteRoomKeysByRoomIdJob"_s,
               makePath("/_matrix/client/v3", "/room_keys/keys/", roomId),
               queryToDeleteRoomKeysByRoomId(version))
 {
@@ -204,16 +204,16 @@ DeleteRoomKeysByRoomIdJob::DeleteRoomKeysByRoomIdJob(const QString& roomId, cons
 auto queryToPutRoomKeys(const QString& version)
 {
     QUrlQuery _q;
-    addParam<>(_q, QStringLiteral("version"), version);
+    addParam<>(_q, u"version"_s, version);
     return _q;
 }
 
 PutRoomKeysJob::PutRoomKeysJob(const QString& version, const QHash<RoomId, RoomKeyBackup>& rooms)
-    : BaseJob(HttpVerb::Put, QStringLiteral("PutRoomKeysJob"),
-              makePath("/_matrix/client/v3", "/room_keys/keys"), queryToPutRoomKeys(version))
+    : BaseJob(HttpVerb::Put, u"PutRoomKeysJob"_s, makePath("/_matrix/client/v3", "/room_keys/keys"),
+              queryToPutRoomKeys(version))
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, QStringLiteral("rooms"), rooms);
+    addParam<>(_dataJson, "rooms"_L1, rooms);
     setRequestData({ _dataJson });
     addExpectedKey("etag");
     addExpectedKey("count");
@@ -222,7 +222,7 @@ PutRoomKeysJob::PutRoomKeysJob(const QString& version, const QHash<RoomId, RoomK
 auto queryToGetRoomKeys(const QString& version)
 {
     QUrlQuery _q;
-    addParam<>(_q, QStringLiteral("version"), version);
+    addParam<>(_q, u"version"_s, version);
     return _q;
 }
 
@@ -233,8 +233,8 @@ QUrl GetRoomKeysJob::makeRequestUrl(const HomeserverData& hsData, const QString&
 }
 
 GetRoomKeysJob::GetRoomKeysJob(const QString& version)
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetRoomKeysJob"),
-              makePath("/_matrix/client/v3", "/room_keys/keys"), queryToGetRoomKeys(version))
+    : BaseJob(HttpVerb::Get, u"GetRoomKeysJob"_s, makePath("/_matrix/client/v3", "/room_keys/keys"),
+              queryToGetRoomKeys(version))
 {
     addExpectedKey("rooms");
 }
@@ -242,7 +242,7 @@ GetRoomKeysJob::GetRoomKeysJob(const QString& version)
 auto queryToDeleteRoomKeys(const QString& version)
 {
     QUrlQuery _q;
-    addParam<>(_q, QStringLiteral("version"), version);
+    addParam<>(_q, u"version"_s, version);
     return _q;
 }
 
@@ -253,7 +253,7 @@ QUrl DeleteRoomKeysJob::makeRequestUrl(const HomeserverData& hsData, const QStri
 }
 
 DeleteRoomKeysJob::DeleteRoomKeysJob(const QString& version)
-    : BaseJob(HttpVerb::Delete, QStringLiteral("DeleteRoomKeysJob"),
+    : BaseJob(HttpVerb::Delete, u"DeleteRoomKeysJob"_s,
               makePath("/_matrix/client/v3", "/room_keys/keys"), queryToDeleteRoomKeys(version))
 {
     addExpectedKey("etag");

--- a/Quotient/csapi/key_backup.h
+++ b/Quotient/csapi/key_backup.h
@@ -26,7 +26,7 @@ public:
     // Result properties
 
     //! The backup version. This is an opaque string.
-    QString version() const { return loadFromJson<QString>("version"_ls); }
+    QString version() const { return loadFromJson<QString>("version"_L1); }
 };
 
 inline auto collectResponse(const PostRoomKeysVersionJob* job) { return job->version(); }
@@ -47,24 +47,24 @@ public:
     // Result properties
 
     //! The algorithm used for storing backups.
-    QString algorithm() const { return loadFromJson<QString>("algorithm"_ls); }
+    QString algorithm() const { return loadFromJson<QString>("algorithm"_L1); }
 
     //! Algorithm-dependent data. See the documentation for the backup
     //! algorithms in [Server-side key backups](/client-server-api/#server-side-key-backups) for
     //! more information on the expected format of the data.
-    QJsonObject authData() const { return loadFromJson<QJsonObject>("auth_data"_ls); }
+    QJsonObject authData() const { return loadFromJson<QJsonObject>("auth_data"_L1); }
 
     //! The number of keys stored in the backup.
-    int count() const { return loadFromJson<int>("count"_ls); }
+    int count() const { return loadFromJson<int>("count"_L1); }
 
     //! An opaque string representing stored keys in the backup.
     //! Clients can compare it with the `etag` value they received
     //! in the request of their last key storage request.  If not
     //! equal, another client has modified the backup.
-    QString etag() const { return loadFromJson<QString>("etag"_ls); }
+    QString etag() const { return loadFromJson<QString>("etag"_L1); }
 
     //! The backup version.
-    QString version() const { return loadFromJson<QString>("version"_ls); }
+    QString version() const { return loadFromJson<QString>("version"_L1); }
 
     struct Response {
         //! The algorithm used for storing backups.
@@ -117,24 +117,24 @@ public:
     // Result properties
 
     //! The algorithm used for storing backups.
-    QString algorithm() const { return loadFromJson<QString>("algorithm"_ls); }
+    QString algorithm() const { return loadFromJson<QString>("algorithm"_L1); }
 
     //! Algorithm-dependent data. See the documentation for the backup
     //! algorithms in [Server-side key backups](/client-server-api/#server-side-key-backups) for
     //! more information on the expected format of the data.
-    QJsonObject authData() const { return loadFromJson<QJsonObject>("auth_data"_ls); }
+    QJsonObject authData() const { return loadFromJson<QJsonObject>("auth_data"_L1); }
 
     //! The number of keys stored in the backup.
-    int count() const { return loadFromJson<int>("count"_ls); }
+    int count() const { return loadFromJson<int>("count"_L1); }
 
     //! An opaque string representing stored keys in the backup.
     //! Clients can compare it with the `etag` value they received
     //! in the request of their last key storage request.  If not
     //! equal, another client has modified the backup.
-    QString etag() const { return loadFromJson<QString>("etag"_ls); }
+    QString etag() const { return loadFromJson<QString>("etag"_L1); }
 
     //! The backup version.
-    QString version() const { return loadFromJson<QString>("version"_ls); }
+    QString version() const { return loadFromJson<QString>("version"_L1); }
 
     struct Response {
         //! The algorithm used for storing backups.
@@ -234,10 +234,10 @@ public:
 
     //! The new etag value representing stored keys in the backup.
     //! See `GET /room_keys/version/{version}` for more details.
-    QString etag() const { return loadFromJson<QString>("etag"_ls); }
+    QString etag() const { return loadFromJson<QString>("etag"_L1); }
 
     //! The number of keys stored in the backup
-    int count() const { return loadFromJson<int>("count"_ls); }
+    int count() const { return loadFromJson<int>("count"_L1); }
 
     struct Response {
         //! The new etag value representing stored keys in the backup.
@@ -311,10 +311,10 @@ public:
 
     //! The new etag value representing stored keys in the backup.
     //! See `GET /room_keys/version/{version}` for more details.
-    QString etag() const { return loadFromJson<QString>("etag"_ls); }
+    QString etag() const { return loadFromJson<QString>("etag"_L1); }
 
     //! The number of keys stored in the backup
-    int count() const { return loadFromJson<int>("count"_ls); }
+    int count() const { return loadFromJson<int>("count"_L1); }
 
     struct Response {
         //! The new etag value representing stored keys in the backup.
@@ -350,10 +350,10 @@ public:
 
     //! The new etag value representing stored keys in the backup.
     //! See `GET /room_keys/version/{version}` for more details.
-    QString etag() const { return loadFromJson<QString>("etag"_ls); }
+    QString etag() const { return loadFromJson<QString>("etag"_L1); }
 
     //! The number of keys stored in the backup
-    int count() const { return loadFromJson<int>("count"_ls); }
+    int count() const { return loadFromJson<int>("count"_L1); }
 
     struct Response {
         //! The new etag value representing stored keys in the backup.
@@ -420,10 +420,10 @@ public:
 
     //! The new etag value representing stored keys in the backup.
     //! See `GET /room_keys/version/{version}` for more details.
-    QString etag() const { return loadFromJson<QString>("etag"_ls); }
+    QString etag() const { return loadFromJson<QString>("etag"_L1); }
 
     //! The number of keys stored in the backup
-    int count() const { return loadFromJson<int>("count"_ls); }
+    int count() const { return loadFromJson<int>("count"_L1); }
 
     struct Response {
         //! The new etag value representing stored keys in the backup.
@@ -455,10 +455,10 @@ public:
 
     //! The new etag value representing stored keys in the backup.
     //! See `GET /room_keys/version/{version}` for more details.
-    QString etag() const { return loadFromJson<QString>("etag"_ls); }
+    QString etag() const { return loadFromJson<QString>("etag"_L1); }
 
     //! The number of keys stored in the backup
-    int count() const { return loadFromJson<int>("count"_ls); }
+    int count() const { return loadFromJson<int>("count"_L1); }
 
     struct Response {
         //! The new etag value representing stored keys in the backup.
@@ -494,7 +494,7 @@ public:
     //! A map of room IDs to room key backup data.
     QHash<RoomId, RoomKeyBackup> rooms() const
     {
-        return loadFromJson<QHash<RoomId, RoomKeyBackup>>("rooms"_ls);
+        return loadFromJson<QHash<RoomId, RoomKeyBackup>>("rooms"_L1);
     }
 };
 
@@ -519,10 +519,10 @@ public:
 
     //! The new etag value representing stored keys in the backup.
     //! See `GET /room_keys/version/{version}` for more details.
-    QString etag() const { return loadFromJson<QString>("etag"_ls); }
+    QString etag() const { return loadFromJson<QString>("etag"_L1); }
 
     //! The number of keys stored in the backup
-    int count() const { return loadFromJson<int>("count"_ls); }
+    int count() const { return loadFromJson<int>("count"_L1); }
 
     struct Response {
         //! The new etag value representing stored keys in the backup.

--- a/Quotient/csapi/keys.cpp
+++ b/Quotient/csapi/keys.cpp
@@ -6,35 +6,32 @@ using namespace Quotient;
 
 UploadKeysJob::UploadKeysJob(const std::optional<DeviceKeys>& deviceKeys,
                              const OneTimeKeys& oneTimeKeys, const OneTimeKeys& fallbackKeys)
-    : BaseJob(HttpVerb::Post, QStringLiteral("UploadKeysJob"),
-              makePath("/_matrix/client/v3", "/keys/upload"))
+    : BaseJob(HttpVerb::Post, u"UploadKeysJob"_s, makePath("/_matrix/client/v3", "/keys/upload"))
 {
     QJsonObject _dataJson;
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("device_keys"), deviceKeys);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("one_time_keys"), oneTimeKeys);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("fallback_keys"), fallbackKeys);
+    addParam<IfNotEmpty>(_dataJson, "device_keys"_L1, deviceKeys);
+    addParam<IfNotEmpty>(_dataJson, "one_time_keys"_L1, oneTimeKeys);
+    addParam<IfNotEmpty>(_dataJson, "fallback_keys"_L1, fallbackKeys);
     setRequestData({ _dataJson });
     addExpectedKey("one_time_key_counts");
 }
 
 QueryKeysJob::QueryKeysJob(const QHash<UserId, QStringList>& deviceKeys, std::optional<int> timeout)
-    : BaseJob(HttpVerb::Post, QStringLiteral("QueryKeysJob"),
-              makePath("/_matrix/client/v3", "/keys/query"))
+    : BaseJob(HttpVerb::Post, u"QueryKeysJob"_s, makePath("/_matrix/client/v3", "/keys/query"))
 {
     QJsonObject _dataJson;
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("timeout"), timeout);
-    addParam<>(_dataJson, QStringLiteral("device_keys"), deviceKeys);
+    addParam<IfNotEmpty>(_dataJson, "timeout"_L1, timeout);
+    addParam<>(_dataJson, "device_keys"_L1, deviceKeys);
     setRequestData({ _dataJson });
 }
 
 ClaimKeysJob::ClaimKeysJob(const QHash<UserId, QHash<QString, QString>>& oneTimeKeys,
                            std::optional<int> timeout)
-    : BaseJob(HttpVerb::Post, QStringLiteral("ClaimKeysJob"),
-              makePath("/_matrix/client/v3", "/keys/claim"))
+    : BaseJob(HttpVerb::Post, u"ClaimKeysJob"_s, makePath("/_matrix/client/v3", "/keys/claim"))
 {
     QJsonObject _dataJson;
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("timeout"), timeout);
-    addParam<>(_dataJson, QStringLiteral("one_time_keys"), oneTimeKeys);
+    addParam<IfNotEmpty>(_dataJson, "timeout"_L1, timeout);
+    addParam<>(_dataJson, "one_time_keys"_L1, oneTimeKeys);
     setRequestData({ _dataJson });
     addExpectedKey("one_time_keys");
 }
@@ -42,8 +39,8 @@ ClaimKeysJob::ClaimKeysJob(const QHash<UserId, QHash<QString, QString>>& oneTime
 auto queryToGetKeysChanges(const QString& from, const QString& to)
 {
     QUrlQuery _q;
-    addParam<>(_q, QStringLiteral("from"), from);
-    addParam<>(_q, QStringLiteral("to"), to);
+    addParam<>(_q, u"from"_s, from);
+    addParam<>(_q, u"to"_s, to);
     return _q;
 }
 
@@ -55,6 +52,6 @@ QUrl GetKeysChangesJob::makeRequestUrl(const HomeserverData& hsData, const QStri
 }
 
 GetKeysChangesJob::GetKeysChangesJob(const QString& from, const QString& to)
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetKeysChangesJob"),
+    : BaseJob(HttpVerb::Get, u"GetKeysChangesJob"_s,
               makePath("/_matrix/client/v3", "/keys/changes"), queryToGetKeysChanges(from, to))
 {}

--- a/Quotient/csapi/keys.h
+++ b/Quotient/csapi/keys.h
@@ -54,7 +54,7 @@ public:
     //! is to be assumed zero.
     QHash<QString, int> oneTimeKeyCounts() const
     {
-        return loadFromJson<QHash<QString, int>>("one_time_key_counts"_ls);
+        return loadFromJson<QHash<QString, int>>("one_time_key_counts"_L1);
     }
 };
 
@@ -106,7 +106,7 @@ public:
     //! user or device is missing from the `device_keys` result.
     QHash<QString, QJsonObject> failures() const
     {
-        return loadFromJson<QHash<QString, QJsonObject>>("failures"_ls);
+        return loadFromJson<QHash<QString, QJsonObject>>("failures"_L1);
     }
 
     //! Information on the queried devices. A map from user ID, to a
@@ -116,7 +116,7 @@ public:
     //! property.
     QHash<UserId, QHash<QString, DeviceInformation>> deviceKeys() const
     {
-        return loadFromJson<QHash<UserId, QHash<QString, DeviceInformation>>>("device_keys"_ls);
+        return loadFromJson<QHash<UserId, QHash<QString, DeviceInformation>>>("device_keys"_L1);
     }
 
     //! Information on the master cross-signing keys of the queried users.
@@ -127,7 +127,7 @@ public:
     //! is allowed to see.
     QHash<UserId, CrossSigningKey> masterKeys() const
     {
-        return loadFromJson<QHash<UserId, CrossSigningKey>>("master_keys"_ls);
+        return loadFromJson<QHash<UserId, CrossSigningKey>>("master_keys"_L1);
     }
 
     //! Information on the self-signing keys of the queried users. A map
@@ -136,7 +136,7 @@ public:
     //! `/keys/device_signing/upload`.
     QHash<UserId, CrossSigningKey> selfSigningKeys() const
     {
-        return loadFromJson<QHash<UserId, CrossSigningKey>>("self_signing_keys"_ls);
+        return loadFromJson<QHash<UserId, CrossSigningKey>>("self_signing_keys"_L1);
     }
 
     //! Information on the user-signing key of the user making the
@@ -146,7 +146,7 @@ public:
     //! `/keys/device_signing/upload`.
     QHash<UserId, CrossSigningKey> userSigningKeys() const
     {
-        return loadFromJson<QHash<UserId, CrossSigningKey>>("user_signing_keys"_ls);
+        return loadFromJson<QHash<UserId, CrossSigningKey>>("user_signing_keys"_L1);
     }
 
     struct Response {
@@ -199,7 +199,7 @@ template <>
 struct QUOTIENT_API JsonObjectConverter<QueryKeysJob::UnsignedDeviceInfo> {
     static void fillFrom(const QJsonObject& jo, QueryKeysJob::UnsignedDeviceInfo& result)
     {
-        fillFromJson(jo.value("device_display_name"_ls), result.deviceDisplayName);
+        fillFromJson(jo.value("device_display_name"_L1), result.deviceDisplayName);
     }
 };
 
@@ -208,7 +208,7 @@ struct QUOTIENT_API JsonObjectConverter<QueryKeysJob::DeviceInformation> {
     static void fillFrom(const QJsonObject& jo, QueryKeysJob::DeviceInformation& result)
     {
         fillFromJson<DeviceKeys>(jo, result);
-        fillFromJson(jo.value("unsigned"_ls), result.unsignedData);
+        fillFromJson(jo.value("unsigned"_L1), result.unsignedData);
     }
 };
 
@@ -238,7 +238,7 @@ public:
     //! user or device is missing from the `one_time_keys` result.
     QHash<QString, QJsonObject> failures() const
     {
-        return loadFromJson<QHash<QString, QJsonObject>>("failures"_ls);
+        return loadFromJson<QHash<QString, QJsonObject>>("failures"_L1);
     }
 
     //! One-time keys for the queried devices. A map from user ID, to a
@@ -251,7 +251,7 @@ public:
     //! keys are re-used by the server until replaced by the device.
     QHash<UserId, QHash<QString, OneTimeKeys>> oneTimeKeys() const
     {
-        return loadFromJson<QHash<UserId, QHash<QString, OneTimeKeys>>>("one_time_keys"_ls);
+        return loadFromJson<QHash<UserId, QHash<QString, OneTimeKeys>>>("one_time_keys"_L1);
     }
 
     struct Response {
@@ -317,12 +317,12 @@ public:
 
     //! The Matrix User IDs of all users who updated their device
     //! identity keys.
-    QStringList changed() const { return loadFromJson<QStringList>("changed"_ls); }
+    QStringList changed() const { return loadFromJson<QStringList>("changed"_L1); }
 
     //! The Matrix User IDs of all users who may have left all
     //! the end-to-end encrypted rooms they previously shared
     //! with the user.
-    QStringList left() const { return loadFromJson<QStringList>("left"_ls); }
+    QStringList left() const { return loadFromJson<QStringList>("left"_L1); }
 
     struct Response {
         //! The Matrix User IDs of all users who updated their device

--- a/Quotient/csapi/kicking.cpp
+++ b/Quotient/csapi/kicking.cpp
@@ -5,11 +5,11 @@
 using namespace Quotient;
 
 KickJob::KickJob(const QString& roomId, const QString& userId, const QString& reason)
-    : BaseJob(HttpVerb::Post, QStringLiteral("KickJob"),
+    : BaseJob(HttpVerb::Post, u"KickJob"_s,
               makePath("/_matrix/client/v3", "/rooms/", roomId, "/kick"))
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, QStringLiteral("user_id"), userId);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("reason"), reason);
+    addParam<>(_dataJson, "user_id"_L1, userId);
+    addParam<IfNotEmpty>(_dataJson, "reason"_L1, reason);
     setRequestData({ _dataJson });
 }

--- a/Quotient/csapi/knocking.cpp
+++ b/Quotient/csapi/knocking.cpp
@@ -7,17 +7,17 @@ using namespace Quotient;
 auto queryToKnockRoom(const QStringList& serverName)
 {
     QUrlQuery _q;
-    addParam<IfNotEmpty>(_q, QStringLiteral("server_name"), serverName);
+    addParam<IfNotEmpty>(_q, u"server_name"_s, serverName);
     return _q;
 }
 
 KnockRoomJob::KnockRoomJob(const QString& roomIdOrAlias, const QStringList& serverName,
                            const QString& reason)
-    : BaseJob(HttpVerb::Post, QStringLiteral("KnockRoomJob"),
+    : BaseJob(HttpVerb::Post, u"KnockRoomJob"_s,
               makePath("/_matrix/client/v3", "/knock/", roomIdOrAlias), queryToKnockRoom(serverName))
 {
     QJsonObject _dataJson;
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("reason"), reason);
+    addParam<IfNotEmpty>(_dataJson, "reason"_L1, reason);
     setRequestData({ _dataJson });
     addExpectedKey("room_id");
 }

--- a/Quotient/csapi/knocking.h
+++ b/Quotient/csapi/knocking.h
@@ -41,7 +41,7 @@ public:
     // Result properties
 
     //! The knocked room ID.
-    QString roomId() const { return loadFromJson<QString>("room_id"_ls); }
+    QString roomId() const { return loadFromJson<QString>("room_id"_L1); }
 };
 
 inline auto collectResponse(const KnockRoomJob* job) { return job->roomId(); }

--- a/Quotient/csapi/leaving.cpp
+++ b/Quotient/csapi/leaving.cpp
@@ -5,11 +5,11 @@
 using namespace Quotient;
 
 LeaveRoomJob::LeaveRoomJob(const QString& roomId, const QString& reason)
-    : BaseJob(HttpVerb::Post, QStringLiteral("LeaveRoomJob"),
+    : BaseJob(HttpVerb::Post, u"LeaveRoomJob"_s,
               makePath("/_matrix/client/v3", "/rooms/", roomId, "/leave"))
 {
     QJsonObject _dataJson;
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("reason"), reason);
+    addParam<IfNotEmpty>(_dataJson, "reason"_L1, reason);
     setRequestData({ _dataJson });
 }
 
@@ -20,6 +20,6 @@ QUrl ForgetRoomJob::makeRequestUrl(const HomeserverData& hsData, const QString& 
 }
 
 ForgetRoomJob::ForgetRoomJob(const QString& roomId)
-    : BaseJob(HttpVerb::Post, QStringLiteral("ForgetRoomJob"),
+    : BaseJob(HttpVerb::Post, u"ForgetRoomJob"_s,
               makePath("/_matrix/client/v3", "/rooms/", roomId, "/forget"))
 {}

--- a/Quotient/csapi/list_joined_rooms.cpp
+++ b/Quotient/csapi/list_joined_rooms.cpp
@@ -10,8 +10,7 @@ QUrl GetJoinedRoomsJob::makeRequestUrl(const HomeserverData& hsData)
 }
 
 GetJoinedRoomsJob::GetJoinedRoomsJob()
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetJoinedRoomsJob"),
-              makePath("/_matrix/client/v3", "/joined_rooms"))
+    : BaseJob(HttpVerb::Get, u"GetJoinedRoomsJob"_s, makePath("/_matrix/client/v3", "/joined_rooms"))
 {
     addExpectedKey("joined_rooms");
 }

--- a/Quotient/csapi/list_joined_rooms.h
+++ b/Quotient/csapi/list_joined_rooms.h
@@ -22,7 +22,7 @@ public:
     // Result properties
 
     //! The ID of each room in which the user has `joined` membership.
-    QStringList joinedRooms() const { return loadFromJson<QStringList>("joined_rooms"_ls); }
+    QStringList joinedRooms() const { return loadFromJson<QStringList>("joined_rooms"_L1); }
 };
 
 inline auto collectResponse(const GetJoinedRoomsJob* job) { return job->joinedRooms(); }

--- a/Quotient/csapi/list_public_rooms.cpp
+++ b/Quotient/csapi/list_public_rooms.cpp
@@ -12,26 +12,26 @@ QUrl GetRoomVisibilityOnDirectoryJob::makeRequestUrl(const HomeserverData& hsDat
 }
 
 GetRoomVisibilityOnDirectoryJob::GetRoomVisibilityOnDirectoryJob(const QString& roomId)
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetRoomVisibilityOnDirectoryJob"),
+    : BaseJob(HttpVerb::Get, u"GetRoomVisibilityOnDirectoryJob"_s,
               makePath("/_matrix/client/v3", "/directory/list/room/", roomId), false)
 {}
 
 SetRoomVisibilityOnDirectoryJob::SetRoomVisibilityOnDirectoryJob(const QString& roomId,
                                                                  const QString& visibility)
-    : BaseJob(HttpVerb::Put, QStringLiteral("SetRoomVisibilityOnDirectoryJob"),
+    : BaseJob(HttpVerb::Put, u"SetRoomVisibilityOnDirectoryJob"_s,
               makePath("/_matrix/client/v3", "/directory/list/room/", roomId))
 {
     QJsonObject _dataJson;
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("visibility"), visibility);
+    addParam<IfNotEmpty>(_dataJson, "visibility"_L1, visibility);
     setRequestData({ _dataJson });
 }
 
 auto queryToGetPublicRooms(std::optional<int> limit, const QString& since, const QString& server)
 {
     QUrlQuery _q;
-    addParam<IfNotEmpty>(_q, QStringLiteral("limit"), limit);
-    addParam<IfNotEmpty>(_q, QStringLiteral("since"), since);
-    addParam<IfNotEmpty>(_q, QStringLiteral("server"), server);
+    addParam<IfNotEmpty>(_q, u"limit"_s, limit);
+    addParam<IfNotEmpty>(_q, u"since"_s, since);
+    addParam<IfNotEmpty>(_q, u"server"_s, server);
     return _q;
 }
 
@@ -44,8 +44,7 @@ QUrl GetPublicRoomsJob::makeRequestUrl(const HomeserverData& hsData, std::option
 
 GetPublicRoomsJob::GetPublicRoomsJob(std::optional<int> limit, const QString& since,
                                      const QString& server)
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetPublicRoomsJob"),
-              makePath("/_matrix/client/v3", "/publicRooms"),
+    : BaseJob(HttpVerb::Get, u"GetPublicRoomsJob"_s, makePath("/_matrix/client/v3", "/publicRooms"),
               queryToGetPublicRooms(limit, since, server), {}, false)
 {
     addExpectedKey("chunk");
@@ -54,7 +53,7 @@ GetPublicRoomsJob::GetPublicRoomsJob(std::optional<int> limit, const QString& si
 auto queryToQueryPublicRooms(const QString& server)
 {
     QUrlQuery _q;
-    addParam<IfNotEmpty>(_q, QStringLiteral("server"), server);
+    addParam<IfNotEmpty>(_q, u"server"_s, server);
     return _q;
 }
 
@@ -62,15 +61,15 @@ QueryPublicRoomsJob::QueryPublicRoomsJob(const QString& server, std::optional<in
                                          const QString& since, const std::optional<Filter>& filter,
                                          std::optional<bool> includeAllNetworks,
                                          const QString& thirdPartyInstanceId)
-    : BaseJob(HttpVerb::Post, QStringLiteral("QueryPublicRoomsJob"),
+    : BaseJob(HttpVerb::Post, u"QueryPublicRoomsJob"_s,
               makePath("/_matrix/client/v3", "/publicRooms"), queryToQueryPublicRooms(server))
 {
     QJsonObject _dataJson;
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("limit"), limit);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("since"), since);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("filter"), filter);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("include_all_networks"), includeAllNetworks);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("third_party_instance_id"), thirdPartyInstanceId);
+    addParam<IfNotEmpty>(_dataJson, "limit"_L1, limit);
+    addParam<IfNotEmpty>(_dataJson, "since"_L1, since);
+    addParam<IfNotEmpty>(_dataJson, "filter"_L1, filter);
+    addParam<IfNotEmpty>(_dataJson, "include_all_networks"_L1, includeAllNetworks);
+    addParam<IfNotEmpty>(_dataJson, "third_party_instance_id"_L1, thirdPartyInstanceId);
     setRequestData({ _dataJson });
     addExpectedKey("chunk");
 }

--- a/Quotient/csapi/list_public_rooms.h
+++ b/Quotient/csapi/list_public_rooms.h
@@ -26,7 +26,7 @@ public:
     // Result properties
 
     //! The visibility of the room in the directory.
-    QString visibility() const { return loadFromJson<QString>("visibility"_ls); }
+    QString visibility() const { return loadFromJson<QString>("visibility"_L1); }
 };
 
 inline auto collectResponse(const GetRoomVisibilityOnDirectoryJob* job)
@@ -88,24 +88,24 @@ public:
     //! A paginated chunk of public rooms.
     QVector<PublicRoomsChunk> chunk() const
     {
-        return loadFromJson<QVector<PublicRoomsChunk>>("chunk"_ls);
+        return loadFromJson<QVector<PublicRoomsChunk>>("chunk"_L1);
     }
 
     //! A pagination token for the response. The absence of this token
     //! means there are no more results to fetch and the client should
     //! stop paginating.
-    QString nextBatch() const { return loadFromJson<QString>("next_batch"_ls); }
+    QString nextBatch() const { return loadFromJson<QString>("next_batch"_L1); }
 
     //! A pagination token that allows fetching previous results. The
     //! absence of this token means there are no results before this
     //! batch, i.e. this is the first batch.
-    QString prevBatch() const { return loadFromJson<QString>("prev_batch"_ls); }
+    QString prevBatch() const { return loadFromJson<QString>("prev_batch"_L1); }
 
     //! An estimate on the total number of public rooms, if the
     //! server has an estimate.
     std::optional<int> totalRoomCountEstimate() const
     {
-        return loadFromJson<std::optional<int>>("total_room_count_estimate"_ls);
+        return loadFromJson<std::optional<int>>("total_room_count_estimate"_L1);
     }
 
     struct Response {
@@ -192,24 +192,24 @@ public:
     //! A paginated chunk of public rooms.
     QVector<PublicRoomsChunk> chunk() const
     {
-        return loadFromJson<QVector<PublicRoomsChunk>>("chunk"_ls);
+        return loadFromJson<QVector<PublicRoomsChunk>>("chunk"_L1);
     }
 
     //! A pagination token for the response. The absence of this token
     //! means there are no more results to fetch and the client should
     //! stop paginating.
-    QString nextBatch() const { return loadFromJson<QString>("next_batch"_ls); }
+    QString nextBatch() const { return loadFromJson<QString>("next_batch"_L1); }
 
     //! A pagination token that allows fetching previous results. The
     //! absence of this token means there are no results before this
     //! batch, i.e. this is the first batch.
-    QString prevBatch() const { return loadFromJson<QString>("prev_batch"_ls); }
+    QString prevBatch() const { return loadFromJson<QString>("prev_batch"_L1); }
 
     //! An estimate on the total number of public rooms, if the
     //! server has an estimate.
     std::optional<int> totalRoomCountEstimate() const
     {
-        return loadFromJson<std::optional<int>>("total_room_count_estimate"_ls);
+        return loadFromJson<std::optional<int>>("total_room_count_estimate"_L1);
     }
 
     struct Response {
@@ -241,8 +241,8 @@ template <>
 struct QUOTIENT_API JsonObjectConverter<QueryPublicRoomsJob::Filter> {
     static void dumpTo(QJsonObject& jo, const QueryPublicRoomsJob::Filter& pod)
     {
-        addParam<IfNotEmpty>(jo, QStringLiteral("generic_search_term"), pod.genericSearchTerm);
-        addParam<IfNotEmpty>(jo, QStringLiteral("room_types"), pod.roomTypes);
+        addParam<IfNotEmpty>(jo, "generic_search_term"_L1, pod.genericSearchTerm);
+        addParam<IfNotEmpty>(jo, "room_types"_L1, pod.roomTypes);
     }
 };
 

--- a/Quotient/csapi/login.cpp
+++ b/Quotient/csapi/login.cpp
@@ -10,25 +10,22 @@ QUrl GetLoginFlowsJob::makeRequestUrl(const HomeserverData& hsData)
 }
 
 GetLoginFlowsJob::GetLoginFlowsJob()
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetLoginFlowsJob"),
-              makePath("/_matrix/client/v3", "/login"), false)
+    : BaseJob(HttpVerb::Get, u"GetLoginFlowsJob"_s, makePath("/_matrix/client/v3", "/login"), false)
 {}
 
 LoginJob::LoginJob(const QString& type, const std::optional<UserIdentifier>& identifier,
                    const QString& password, const QString& token, const QString& deviceId,
                    const QString& initialDeviceDisplayName, std::optional<bool> refreshToken)
-    : BaseJob(HttpVerb::Post, QStringLiteral("LoginJob"), makePath("/_matrix/client/v3", "/login"),
-              false)
+    : BaseJob(HttpVerb::Post, u"LoginJob"_s, makePath("/_matrix/client/v3", "/login"), false)
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, QStringLiteral("type"), type);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("identifier"), identifier);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("password"), password);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("token"), token);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("device_id"), deviceId);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("initial_device_display_name"),
-                         initialDeviceDisplayName);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("refresh_token"), refreshToken);
+    addParam<>(_dataJson, "type"_L1, type);
+    addParam<IfNotEmpty>(_dataJson, "identifier"_L1, identifier);
+    addParam<IfNotEmpty>(_dataJson, "password"_L1, password);
+    addParam<IfNotEmpty>(_dataJson, "token"_L1, token);
+    addParam<IfNotEmpty>(_dataJson, "device_id"_L1, deviceId);
+    addParam<IfNotEmpty>(_dataJson, "initial_device_display_name"_L1, initialDeviceDisplayName);
+    addParam<IfNotEmpty>(_dataJson, "refresh_token"_L1, refreshToken);
     setRequestData({ _dataJson });
     addExpectedKey("user_id");
     addExpectedKey("access_token");

--- a/Quotient/csapi/login.h
+++ b/Quotient/csapi/login.h
@@ -44,7 +44,7 @@ public:
     // Result properties
 
     //! The homeserver's supported login types
-    QVector<LoginFlow> flows() const { return loadFromJson<QVector<LoginFlow>>("flows"_ls); }
+    QVector<LoginFlow> flows() const { return loadFromJson<QVector<LoginFlow>>("flows"_L1); }
 };
 
 inline auto collectResponse(const GetLoginFlowsJob* job) { return job->flows(); }
@@ -53,8 +53,8 @@ template <>
 struct QUOTIENT_API JsonObjectConverter<GetLoginFlowsJob::LoginFlow> {
     static void fillFrom(const QJsonObject& jo, GetLoginFlowsJob::LoginFlow& result)
     {
-        fillFromJson(jo.value("type"_ls), result.type);
-        fillFromJson(jo.value("get_login_token"_ls), result.getLoginToken);
+        fillFromJson(jo.value("type"_L1), result.type);
+        fillFromJson(jo.value("get_login_token"_L1), result.getLoginToken);
     }
 };
 
@@ -111,16 +111,16 @@ public:
     // Result properties
 
     //! The fully-qualified Matrix ID for the account.
-    QString userId() const { return loadFromJson<QString>("user_id"_ls); }
+    QString userId() const { return loadFromJson<QString>("user_id"_L1); }
 
     //! An access token for the account.
     //! This access token can then be used to authorize other requests.
-    QString accessToken() const { return loadFromJson<QString>("access_token"_ls); }
+    QString accessToken() const { return loadFromJson<QString>("access_token"_L1); }
 
     //! A refresh token for the account. This token can be used to
     //! obtain a new access token when it expires by calling the
     //! `/refresh` endpoint.
-    QString refreshToken() const { return loadFromJson<QString>("refresh_token"_ls); }
+    QString refreshToken() const { return loadFromJson<QString>("refresh_token"_L1); }
 
     //! The lifetime of the access token, in milliseconds. Once
     //! the access token has expired a new access token can be
@@ -130,12 +130,12 @@ public:
     //! assume that the access token will not expire.
     std::optional<int> expiresInMs() const
     {
-        return loadFromJson<std::optional<int>>("expires_in_ms"_ls);
+        return loadFromJson<std::optional<int>>("expires_in_ms"_L1);
     }
 
     //! ID of the logged-in device. Will be the same as the
     //! corresponding parameter in the request, if one was specified.
-    QString deviceId() const { return loadFromJson<QString>("device_id"_ls); }
+    QString deviceId() const { return loadFromJson<QString>("device_id"_L1); }
 
     //! Optional client configuration provided by the server. If present,
     //! clients SHOULD use the provided object to reconfigure themselves,
@@ -143,7 +143,7 @@ public:
     //! form as the one returned from .well-known autodiscovery.
     std::optional<DiscoveryInformation> wellKnown() const
     {
-        return loadFromJson<std::optional<DiscoveryInformation>>("well_known"_ls);
+        return loadFromJson<std::optional<DiscoveryInformation>>("well_known"_L1);
     }
 
     struct Response {

--- a/Quotient/csapi/login_token.cpp
+++ b/Quotient/csapi/login_token.cpp
@@ -5,11 +5,11 @@
 using namespace Quotient;
 
 GenerateLoginTokenJob::GenerateLoginTokenJob(const std::optional<AuthenticationData>& auth)
-    : BaseJob(HttpVerb::Post, QStringLiteral("GenerateLoginTokenJob"),
+    : BaseJob(HttpVerb::Post, u"GenerateLoginTokenJob"_s,
               makePath("/_matrix/client/v1", "/login/get_token"))
 {
     QJsonObject _dataJson;
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("auth"), auth);
+    addParam<IfNotEmpty>(_dataJson, "auth"_L1, auth);
     setRequestData({ _dataJson });
     addExpectedKey("login_token");
     addExpectedKey("expires_in_ms");

--- a/Quotient/csapi/login_token.h
+++ b/Quotient/csapi/login_token.h
@@ -52,11 +52,11 @@ public:
     // Result properties
 
     //! The login token for the `m.login.token` login flow.
-    QString loginToken() const { return loadFromJson<QString>("login_token"_ls); }
+    QString loginToken() const { return loadFromJson<QString>("login_token"_L1); }
 
     //! The time remaining in milliseconds until the homeserver will no longer accept the token.
     //! `120000` (2 minutes) is recommended as a default.
-    int expiresInMs() const { return loadFromJson<int>("expires_in_ms"_ls); }
+    int expiresInMs() const { return loadFromJson<int>("expires_in_ms"_L1); }
 
     struct Response {
         //! The login token for the `m.login.token` login flow.

--- a/Quotient/csapi/logout.cpp
+++ b/Quotient/csapi/logout.cpp
@@ -10,7 +10,7 @@ QUrl LogoutJob::makeRequestUrl(const HomeserverData& hsData)
 }
 
 LogoutJob::LogoutJob()
-    : BaseJob(HttpVerb::Post, QStringLiteral("LogoutJob"), makePath("/_matrix/client/v3", "/logout"))
+    : BaseJob(HttpVerb::Post, u"LogoutJob"_s, makePath("/_matrix/client/v3", "/logout"))
 {}
 
 QUrl LogoutAllJob::makeRequestUrl(const HomeserverData& hsData)
@@ -19,6 +19,5 @@ QUrl LogoutAllJob::makeRequestUrl(const HomeserverData& hsData)
 }
 
 LogoutAllJob::LogoutAllJob()
-    : BaseJob(HttpVerb::Post, QStringLiteral("LogoutAllJob"),
-              makePath("/_matrix/client/v3", "/logout/all"))
+    : BaseJob(HttpVerb::Post, u"LogoutAllJob"_s, makePath("/_matrix/client/v3", "/logout/all"))
 {}

--- a/Quotient/csapi/message_pagination.cpp
+++ b/Quotient/csapi/message_pagination.cpp
@@ -8,11 +8,11 @@ auto queryToGetRoomEvents(const QString& from, const QString& to, const QString&
                           std::optional<int> limit, const QString& filter)
 {
     QUrlQuery _q;
-    addParam<IfNotEmpty>(_q, QStringLiteral("from"), from);
-    addParam<IfNotEmpty>(_q, QStringLiteral("to"), to);
-    addParam<>(_q, QStringLiteral("dir"), dir);
-    addParam<IfNotEmpty>(_q, QStringLiteral("limit"), limit);
-    addParam<IfNotEmpty>(_q, QStringLiteral("filter"), filter);
+    addParam<IfNotEmpty>(_q, u"from"_s, from);
+    addParam<IfNotEmpty>(_q, u"to"_s, to);
+    addParam<>(_q, u"dir"_s, dir);
+    addParam<IfNotEmpty>(_q, u"limit"_s, limit);
+    addParam<IfNotEmpty>(_q, u"filter"_s, filter);
     return _q;
 }
 
@@ -28,7 +28,7 @@ QUrl GetRoomEventsJob::makeRequestUrl(const HomeserverData& hsData, const QStrin
 GetRoomEventsJob::GetRoomEventsJob(const QString& roomId, const QString& dir, const QString& from,
                                    const QString& to, std::optional<int> limit,
                                    const QString& filter)
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetRoomEventsJob"),
+    : BaseJob(HttpVerb::Get, u"GetRoomEventsJob"_s,
               makePath("/_matrix/client/v3", "/rooms/", roomId, "/messages"),
               queryToGetRoomEvents(from, to, dir, limit, filter))
 {

--- a/Quotient/csapi/message_pagination.h
+++ b/Quotient/csapi/message_pagination.h
@@ -64,7 +64,7 @@ public:
 
     //! A token corresponding to the start of `chunk`. This will be the same as
     //! the value given in `from`.
-    QString begin() const { return loadFromJson<QString>("start"_ls); }
+    QString begin() const { return loadFromJson<QString>("start"_L1); }
 
     //! A token corresponding to the end of `chunk`. This token can be passed
     //! back to this endpoint to request further events.
@@ -73,7 +73,7 @@ public:
     //! reached the start of the timeline, or because the user does
     //! not have permission to see any more events), this property
     //! is omitted from the response.
-    QString end() const { return loadFromJson<QString>("end"_ls); }
+    QString end() const { return loadFromJson<QString>("end"_L1); }
 
     //! A list of room events. The order depends on the `dir` parameter.
     //! For `dir=b` events will be in reverse-chronological order,
@@ -83,7 +83,7 @@ public:
     //! Note that an empty `chunk` does not *necessarily* imply that no more events
     //! are available. Clients should continue to paginate until no `end` property
     //! is returned.
-    RoomEvents chunk() { return takeFromJson<RoomEvents>("chunk"_ls); }
+    RoomEvents chunk() { return takeFromJson<RoomEvents>("chunk"_L1); }
 
     //! A list of state events relevant to showing the `chunk`. For example, if
     //! `lazy_load_members` is enabled in the filter then this may contain
@@ -93,7 +93,7 @@ public:
     //! may remove membership events which would have already been
     //! sent to the client in prior calls to this endpoint, assuming
     //! the membership of those members has not changed.
-    RoomEvents state() { return takeFromJson<RoomEvents>("state"_ls); }
+    RoomEvents state() { return takeFromJson<RoomEvents>("state"_L1); }
 
     struct Response {
         //! A token corresponding to the start of `chunk`. This will be the same as

--- a/Quotient/csapi/notifications.cpp
+++ b/Quotient/csapi/notifications.cpp
@@ -7,9 +7,9 @@ using namespace Quotient;
 auto queryToGetNotifications(const QString& from, std::optional<int> limit, const QString& only)
 {
     QUrlQuery _q;
-    addParam<IfNotEmpty>(_q, QStringLiteral("from"), from);
-    addParam<IfNotEmpty>(_q, QStringLiteral("limit"), limit);
-    addParam<IfNotEmpty>(_q, QStringLiteral("only"), only);
+    addParam<IfNotEmpty>(_q, u"from"_s, from);
+    addParam<IfNotEmpty>(_q, u"limit"_s, limit);
+    addParam<IfNotEmpty>(_q, u"only"_s, only);
     return _q;
 }
 
@@ -22,7 +22,7 @@ QUrl GetNotificationsJob::makeRequestUrl(const HomeserverData& hsData, const QSt
 
 GetNotificationsJob::GetNotificationsJob(const QString& from, std::optional<int> limit,
                                          const QString& only)
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetNotificationsJob"),
+    : BaseJob(HttpVerb::Get, u"GetNotificationsJob"_s,
               makePath("/_matrix/client/v3", "/notifications"),
               queryToGetNotifications(from, limit, only))
 {

--- a/Quotient/csapi/notifications.h
+++ b/Quotient/csapi/notifications.h
@@ -66,12 +66,12 @@ public:
     //! The token to supply in the `from` param of the next
     //! `/notifications` request in order to request more
     //! events. If this is absent, there are no more results.
-    QString nextToken() const { return loadFromJson<QString>("next_token"_ls); }
+    QString nextToken() const { return loadFromJson<QString>("next_token"_L1); }
 
     //! The list of events that triggered notifications.
     std::vector<Notification> notifications()
     {
-        return takeFromJson<std::vector<Notification>>("notifications"_ls);
+        return takeFromJson<std::vector<Notification>>("notifications"_L1);
     }
 
     struct Response {
@@ -93,12 +93,12 @@ template <>
 struct QUOTIENT_API JsonObjectConverter<GetNotificationsJob::Notification> {
     static void fillFrom(const QJsonObject& jo, GetNotificationsJob::Notification& result)
     {
-        fillFromJson(jo.value("actions"_ls), result.actions);
-        fillFromJson(jo.value("event"_ls), result.event);
-        fillFromJson(jo.value("read"_ls), result.read);
-        fillFromJson(jo.value("room_id"_ls), result.roomId);
-        fillFromJson(jo.value("ts"_ls), result.ts);
-        fillFromJson(jo.value("profile_tag"_ls), result.profileTag);
+        fillFromJson(jo.value("actions"_L1), result.actions);
+        fillFromJson(jo.value("event"_L1), result.event);
+        fillFromJson(jo.value("read"_L1), result.read);
+        fillFromJson(jo.value("room_id"_L1), result.roomId);
+        fillFromJson(jo.value("ts"_L1), result.ts);
+        fillFromJson(jo.value("profile_tag"_L1), result.profileTag);
     }
 };
 

--- a/Quotient/csapi/openid.cpp
+++ b/Quotient/csapi/openid.cpp
@@ -5,7 +5,7 @@
 using namespace Quotient;
 
 RequestOpenIdTokenJob::RequestOpenIdTokenJob(const QString& userId, const QJsonObject& dontUse)
-    : BaseJob(HttpVerb::Post, QStringLiteral("RequestOpenIdTokenJob"),
+    : BaseJob(HttpVerb::Post, u"RequestOpenIdTokenJob"_s,
               makePath("/_matrix/client/v3", "/user/", userId, "/openid/request_token"))
 {
     setRequestData({ toJson(dontUse) });

--- a/Quotient/csapi/peeking_events.cpp
+++ b/Quotient/csapi/peeking_events.cpp
@@ -7,9 +7,9 @@ using namespace Quotient;
 auto queryToPeekEvents(const QString& from, std::optional<int> timeout, const QString& roomId)
 {
     QUrlQuery _q;
-    addParam<IfNotEmpty>(_q, QStringLiteral("from"), from);
-    addParam<IfNotEmpty>(_q, QStringLiteral("timeout"), timeout);
-    addParam<IfNotEmpty>(_q, QStringLiteral("room_id"), roomId);
+    addParam<IfNotEmpty>(_q, u"from"_s, from);
+    addParam<IfNotEmpty>(_q, u"timeout"_s, timeout);
+    addParam<IfNotEmpty>(_q, u"room_id"_s, roomId);
     return _q;
 }
 
@@ -21,6 +21,6 @@ QUrl PeekEventsJob::makeRequestUrl(const HomeserverData& hsData, const QString& 
 }
 
 PeekEventsJob::PeekEventsJob(const QString& from, std::optional<int> timeout, const QString& roomId)
-    : BaseJob(HttpVerb::Get, QStringLiteral("PeekEventsJob"),
-              makePath("/_matrix/client/v3", "/events"), queryToPeekEvents(from, timeout, roomId))
+    : BaseJob(HttpVerb::Get, u"PeekEventsJob"_s, makePath("/_matrix/client/v3", "/events"),
+              queryToPeekEvents(from, timeout, roomId))
 {}

--- a/Quotient/csapi/peeking_events.h
+++ b/Quotient/csapi/peeking_events.h
@@ -45,14 +45,14 @@ public:
 
     //! A token which correlates to the first value in `chunk`. This
     //! is usually the same token supplied to `from=`.
-    QString begin() const { return loadFromJson<QString>("start"_ls); }
+    QString begin() const { return loadFromJson<QString>("start"_L1); }
 
     //! A token which correlates to the last value in `chunk`. This
     //! token should be used in the next request to `/events`.
-    QString end() const { return loadFromJson<QString>("end"_ls); }
+    QString end() const { return loadFromJson<QString>("end"_L1); }
 
     //! An array of events.
-    RoomEvents chunk() { return takeFromJson<RoomEvents>("chunk"_ls); }
+    RoomEvents chunk() { return takeFromJson<RoomEvents>("chunk"_L1); }
 
     struct Response {
         //! A token which correlates to the first value in `chunk`. This

--- a/Quotient/csapi/presence.cpp
+++ b/Quotient/csapi/presence.cpp
@@ -6,12 +6,12 @@ using namespace Quotient;
 
 SetPresenceJob::SetPresenceJob(const QString& userId, const QString& presence,
                                const QString& statusMsg)
-    : BaseJob(HttpVerb::Put, QStringLiteral("SetPresenceJob"),
+    : BaseJob(HttpVerb::Put, u"SetPresenceJob"_s,
               makePath("/_matrix/client/v3", "/presence/", userId, "/status"))
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, QStringLiteral("presence"), presence);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("status_msg"), statusMsg);
+    addParam<>(_dataJson, "presence"_L1, presence);
+    addParam<IfNotEmpty>(_dataJson, "status_msg"_L1, statusMsg);
     setRequestData({ _dataJson });
 }
 
@@ -22,7 +22,7 @@ QUrl GetPresenceJob::makeRequestUrl(const HomeserverData& hsData, const QString&
 }
 
 GetPresenceJob::GetPresenceJob(const QString& userId)
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetPresenceJob"),
+    : BaseJob(HttpVerb::Get, u"GetPresenceJob"_s,
               makePath("/_matrix/client/v3", "/presence/", userId, "/status"))
 {
     addExpectedKey("presence");

--- a/Quotient/csapi/presence.h
+++ b/Quotient/csapi/presence.h
@@ -44,22 +44,22 @@ public:
     // Result properties
 
     //! This user's presence.
-    QString presence() const { return loadFromJson<QString>("presence"_ls); }
+    QString presence() const { return loadFromJson<QString>("presence"_L1); }
 
     //! The length of time in milliseconds since an action was performed
     //! by this user.
     std::optional<int> lastActiveAgo() const
     {
-        return loadFromJson<std::optional<int>>("last_active_ago"_ls);
+        return loadFromJson<std::optional<int>>("last_active_ago"_L1);
     }
 
     //! The state message for this user if one was set.
-    QString statusMsg() const { return loadFromJson<QString>("status_msg"_ls); }
+    QString statusMsg() const { return loadFromJson<QString>("status_msg"_L1); }
 
     //! Whether the user is currently active
     std::optional<bool> currentlyActive() const
     {
-        return loadFromJson<std::optional<bool>>("currently_active"_ls);
+        return loadFromJson<std::optional<bool>>("currently_active"_L1);
     }
 
     struct Response {

--- a/Quotient/csapi/profile.cpp
+++ b/Quotient/csapi/profile.cpp
@@ -5,11 +5,11 @@
 using namespace Quotient;
 
 SetDisplayNameJob::SetDisplayNameJob(const QString& userId, const QString& displayname)
-    : BaseJob(HttpVerb::Put, QStringLiteral("SetDisplayNameJob"),
+    : BaseJob(HttpVerb::Put, u"SetDisplayNameJob"_s,
               makePath("/_matrix/client/v3", "/profile/", userId, "/displayname"))
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, QStringLiteral("displayname"), displayname);
+    addParam<>(_dataJson, "displayname"_L1, displayname);
     setRequestData({ _dataJson });
 }
 
@@ -20,16 +20,16 @@ QUrl GetDisplayNameJob::makeRequestUrl(const HomeserverData& hsData, const QStri
 }
 
 GetDisplayNameJob::GetDisplayNameJob(const QString& userId)
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetDisplayNameJob"),
+    : BaseJob(HttpVerb::Get, u"GetDisplayNameJob"_s,
               makePath("/_matrix/client/v3", "/profile/", userId, "/displayname"), false)
 {}
 
 SetAvatarUrlJob::SetAvatarUrlJob(const QString& userId, const QUrl& avatarUrl)
-    : BaseJob(HttpVerb::Put, QStringLiteral("SetAvatarUrlJob"),
+    : BaseJob(HttpVerb::Put, u"SetAvatarUrlJob"_s,
               makePath("/_matrix/client/v3", "/profile/", userId, "/avatar_url"))
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, QStringLiteral("avatar_url"), avatarUrl);
+    addParam<>(_dataJson, "avatar_url"_L1, avatarUrl);
     setRequestData({ _dataJson });
 }
 
@@ -40,7 +40,7 @@ QUrl GetAvatarUrlJob::makeRequestUrl(const HomeserverData& hsData, const QString
 }
 
 GetAvatarUrlJob::GetAvatarUrlJob(const QString& userId)
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetAvatarUrlJob"),
+    : BaseJob(HttpVerb::Get, u"GetAvatarUrlJob"_s,
               makePath("/_matrix/client/v3", "/profile/", userId, "/avatar_url"), false)
 {}
 
@@ -50,6 +50,6 @@ QUrl GetUserProfileJob::makeRequestUrl(const HomeserverData& hsData, const QStri
 }
 
 GetUserProfileJob::GetUserProfileJob(const QString& userId)
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetUserProfileJob"),
+    : BaseJob(HttpVerb::Get, u"GetUserProfileJob"_s,
               makePath("/_matrix/client/v3", "/profile/", userId), false)
 {}

--- a/Quotient/csapi/profile.h
+++ b/Quotient/csapi/profile.h
@@ -40,7 +40,7 @@ public:
     // Result properties
 
     //! The user's display name if they have set one, otherwise not present.
-    QString displayname() const { return loadFromJson<QString>("displayname"_ls); }
+    QString displayname() const { return loadFromJson<QString>("displayname"_L1); }
 };
 
 inline auto collectResponse(const GetDisplayNameJob* job) { return job->displayname(); }
@@ -79,7 +79,7 @@ public:
     // Result properties
 
     //! The user's avatar URL if they have set one, otherwise not present.
-    QUrl avatarUrl() const { return loadFromJson<QUrl>("avatar_url"_ls); }
+    QUrl avatarUrl() const { return loadFromJson<QUrl>("avatar_url"_L1); }
 };
 
 inline auto collectResponse(const GetAvatarUrlJob* job) { return job->avatarUrl(); }
@@ -105,10 +105,10 @@ public:
     // Result properties
 
     //! The user's avatar URL if they have set one, otherwise not present.
-    QUrl avatarUrl() const { return loadFromJson<QUrl>("avatar_url"_ls); }
+    QUrl avatarUrl() const { return loadFromJson<QUrl>("avatar_url"_L1); }
 
     //! The user's display name if they have set one, otherwise not present.
-    QString displayname() const { return loadFromJson<QString>("displayname"_ls); }
+    QString displayname() const { return loadFromJson<QString>("displayname"_L1); }
 
     struct Response {
         //! The user's avatar URL if they have set one, otherwise not present.

--- a/Quotient/csapi/pusher.cpp
+++ b/Quotient/csapi/pusher.cpp
@@ -10,26 +10,24 @@ QUrl GetPushersJob::makeRequestUrl(const HomeserverData& hsData)
 }
 
 GetPushersJob::GetPushersJob()
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetPushersJob"),
-              makePath("/_matrix/client/v3", "/pushers"))
+    : BaseJob(HttpVerb::Get, u"GetPushersJob"_s, makePath("/_matrix/client/v3", "/pushers"))
 {}
 
 PostPusherJob::PostPusherJob(const QString& pushkey, const QString& kind, const QString& appId,
                              const QString& appDisplayName, const QString& deviceDisplayName,
                              const QString& profileTag, const QString& lang,
                              const std::optional<PusherData>& data, std::optional<bool> append)
-    : BaseJob(HttpVerb::Post, QStringLiteral("PostPusherJob"),
-              makePath("/_matrix/client/v3", "/pushers/set"))
+    : BaseJob(HttpVerb::Post, u"PostPusherJob"_s, makePath("/_matrix/client/v3", "/pushers/set"))
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, QStringLiteral("pushkey"), pushkey);
-    addParam<>(_dataJson, QStringLiteral("kind"), kind);
-    addParam<>(_dataJson, QStringLiteral("app_id"), appId);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("app_display_name"), appDisplayName);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("device_display_name"), deviceDisplayName);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("profile_tag"), profileTag);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("lang"), lang);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("data"), data);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("append"), append);
+    addParam<>(_dataJson, "pushkey"_L1, pushkey);
+    addParam<>(_dataJson, "kind"_L1, kind);
+    addParam<>(_dataJson, "app_id"_L1, appId);
+    addParam<IfNotEmpty>(_dataJson, "app_display_name"_L1, appDisplayName);
+    addParam<IfNotEmpty>(_dataJson, "device_display_name"_L1, deviceDisplayName);
+    addParam<IfNotEmpty>(_dataJson, "profile_tag"_L1, profileTag);
+    addParam<IfNotEmpty>(_dataJson, "lang"_L1, lang);
+    addParam<IfNotEmpty>(_dataJson, "data"_L1, data);
+    addParam<IfNotEmpty>(_dataJson, "append"_L1, append);
     setRequestData({ _dataJson });
 }

--- a/Quotient/csapi/pusher.h
+++ b/Quotient/csapi/pusher.h
@@ -73,7 +73,7 @@ public:
     // Result properties
 
     //! An array containing the current pushers for the user
-    QVector<Pusher> pushers() const { return loadFromJson<QVector<Pusher>>("pushers"_ls); }
+    QVector<Pusher> pushers() const { return loadFromJson<QVector<Pusher>>("pushers"_L1); }
 };
 
 inline auto collectResponse(const GetPushersJob* job) { return job->pushers(); }
@@ -82,8 +82,8 @@ template <>
 struct QUOTIENT_API JsonObjectConverter<GetPushersJob::PusherData> {
     static void fillFrom(const QJsonObject& jo, GetPushersJob::PusherData& result)
     {
-        fillFromJson(jo.value("url"_ls), result.url);
-        fillFromJson(jo.value("format"_ls), result.format);
+        fillFromJson(jo.value("url"_L1), result.url);
+        fillFromJson(jo.value("format"_L1), result.format);
     }
 };
 
@@ -91,14 +91,14 @@ template <>
 struct QUOTIENT_API JsonObjectConverter<GetPushersJob::Pusher> {
     static void fillFrom(const QJsonObject& jo, GetPushersJob::Pusher& result)
     {
-        fillFromJson(jo.value("pushkey"_ls), result.pushkey);
-        fillFromJson(jo.value("kind"_ls), result.kind);
-        fillFromJson(jo.value("app_id"_ls), result.appId);
-        fillFromJson(jo.value("app_display_name"_ls), result.appDisplayName);
-        fillFromJson(jo.value("device_display_name"_ls), result.deviceDisplayName);
-        fillFromJson(jo.value("lang"_ls), result.lang);
-        fillFromJson(jo.value("data"_ls), result.data);
-        fillFromJson(jo.value("profile_tag"_ls), result.profileTag);
+        fillFromJson(jo.value("pushkey"_L1), result.pushkey);
+        fillFromJson(jo.value("kind"_L1), result.kind);
+        fillFromJson(jo.value("app_id"_L1), result.appId);
+        fillFromJson(jo.value("app_display_name"_L1), result.appDisplayName);
+        fillFromJson(jo.value("device_display_name"_L1), result.deviceDisplayName);
+        fillFromJson(jo.value("lang"_L1), result.lang);
+        fillFromJson(jo.value("data"_L1), result.data);
+        fillFromJson(jo.value("profile_tag"_L1), result.profileTag);
     }
 };
 
@@ -199,8 +199,8 @@ template <>
 struct QUOTIENT_API JsonObjectConverter<PostPusherJob::PusherData> {
     static void dumpTo(QJsonObject& jo, const PostPusherJob::PusherData& pod)
     {
-        addParam<IfNotEmpty>(jo, QStringLiteral("url"), pod.url);
-        addParam<IfNotEmpty>(jo, QStringLiteral("format"), pod.format);
+        addParam<IfNotEmpty>(jo, "url"_L1, pod.url);
+        addParam<IfNotEmpty>(jo, "format"_L1, pod.format);
     }
 };
 

--- a/Quotient/csapi/pushrules.cpp
+++ b/Quotient/csapi/pushrules.cpp
@@ -10,8 +10,7 @@ QUrl GetPushRulesJob::makeRequestUrl(const HomeserverData& hsData)
 }
 
 GetPushRulesJob::GetPushRulesJob()
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetPushRulesJob"),
-              makePath("/_matrix/client/v3", "/pushrules"))
+    : BaseJob(HttpVerb::Get, u"GetPushRulesJob"_s, makePath("/_matrix/client/v3", "/pushrules"))
 {
     addExpectedKey("global");
 }
@@ -24,7 +23,7 @@ QUrl GetPushRuleJob::makeRequestUrl(const HomeserverData& hsData, const QString&
 }
 
 GetPushRuleJob::GetPushRuleJob(const QString& scope, const QString& kind, const QString& ruleId)
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetPushRuleJob"),
+    : BaseJob(HttpVerb::Get, u"GetPushRuleJob"_s,
               makePath("/_matrix/client/v3", "/pushrules/", scope, "/", kind, "/", ruleId))
 {}
 
@@ -37,15 +36,15 @@ QUrl DeletePushRuleJob::makeRequestUrl(const HomeserverData& hsData, const QStri
 
 DeletePushRuleJob::DeletePushRuleJob(const QString& scope, const QString& kind,
                                      const QString& ruleId)
-    : BaseJob(HttpVerb::Delete, QStringLiteral("DeletePushRuleJob"),
+    : BaseJob(HttpVerb::Delete, u"DeletePushRuleJob"_s,
               makePath("/_matrix/client/v3", "/pushrules/", scope, "/", kind, "/", ruleId))
 {}
 
 auto queryToSetPushRule(const QString& before, const QString& after)
 {
     QUrlQuery _q;
-    addParam<IfNotEmpty>(_q, QStringLiteral("before"), before);
-    addParam<IfNotEmpty>(_q, QStringLiteral("after"), after);
+    addParam<IfNotEmpty>(_q, u"before"_s, before);
+    addParam<IfNotEmpty>(_q, u"after"_s, after);
     return _q;
 }
 
@@ -53,14 +52,14 @@ SetPushRuleJob::SetPushRuleJob(const QString& scope, const QString& kind, const 
                                const QVector<QVariant>& actions, const QString& before,
                                const QString& after, const QVector<PushCondition>& conditions,
                                const QString& pattern)
-    : BaseJob(HttpVerb::Put, QStringLiteral("SetPushRuleJob"),
+    : BaseJob(HttpVerb::Put, u"SetPushRuleJob"_s,
               makePath("/_matrix/client/v3", "/pushrules/", scope, "/", kind, "/", ruleId),
               queryToSetPushRule(before, after))
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, QStringLiteral("actions"), actions);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("conditions"), conditions);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("pattern"), pattern);
+    addParam<>(_dataJson, "actions"_L1, actions);
+    addParam<IfNotEmpty>(_dataJson, "conditions"_L1, conditions);
+    addParam<IfNotEmpty>(_dataJson, "pattern"_L1, pattern);
     setRequestData({ _dataJson });
 }
 
@@ -73,7 +72,7 @@ QUrl IsPushRuleEnabledJob::makeRequestUrl(const HomeserverData& hsData, const QS
 
 IsPushRuleEnabledJob::IsPushRuleEnabledJob(const QString& scope, const QString& kind,
                                            const QString& ruleId)
-    : BaseJob(HttpVerb::Get, QStringLiteral("IsPushRuleEnabledJob"),
+    : BaseJob(HttpVerb::Get, u"IsPushRuleEnabledJob"_s,
               makePath("/_matrix/client/v3", "/pushrules/", scope, "/", kind, "/", ruleId,
                        "/enabled"))
 {
@@ -82,12 +81,12 @@ IsPushRuleEnabledJob::IsPushRuleEnabledJob(const QString& scope, const QString& 
 
 SetPushRuleEnabledJob::SetPushRuleEnabledJob(const QString& scope, const QString& kind,
                                              const QString& ruleId, bool enabled)
-    : BaseJob(HttpVerb::Put, QStringLiteral("SetPushRuleEnabledJob"),
+    : BaseJob(HttpVerb::Put, u"SetPushRuleEnabledJob"_s,
               makePath("/_matrix/client/v3", "/pushrules/", scope, "/", kind, "/", ruleId,
                        "/enabled"))
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, QStringLiteral("enabled"), enabled);
+    addParam<>(_dataJson, "enabled"_L1, enabled);
     setRequestData({ _dataJson });
 }
 
@@ -100,7 +99,7 @@ QUrl GetPushRuleActionsJob::makeRequestUrl(const HomeserverData& hsData, const Q
 
 GetPushRuleActionsJob::GetPushRuleActionsJob(const QString& scope, const QString& kind,
                                              const QString& ruleId)
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetPushRuleActionsJob"),
+    : BaseJob(HttpVerb::Get, u"GetPushRuleActionsJob"_s,
               makePath("/_matrix/client/v3", "/pushrules/", scope, "/", kind, "/", ruleId,
                        "/actions"))
 {
@@ -109,11 +108,11 @@ GetPushRuleActionsJob::GetPushRuleActionsJob(const QString& scope, const QString
 
 SetPushRuleActionsJob::SetPushRuleActionsJob(const QString& scope, const QString& kind,
                                              const QString& ruleId, const QVector<QVariant>& actions)
-    : BaseJob(HttpVerb::Put, QStringLiteral("SetPushRuleActionsJob"),
+    : BaseJob(HttpVerb::Put, u"SetPushRuleActionsJob"_s,
               makePath("/_matrix/client/v3", "/pushrules/", scope, "/", kind, "/", ruleId,
                        "/actions"))
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, QStringLiteral("actions"), actions);
+    addParam<>(_dataJson, "actions"_L1, actions);
     setRequestData({ _dataJson });
 }

--- a/Quotient/csapi/pushrules.h
+++ b/Quotient/csapi/pushrules.h
@@ -29,7 +29,7 @@ public:
     // Result properties
 
     //! The global ruleset.
-    PushRuleset global() const { return loadFromJson<PushRuleset>("global"_ls); }
+    PushRuleset global() const { return loadFromJson<PushRuleset>("global"_L1); }
 };
 
 inline auto collectResponse(const GetPushRulesJob* job) { return job->global(); }
@@ -171,7 +171,7 @@ public:
     // Result properties
 
     //! Whether the push rule is enabled or not.
-    bool enabled() const { return loadFromJson<bool>("enabled"_ls); }
+    bool enabled() const { return loadFromJson<bool>("enabled"_L1); }
 };
 
 inline auto collectResponse(const IsPushRuleEnabledJob* job) { return job->enabled(); }
@@ -222,7 +222,7 @@ public:
     // Result properties
 
     //! The action(s) to perform for this rule.
-    QVector<QVariant> actions() const { return loadFromJson<QVector<QVariant>>("actions"_ls); }
+    QVector<QVariant> actions() const { return loadFromJson<QVector<QVariant>>("actions"_L1); }
 };
 
 inline auto collectResponse(const GetPushRuleActionsJob* job) { return job->actions(); }

--- a/Quotient/csapi/read_markers.cpp
+++ b/Quotient/csapi/read_markers.cpp
@@ -6,12 +6,12 @@ using namespace Quotient;
 
 SetReadMarkerJob::SetReadMarkerJob(const QString& roomId, const QString& mFullyRead,
                                    const QString& mRead, const QString& mReadPrivate)
-    : BaseJob(HttpVerb::Post, QStringLiteral("SetReadMarkerJob"),
+    : BaseJob(HttpVerb::Post, u"SetReadMarkerJob"_s,
               makePath("/_matrix/client/v3", "/rooms/", roomId, "/read_markers"))
 {
     QJsonObject _dataJson;
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("m.fully_read"), mFullyRead);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("m.read"), mRead);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("m.read.private"), mReadPrivate);
+    addParam<IfNotEmpty>(_dataJson, "m.fully_read"_L1, mFullyRead);
+    addParam<IfNotEmpty>(_dataJson, "m.read"_L1, mRead);
+    addParam<IfNotEmpty>(_dataJson, "m.read.private"_L1, mReadPrivate);
     setRequestData({ _dataJson });
 }

--- a/Quotient/csapi/receipts.cpp
+++ b/Quotient/csapi/receipts.cpp
@@ -6,11 +6,11 @@ using namespace Quotient;
 
 PostReceiptJob::PostReceiptJob(const QString& roomId, const QString& receiptType,
                                const QString& eventId, const QString& threadId)
-    : BaseJob(HttpVerb::Post, QStringLiteral("PostReceiptJob"),
+    : BaseJob(HttpVerb::Post, u"PostReceiptJob"_s,
               makePath("/_matrix/client/v3", "/rooms/", roomId, "/receipt/", receiptType, "/",
                        eventId))
 {
     QJsonObject _dataJson;
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("thread_id"), threadId);
+    addParam<IfNotEmpty>(_dataJson, "thread_id"_L1, threadId);
     setRequestData({ _dataJson });
 }

--- a/Quotient/csapi/redaction.cpp
+++ b/Quotient/csapi/redaction.cpp
@@ -6,10 +6,10 @@ using namespace Quotient;
 
 RedactEventJob::RedactEventJob(const QString& roomId, const QString& eventId, const QString& txnId,
                                const QString& reason)
-    : BaseJob(HttpVerb::Put, QStringLiteral("RedactEventJob"),
+    : BaseJob(HttpVerb::Put, u"RedactEventJob"_s,
               makePath("/_matrix/client/v3", "/rooms/", roomId, "/redact/", eventId, "/", txnId))
 {
     QJsonObject _dataJson;
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("reason"), reason);
+    addParam<IfNotEmpty>(_dataJson, "reason"_L1, reason);
     setRequestData({ _dataJson });
 }

--- a/Quotient/csapi/redaction.h
+++ b/Quotient/csapi/redaction.h
@@ -40,7 +40,7 @@ public:
     // Result properties
 
     //! A unique identifier for the event.
-    QString eventId() const { return loadFromJson<QString>("event_id"_ls); }
+    QString eventId() const { return loadFromJson<QString>("event_id"_L1); }
 };
 
 inline auto collectResponse(const RedactEventJob* job) { return job->eventId(); }

--- a/Quotient/csapi/refresh.cpp
+++ b/Quotient/csapi/refresh.cpp
@@ -5,11 +5,10 @@
 using namespace Quotient;
 
 RefreshJob::RefreshJob(const QString& refreshToken)
-    : BaseJob(HttpVerb::Post, QStringLiteral("RefreshJob"),
-              makePath("/_matrix/client/v3", "/refresh"), false)
+    : BaseJob(HttpVerb::Post, u"RefreshJob"_s, makePath("/_matrix/client/v3", "/refresh"), false)
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, QStringLiteral("refresh_token"), refreshToken);
+    addParam<>(_dataJson, "refresh_token"_L1, refreshToken);
     setRequestData({ _dataJson });
     addExpectedKey("access_token");
 }

--- a/Quotient/csapi/refresh.h
+++ b/Quotient/csapi/refresh.h
@@ -34,19 +34,19 @@ public:
     // Result properties
 
     //! The new access token to use.
-    QString accessToken() const { return loadFromJson<QString>("access_token"_ls); }
+    QString accessToken() const { return loadFromJson<QString>("access_token"_L1); }
 
     //! The new refresh token to use when the access token needs to
     //! be refreshed again. If not given, the old refresh token can
     //! be re-used.
-    QString refreshToken() const { return loadFromJson<QString>("refresh_token"_ls); }
+    QString refreshToken() const { return loadFromJson<QString>("refresh_token"_L1); }
 
     //! The lifetime of the access token, in milliseconds. If not
     //! given, the client can assume that the access token will not
     //! expire.
     std::optional<int> expiresInMs() const
     {
-        return loadFromJson<std::optional<int>>("expires_in_ms"_ls);
+        return loadFromJson<std::optional<int>>("expires_in_ms"_L1);
     }
 
     struct Response {

--- a/Quotient/csapi/registration.cpp
+++ b/Quotient/csapi/registration.cpp
@@ -7,7 +7,7 @@ using namespace Quotient;
 auto queryToRegister(const QString& kind)
 {
     QUrlQuery _q;
-    addParam<IfNotEmpty>(_q, QStringLiteral("kind"), kind);
+    addParam<IfNotEmpty>(_q, u"kind"_s, kind);
     return _q;
 }
 
@@ -15,31 +15,30 @@ RegisterJob::RegisterJob(const QString& kind, const std::optional<Authentication
                          const QString& username, const QString& password, const QString& deviceId,
                          const QString& initialDeviceDisplayName, std::optional<bool> inhibitLogin,
                          std::optional<bool> refreshToken)
-    : BaseJob(HttpVerb::Post, QStringLiteral("RegisterJob"),
-              makePath("/_matrix/client/v3", "/register"), queryToRegister(kind), {}, false)
+    : BaseJob(HttpVerb::Post, u"RegisterJob"_s, makePath("/_matrix/client/v3", "/register"),
+              queryToRegister(kind), {}, false)
 {
     QJsonObject _dataJson;
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("auth"), auth);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("username"), username);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("password"), password);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("device_id"), deviceId);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("initial_device_display_name"),
-                         initialDeviceDisplayName);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("inhibit_login"), inhibitLogin);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("refresh_token"), refreshToken);
+    addParam<IfNotEmpty>(_dataJson, "auth"_L1, auth);
+    addParam<IfNotEmpty>(_dataJson, "username"_L1, username);
+    addParam<IfNotEmpty>(_dataJson, "password"_L1, password);
+    addParam<IfNotEmpty>(_dataJson, "device_id"_L1, deviceId);
+    addParam<IfNotEmpty>(_dataJson, "initial_device_display_name"_L1, initialDeviceDisplayName);
+    addParam<IfNotEmpty>(_dataJson, "inhibit_login"_L1, inhibitLogin);
+    addParam<IfNotEmpty>(_dataJson, "refresh_token"_L1, refreshToken);
     setRequestData({ _dataJson });
     addExpectedKey("user_id");
 }
 
 RequestTokenToRegisterEmailJob::RequestTokenToRegisterEmailJob(const EmailValidationData& data)
-    : BaseJob(HttpVerb::Post, QStringLiteral("RequestTokenToRegisterEmailJob"),
+    : BaseJob(HttpVerb::Post, u"RequestTokenToRegisterEmailJob"_s,
               makePath("/_matrix/client/v3", "/register/email/requestToken"), false)
 {
     setRequestData({ toJson(data) });
 }
 
 RequestTokenToRegisterMSISDNJob::RequestTokenToRegisterMSISDNJob(const MsisdnValidationData& data)
-    : BaseJob(HttpVerb::Post, QStringLiteral("RequestTokenToRegisterMSISDNJob"),
+    : BaseJob(HttpVerb::Post, u"RequestTokenToRegisterMSISDNJob"_s,
               makePath("/_matrix/client/v3", "/register/msisdn/requestToken"), false)
 {
     setRequestData({ toJson(data) });
@@ -47,19 +46,19 @@ RequestTokenToRegisterMSISDNJob::RequestTokenToRegisterMSISDNJob(const MsisdnVal
 
 ChangePasswordJob::ChangePasswordJob(const QString& newPassword, bool logoutDevices,
                                      const std::optional<AuthenticationData>& auth)
-    : BaseJob(HttpVerb::Post, QStringLiteral("ChangePasswordJob"),
+    : BaseJob(HttpVerb::Post, u"ChangePasswordJob"_s,
               makePath("/_matrix/client/v3", "/account/password"))
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, QStringLiteral("new_password"), newPassword);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("logout_devices"), logoutDevices);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("auth"), auth);
+    addParam<>(_dataJson, "new_password"_L1, newPassword);
+    addParam<IfNotEmpty>(_dataJson, "logout_devices"_L1, logoutDevices);
+    addParam<IfNotEmpty>(_dataJson, "auth"_L1, auth);
     setRequestData({ _dataJson });
 }
 
 RequestTokenToResetPasswordEmailJob::RequestTokenToResetPasswordEmailJob(
     const EmailValidationData& data)
-    : BaseJob(HttpVerb::Post, QStringLiteral("RequestTokenToResetPasswordEmailJob"),
+    : BaseJob(HttpVerb::Post, u"RequestTokenToResetPasswordEmailJob"_s,
               makePath("/_matrix/client/v3", "/account/password/email/requestToken"), false)
 {
     setRequestData({ toJson(data) });
@@ -67,7 +66,7 @@ RequestTokenToResetPasswordEmailJob::RequestTokenToResetPasswordEmailJob(
 
 RequestTokenToResetPasswordMSISDNJob::RequestTokenToResetPasswordMSISDNJob(
     const MsisdnValidationData& data)
-    : BaseJob(HttpVerb::Post, QStringLiteral("RequestTokenToResetPasswordMSISDNJob"),
+    : BaseJob(HttpVerb::Post, u"RequestTokenToResetPasswordMSISDNJob"_s,
               makePath("/_matrix/client/v3", "/account/password/msisdn/requestToken"), false)
 {
     setRequestData({ toJson(data) });
@@ -75,13 +74,13 @@ RequestTokenToResetPasswordMSISDNJob::RequestTokenToResetPasswordMSISDNJob(
 
 DeactivateAccountJob::DeactivateAccountJob(const std::optional<AuthenticationData>& auth,
                                            const QString& idServer, std::optional<bool> erase)
-    : BaseJob(HttpVerb::Post, QStringLiteral("DeactivateAccountJob"),
+    : BaseJob(HttpVerb::Post, u"DeactivateAccountJob"_s,
               makePath("/_matrix/client/v3", "/account/deactivate"))
 {
     QJsonObject _dataJson;
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("auth"), auth);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("id_server"), idServer);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("erase"), erase);
+    addParam<IfNotEmpty>(_dataJson, "auth"_L1, auth);
+    addParam<IfNotEmpty>(_dataJson, "id_server"_L1, idServer);
+    addParam<IfNotEmpty>(_dataJson, "erase"_L1, erase);
     setRequestData({ _dataJson });
     addExpectedKey("id_server_unbind_result");
 }
@@ -89,7 +88,7 @@ DeactivateAccountJob::DeactivateAccountJob(const std::optional<AuthenticationDat
 auto queryToCheckUsernameAvailability(const QString& username)
 {
     QUrlQuery _q;
-    addParam<>(_q, QStringLiteral("username"), username);
+    addParam<>(_q, u"username"_s, username);
     return _q;
 }
 
@@ -101,7 +100,7 @@ QUrl CheckUsernameAvailabilityJob::makeRequestUrl(const HomeserverData& hsData,
 }
 
 CheckUsernameAvailabilityJob::CheckUsernameAvailabilityJob(const QString& username)
-    : BaseJob(HttpVerb::Get, QStringLiteral("CheckUsernameAvailabilityJob"),
+    : BaseJob(HttpVerb::Get, u"CheckUsernameAvailabilityJob"_s,
               makePath("/_matrix/client/v3", "/register/available"),
               queryToCheckUsernameAvailability(username), {}, false)
 {}

--- a/Quotient/csapi/registration.h
+++ b/Quotient/csapi/registration.h
@@ -90,7 +90,7 @@ public:
     //!
     //! \param refreshToken
     //!   If true, the client supports refresh tokens.
-    explicit RegisterJob(const QString& kind = QStringLiteral("user"),
+    explicit RegisterJob(const QString& kind = u"user"_s,
                          const std::optional<AuthenticationData>& auth = std::nullopt,
                          const QString& username = {}, const QString& password = {},
                          const QString& deviceId = {}, const QString& initialDeviceDisplayName = {},
@@ -103,19 +103,19 @@ public:
     //!
     //! Any user ID returned by this API must conform to the grammar given in the
     //! [Matrix specification](/appendices/#user-identifiers).
-    QString userId() const { return loadFromJson<QString>("user_id"_ls); }
+    QString userId() const { return loadFromJson<QString>("user_id"_L1); }
 
     //! An access token for the account.
     //! This access token can then be used to authorize other requests.
     //! Required if the `inhibit_login` option is false.
-    QString accessToken() const { return loadFromJson<QString>("access_token"_ls); }
+    QString accessToken() const { return loadFromJson<QString>("access_token"_L1); }
 
     //! A refresh token for the account. This token can be used to
     //! obtain a new access token when it expires by calling the
     //! `/refresh` endpoint.
     //!
     //! Omitted if the `inhibit_login` option is true.
-    QString refreshToken() const { return loadFromJson<QString>("refresh_token"_ls); }
+    QString refreshToken() const { return loadFromJson<QString>("refresh_token"_L1); }
 
     //! The lifetime of the access token, in milliseconds. Once
     //! the access token has expired a new access token can be
@@ -127,13 +127,13 @@ public:
     //! Omitted if the `inhibit_login` option is true.
     std::optional<int> expiresInMs() const
     {
-        return loadFromJson<std::optional<int>>("expires_in_ms"_ls);
+        return loadFromJson<std::optional<int>>("expires_in_ms"_L1);
     }
 
     //! ID of the registered device. Will be the same as the
     //! corresponding parameter in the request, if one was specified.
     //! Required if the `inhibit_login` option is false.
-    QString deviceId() const { return loadFromJson<QString>("device_id"_ls); }
+    QString deviceId() const { return loadFromJson<QString>("device_id"_L1); }
 
     struct Response {
         //! The fully-qualified Matrix user ID (MXID) that has been registered.
@@ -380,7 +380,7 @@ public:
     //! for the user.
     QString idServerUnbindResult() const
     {
-        return loadFromJson<QString>("id_server_unbind_result"_ls);
+        return loadFromJson<QString>("id_server_unbind_result"_L1);
     }
 };
 
@@ -418,7 +418,7 @@ public:
     //! be `true` when the server replies with 200 OK.
     std::optional<bool> available() const
     {
-        return loadFromJson<std::optional<bool>>("available"_ls);
+        return loadFromJson<std::optional<bool>>("available"_L1);
     }
 };
 

--- a/Quotient/csapi/registration_tokens.cpp
+++ b/Quotient/csapi/registration_tokens.cpp
@@ -7,7 +7,7 @@ using namespace Quotient;
 auto queryToRegistrationTokenValidity(const QString& token)
 {
     QUrlQuery _q;
-    addParam<>(_q, QStringLiteral("token"), token);
+    addParam<>(_q, u"token"_s, token);
     return _q;
 }
 
@@ -20,7 +20,7 @@ QUrl RegistrationTokenValidityJob::makeRequestUrl(const HomeserverData& hsData, 
 }
 
 RegistrationTokenValidityJob::RegistrationTokenValidityJob(const QString& token)
-    : BaseJob(HttpVerb::Get, QStringLiteral("RegistrationTokenValidityJob"),
+    : BaseJob(HttpVerb::Get, u"RegistrationTokenValidityJob"_s,
               makePath("/_matrix/client/v1", "/register/m.login.registration_token/validity"),
               queryToRegistrationTokenValidity(token), {}, false)
 {

--- a/Quotient/csapi/registration_tokens.h
+++ b/Quotient/csapi/registration_tokens.h
@@ -31,7 +31,7 @@ public:
     //! True if the token is still valid, false otherwise. This should
     //! additionally be false if the token is not a recognised token by
     //! the server.
-    bool valid() const { return loadFromJson<bool>("valid"_ls); }
+    bool valid() const { return loadFromJson<bool>("valid"_L1); }
 };
 
 inline auto collectResponse(const RegistrationTokenValidityJob* job) { return job->valid(); }

--- a/Quotient/csapi/relations.cpp
+++ b/Quotient/csapi/relations.cpp
@@ -8,11 +8,11 @@ auto queryToGetRelatingEvents(const QString& from, const QString& to, std::optio
                               const QString& dir, std::optional<bool> recurse)
 {
     QUrlQuery _q;
-    addParam<IfNotEmpty>(_q, QStringLiteral("from"), from);
-    addParam<IfNotEmpty>(_q, QStringLiteral("to"), to);
-    addParam<IfNotEmpty>(_q, QStringLiteral("limit"), limit);
-    addParam<IfNotEmpty>(_q, QStringLiteral("dir"), dir);
-    addParam<IfNotEmpty>(_q, QStringLiteral("recurse"), recurse);
+    addParam<IfNotEmpty>(_q, u"from"_s, from);
+    addParam<IfNotEmpty>(_q, u"to"_s, to);
+    addParam<IfNotEmpty>(_q, u"limit"_s, limit);
+    addParam<IfNotEmpty>(_q, u"dir"_s, dir);
+    addParam<IfNotEmpty>(_q, u"recurse"_s, recurse);
     return _q;
 }
 
@@ -31,7 +31,7 @@ GetRelatingEventsJob::GetRelatingEventsJob(const QString& roomId, const QString&
                                            const QString& from, const QString& to,
                                            std::optional<int> limit, const QString& dir,
                                            std::optional<bool> recurse)
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetRelatingEventsJob"),
+    : BaseJob(HttpVerb::Get, u"GetRelatingEventsJob"_s,
               makePath("/_matrix/client/v1", "/rooms/", roomId, "/relations/", eventId),
               queryToGetRelatingEvents(from, to, limit, dir, recurse))
 {
@@ -43,11 +43,11 @@ auto queryToGetRelatingEventsWithRelType(const QString& from, const QString& to,
                                          std::optional<bool> recurse)
 {
     QUrlQuery _q;
-    addParam<IfNotEmpty>(_q, QStringLiteral("from"), from);
-    addParam<IfNotEmpty>(_q, QStringLiteral("to"), to);
-    addParam<IfNotEmpty>(_q, QStringLiteral("limit"), limit);
-    addParam<IfNotEmpty>(_q, QStringLiteral("dir"), dir);
-    addParam<IfNotEmpty>(_q, QStringLiteral("recurse"), recurse);
+    addParam<IfNotEmpty>(_q, u"from"_s, from);
+    addParam<IfNotEmpty>(_q, u"to"_s, to);
+    addParam<IfNotEmpty>(_q, u"limit"_s, limit);
+    addParam<IfNotEmpty>(_q, u"dir"_s, dir);
+    addParam<IfNotEmpty>(_q, u"recurse"_s, recurse);
     return _q;
 }
 
@@ -66,7 +66,7 @@ QUrl GetRelatingEventsWithRelTypeJob::makeRequestUrl(const HomeserverData& hsDat
 GetRelatingEventsWithRelTypeJob::GetRelatingEventsWithRelTypeJob(
     const QString& roomId, const QString& eventId, const QString& relType, const QString& from,
     const QString& to, std::optional<int> limit, const QString& dir, std::optional<bool> recurse)
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetRelatingEventsWithRelTypeJob"),
+    : BaseJob(HttpVerb::Get, u"GetRelatingEventsWithRelTypeJob"_s,
               makePath("/_matrix/client/v1", "/rooms/", roomId, "/relations/", eventId, "/",
                        relType),
               queryToGetRelatingEventsWithRelType(from, to, limit, dir, recurse))
@@ -79,11 +79,11 @@ auto queryToGetRelatingEventsWithRelTypeAndEventType(const QString& from, const 
                                                      std::optional<bool> recurse)
 {
     QUrlQuery _q;
-    addParam<IfNotEmpty>(_q, QStringLiteral("from"), from);
-    addParam<IfNotEmpty>(_q, QStringLiteral("to"), to);
-    addParam<IfNotEmpty>(_q, QStringLiteral("limit"), limit);
-    addParam<IfNotEmpty>(_q, QStringLiteral("dir"), dir);
-    addParam<IfNotEmpty>(_q, QStringLiteral("recurse"), recurse);
+    addParam<IfNotEmpty>(_q, u"from"_s, from);
+    addParam<IfNotEmpty>(_q, u"to"_s, to);
+    addParam<IfNotEmpty>(_q, u"limit"_s, limit);
+    addParam<IfNotEmpty>(_q, u"dir"_s, dir);
+    addParam<IfNotEmpty>(_q, u"recurse"_s, recurse);
     return _q;
 }
 
@@ -103,7 +103,7 @@ GetRelatingEventsWithRelTypeAndEventTypeJob::GetRelatingEventsWithRelTypeAndEven
     const QString& roomId, const QString& eventId, const QString& relType, const QString& eventType,
     const QString& from, const QString& to, std::optional<int> limit, const QString& dir,
     std::optional<bool> recurse)
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetRelatingEventsWithRelTypeAndEventTypeJob"),
+    : BaseJob(HttpVerb::Get, u"GetRelatingEventsWithRelTypeAndEventTypeJob"_s,
               makePath("/_matrix/client/v1", "/rooms/", roomId, "/relations/", eventId, "/",
                        relType, "/", eventType),
               queryToGetRelatingEventsWithRelTypeAndEventType(from, to, limit, dir, recurse))

--- a/Quotient/csapi/relations.h
+++ b/Quotient/csapi/relations.h
@@ -85,22 +85,22 @@ public:
 
     //! An opaque string representing a pagination token. The absence of this token
     //! means there are no more results to fetch and the client should stop paginating.
-    QString nextBatch() const { return loadFromJson<QString>("next_batch"_ls); }
+    QString nextBatch() const { return loadFromJson<QString>("next_batch"_L1); }
 
     //! An opaque string representing a pagination token. The absence of this token
     //! means this is the start of the result set, i.e. this is the first batch/page.
-    QString prevBatch() const { return loadFromJson<QString>("prev_batch"_ls); }
+    QString prevBatch() const { return loadFromJson<QString>("prev_batch"_L1); }
 
     //! If the `recurse` parameter was supplied by the client, this response field is
     //! mandatory and gives the actual depth to which the server recursed. If the client
     //! did not specify the `recurse` parameter, this field must be absent.
     std::optional<int> recursionDepth() const
     {
-        return loadFromJson<std::optional<int>>("recursion_depth"_ls);
+        return loadFromJson<std::optional<int>>("recursion_depth"_L1);
     }
 
     //! The child events of the requested event, ordered topologically most-recent first.
-    RoomEvents chunk() { return takeFromJson<RoomEvents>("chunk"_ls); }
+    RoomEvents chunk() { return takeFromJson<RoomEvents>("chunk"_L1); }
 
     struct Response {
         //! An opaque string representing a pagination token. The absence of this token
@@ -211,24 +211,24 @@ public:
 
     //! An opaque string representing a pagination token. The absence of this token
     //! means there are no more results to fetch and the client should stop paginating.
-    QString nextBatch() const { return loadFromJson<QString>("next_batch"_ls); }
+    QString nextBatch() const { return loadFromJson<QString>("next_batch"_L1); }
 
     //! An opaque string representing a pagination token. The absence of this token
     //! means this is the start of the result set, i.e. this is the first batch/page.
-    QString prevBatch() const { return loadFromJson<QString>("prev_batch"_ls); }
+    QString prevBatch() const { return loadFromJson<QString>("prev_batch"_L1); }
 
     //! If the `recurse` parameter was supplied by the client, this response field is
     //! mandatory and gives the actual depth to which the server recursed. If the client
     //! did not specify the `recurse` parameter, this field must be absent.
     std::optional<int> recursionDepth() const
     {
-        return loadFromJson<std::optional<int>>("recursion_depth"_ls);
+        return loadFromJson<std::optional<int>>("recursion_depth"_L1);
     }
 
     //! The child events of the requested event, ordered topologically
     //! most-recent first. The events returned will match the `relType`
     //! supplied in the URL.
-    RoomEvents chunk() { return takeFromJson<RoomEvents>("chunk"_ls); }
+    RoomEvents chunk() { return takeFromJson<RoomEvents>("chunk"_L1); }
 
     struct Response {
         //! An opaque string representing a pagination token. The absence of this token
@@ -347,24 +347,24 @@ public:
 
     //! An opaque string representing a pagination token. The absence of this token
     //! means there are no more results to fetch and the client should stop paginating.
-    QString nextBatch() const { return loadFromJson<QString>("next_batch"_ls); }
+    QString nextBatch() const { return loadFromJson<QString>("next_batch"_L1); }
 
     //! An opaque string representing a pagination token. The absence of this token
     //! means this is the start of the result set, i.e. this is the first batch/page.
-    QString prevBatch() const { return loadFromJson<QString>("prev_batch"_ls); }
+    QString prevBatch() const { return loadFromJson<QString>("prev_batch"_L1); }
 
     //! If the `recurse` parameter was supplied by the client, this response field is
     //! mandatory and gives the actual depth to which the server recursed. If the client
     //! did not specify the `recurse` parameter, this field must be absent.
     std::optional<int> recursionDepth() const
     {
-        return loadFromJson<std::optional<int>>("recursion_depth"_ls);
+        return loadFromJson<std::optional<int>>("recursion_depth"_L1);
     }
 
     //! The child events of the requested event, ordered topologically most-recent
     //! first. The events returned will match the `relType` and `eventType` supplied
     //! in the URL.
-    RoomEvents chunk() { return takeFromJson<RoomEvents>("chunk"_ls); }
+    RoomEvents chunk() { return takeFromJson<RoomEvents>("chunk"_L1); }
 
     struct Response {
         //! An opaque string representing a pagination token. The absence of this token

--- a/Quotient/csapi/report_content.cpp
+++ b/Quotient/csapi/report_content.cpp
@@ -6,11 +6,11 @@ using namespace Quotient;
 
 ReportContentJob::ReportContentJob(const QString& roomId, const QString& eventId,
                                    std::optional<int> score, const QString& reason)
-    : BaseJob(HttpVerb::Post, QStringLiteral("ReportContentJob"),
+    : BaseJob(HttpVerb::Post, u"ReportContentJob"_s,
               makePath("/_matrix/client/v3", "/rooms/", roomId, "/report/", eventId))
 {
     QJsonObject _dataJson;
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("score"), score);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("reason"), reason);
+    addParam<IfNotEmpty>(_dataJson, "score"_L1, score);
+    addParam<IfNotEmpty>(_dataJson, "reason"_L1, reason);
     setRequestData({ _dataJson });
 }

--- a/Quotient/csapi/room_event_by_timestamp.cpp
+++ b/Quotient/csapi/room_event_by_timestamp.cpp
@@ -7,8 +7,8 @@ using namespace Quotient;
 auto queryToGetEventByTimestamp(int ts, const QString& dir)
 {
     QUrlQuery _q;
-    addParam<>(_q, QStringLiteral("ts"), ts);
-    addParam<>(_q, QStringLiteral("dir"), dir);
+    addParam<>(_q, u"ts"_s, ts);
+    addParam<>(_q, u"dir"_s, dir);
     return _q;
 }
 
@@ -22,7 +22,7 @@ QUrl GetEventByTimestampJob::makeRequestUrl(const HomeserverData& hsData, const 
 }
 
 GetEventByTimestampJob::GetEventByTimestampJob(const QString& roomId, int ts, const QString& dir)
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetEventByTimestampJob"),
+    : BaseJob(HttpVerb::Get, u"GetEventByTimestampJob"_s,
               makePath("/_matrix/client/v1", "/rooms/", roomId, "/timestamp_to_event"),
               queryToGetEventByTimestamp(ts, dir))
 {

--- a/Quotient/csapi/room_event_by_timestamp.h
+++ b/Quotient/csapi/room_event_by_timestamp.h
@@ -55,13 +55,13 @@ public:
     // Result properties
 
     //! The ID of the event found
-    QString eventId() const { return loadFromJson<QString>("event_id"_ls); }
+    QString eventId() const { return loadFromJson<QString>("event_id"_L1); }
 
     //! The event's timestamp, in milliseconds since the Unix epoch.
     //! This makes it easy to do a quick comparison to see if the
     //! `event_id` fetched is too far out of range to be useful for your
     //! use case.
-    int originServerTimestamp() const { return loadFromJson<int>("origin_server_ts"_ls); }
+    int originServerTimestamp() const { return loadFromJson<int>("origin_server_ts"_L1); }
 
     struct Response {
         //! The ID of the event found

--- a/Quotient/csapi/room_send.cpp
+++ b/Quotient/csapi/room_send.cpp
@@ -6,7 +6,7 @@ using namespace Quotient;
 
 SendMessageJob::SendMessageJob(const QString& roomId, const QString& eventType,
                                const QString& txnId, const QJsonObject& content)
-    : BaseJob(HttpVerb::Put, QStringLiteral("SendMessageJob"),
+    : BaseJob(HttpVerb::Put, u"SendMessageJob"_s,
               makePath("/_matrix/client/v3", "/rooms/", roomId, "/send/", eventType, "/", txnId))
 {
     setRequestData({ toJson(content) });

--- a/Quotient/csapi/room_send.h
+++ b/Quotient/csapi/room_send.h
@@ -34,7 +34,7 @@ public:
     // Result properties
 
     //! A unique identifier for the event.
-    QString eventId() const { return loadFromJson<QString>("event_id"_ls); }
+    QString eventId() const { return loadFromJson<QString>("event_id"_L1); }
 };
 
 inline auto collectResponse(const SendMessageJob* job) { return job->eventId(); }

--- a/Quotient/csapi/room_state.cpp
+++ b/Quotient/csapi/room_state.cpp
@@ -6,7 +6,7 @@ using namespace Quotient;
 
 SetRoomStateWithKeyJob::SetRoomStateWithKeyJob(const QString& roomId, const QString& eventType,
                                                const QString& stateKey, const QJsonObject& content)
-    : BaseJob(HttpVerb::Put, QStringLiteral("SetRoomStateWithKeyJob"),
+    : BaseJob(HttpVerb::Put, u"SetRoomStateWithKeyJob"_s,
               makePath("/_matrix/client/v3", "/rooms/", roomId, "/state/", eventType, "/", stateKey))
 {
     setRequestData({ toJson(content) });

--- a/Quotient/csapi/room_state.h
+++ b/Quotient/csapi/room_state.h
@@ -43,7 +43,7 @@ public:
     // Result properties
 
     //! A unique identifier for the event.
-    QString eventId() const { return loadFromJson<QString>("event_id"_ls); }
+    QString eventId() const { return loadFromJson<QString>("event_id"_L1); }
 };
 
 inline auto collectResponse(const SetRoomStateWithKeyJob* job) { return job->eventId(); }

--- a/Quotient/csapi/room_upgrades.cpp
+++ b/Quotient/csapi/room_upgrades.cpp
@@ -5,11 +5,11 @@
 using namespace Quotient;
 
 UpgradeRoomJob::UpgradeRoomJob(const QString& roomId, const QString& newVersion)
-    : BaseJob(HttpVerb::Post, QStringLiteral("UpgradeRoomJob"),
+    : BaseJob(HttpVerb::Post, u"UpgradeRoomJob"_s,
               makePath("/_matrix/client/v3", "/rooms/", roomId, "/upgrade"))
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, QStringLiteral("new_version"), newVersion);
+    addParam<>(_dataJson, "new_version"_L1, newVersion);
     setRequestData({ _dataJson });
     addExpectedKey("replacement_room");
 }

--- a/Quotient/csapi/room_upgrades.h
+++ b/Quotient/csapi/room_upgrades.h
@@ -21,7 +21,7 @@ public:
     // Result properties
 
     //! The ID of the new room.
-    QString replacementRoom() const { return loadFromJson<QString>("replacement_room"_ls); }
+    QString replacementRoom() const { return loadFromJson<QString>("replacement_room"_L1); }
 };
 
 inline auto collectResponse(const UpgradeRoomJob* job) { return job->replacementRoom(); }

--- a/Quotient/csapi/rooms.cpp
+++ b/Quotient/csapi/rooms.cpp
@@ -12,7 +12,7 @@ QUrl GetOneRoomEventJob::makeRequestUrl(const HomeserverData& hsData, const QStr
 }
 
 GetOneRoomEventJob::GetOneRoomEventJob(const QString& roomId, const QString& eventId)
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetOneRoomEventJob"),
+    : BaseJob(HttpVerb::Get, u"GetOneRoomEventJob"_s,
               makePath("/_matrix/client/v3", "/rooms/", roomId, "/event/", eventId))
 {}
 
@@ -25,7 +25,7 @@ QUrl GetRoomStateWithKeyJob::makeRequestUrl(const HomeserverData& hsData, const 
 
 GetRoomStateWithKeyJob::GetRoomStateWithKeyJob(const QString& roomId, const QString& eventType,
                                                const QString& stateKey)
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetRoomStateWithKeyJob"),
+    : BaseJob(HttpVerb::Get, u"GetRoomStateWithKeyJob"_s,
               makePath("/_matrix/client/v3", "/rooms/", roomId, "/state/", eventType, "/", stateKey))
 {}
 
@@ -36,7 +36,7 @@ QUrl GetRoomStateJob::makeRequestUrl(const HomeserverData& hsData, const QString
 }
 
 GetRoomStateJob::GetRoomStateJob(const QString& roomId)
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetRoomStateJob"),
+    : BaseJob(HttpVerb::Get, u"GetRoomStateJob"_s,
               makePath("/_matrix/client/v3", "/rooms/", roomId, "/state"))
 {}
 
@@ -44,9 +44,9 @@ auto queryToGetMembersByRoom(const QString& at, const QString& membership,
                              const QString& notMembership)
 {
     QUrlQuery _q;
-    addParam<IfNotEmpty>(_q, QStringLiteral("at"), at);
-    addParam<IfNotEmpty>(_q, QStringLiteral("membership"), membership);
-    addParam<IfNotEmpty>(_q, QStringLiteral("not_membership"), notMembership);
+    addParam<IfNotEmpty>(_q, u"at"_s, at);
+    addParam<IfNotEmpty>(_q, u"membership"_s, membership);
+    addParam<IfNotEmpty>(_q, u"not_membership"_s, notMembership);
     return _q;
 }
 
@@ -61,7 +61,7 @@ QUrl GetMembersByRoomJob::makeRequestUrl(const HomeserverData& hsData, const QSt
 
 GetMembersByRoomJob::GetMembersByRoomJob(const QString& roomId, const QString& at,
                                          const QString& membership, const QString& notMembership)
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetMembersByRoomJob"),
+    : BaseJob(HttpVerb::Get, u"GetMembersByRoomJob"_s,
               makePath("/_matrix/client/v3", "/rooms/", roomId, "/members"),
               queryToGetMembersByRoom(at, membership, notMembership))
 {}
@@ -73,6 +73,6 @@ QUrl GetJoinedMembersByRoomJob::makeRequestUrl(const HomeserverData& hsData, con
 }
 
 GetJoinedMembersByRoomJob::GetJoinedMembersByRoomJob(const QString& roomId)
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetJoinedMembersByRoomJob"),
+    : BaseJob(HttpVerb::Get, u"GetJoinedMembersByRoomJob"_s,
               makePath("/_matrix/client/v3", "/rooms/", roomId, "/joined_members"))
 {}

--- a/Quotient/csapi/rooms.h
+++ b/Quotient/csapi/rooms.h
@@ -130,7 +130,7 @@ public:
 
     // Result properties
 
-    StateEvents chunk() { return takeFromJson<StateEvents>("chunk"_ls); }
+    StateEvents chunk() { return takeFromJson<StateEvents>("chunk"_L1); }
 };
 
 inline auto collectResponse(GetMembersByRoomJob* job) { return job->chunk(); }
@@ -171,7 +171,7 @@ public:
     //! A map from user ID to a RoomMember object.
     QHash<UserId, RoomMember> joined() const
     {
-        return loadFromJson<QHash<UserId, RoomMember>>("joined"_ls);
+        return loadFromJson<QHash<UserId, RoomMember>>("joined"_L1);
     }
 };
 
@@ -181,8 +181,8 @@ template <>
 struct QUOTIENT_API JsonObjectConverter<GetJoinedMembersByRoomJob::RoomMember> {
     static void fillFrom(const QJsonObject& jo, GetJoinedMembersByRoomJob::RoomMember& result)
     {
-        fillFromJson(jo.value("display_name"_ls), result.displayName);
-        fillFromJson(jo.value("avatar_url"_ls), result.avatarUrl);
+        fillFromJson(jo.value("display_name"_L1), result.displayName);
+        fillFromJson(jo.value("avatar_url"_L1), result.avatarUrl);
     }
 };
 

--- a/Quotient/csapi/search.cpp
+++ b/Quotient/csapi/search.cpp
@@ -7,16 +7,16 @@ using namespace Quotient;
 auto queryToSearch(const QString& nextBatch)
 {
     QUrlQuery _q;
-    addParam<IfNotEmpty>(_q, QStringLiteral("next_batch"), nextBatch);
+    addParam<IfNotEmpty>(_q, u"next_batch"_s, nextBatch);
     return _q;
 }
 
 SearchJob::SearchJob(const Categories& searchCategories, const QString& nextBatch)
-    : BaseJob(HttpVerb::Post, QStringLiteral("SearchJob"),
-              makePath("/_matrix/client/v3", "/search"), queryToSearch(nextBatch))
+    : BaseJob(HttpVerb::Post, u"SearchJob"_s, makePath("/_matrix/client/v3", "/search"),
+              queryToSearch(nextBatch))
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, QStringLiteral("search_categories"), searchCategories);
+    addParam<>(_dataJson, "search_categories"_L1, searchCategories);
     setRequestData({ _dataJson });
     addExpectedKey("search_categories");
 }

--- a/Quotient/csapi/search.h
+++ b/Quotient/csapi/search.h
@@ -194,7 +194,7 @@ public:
     //! Describes which categories to search in and their criteria.
     ResultCategories searchCategories() const
     {
-        return loadFromJson<ResultCategories>("search_categories"_ls);
+        return loadFromJson<ResultCategories>("search_categories"_L1);
     }
 };
 
@@ -204,9 +204,9 @@ template <>
 struct QUOTIENT_API JsonObjectConverter<SearchJob::IncludeEventContext> {
     static void dumpTo(QJsonObject& jo, const SearchJob::IncludeEventContext& pod)
     {
-        addParam<IfNotEmpty>(jo, QStringLiteral("before_limit"), pod.beforeLimit);
-        addParam<IfNotEmpty>(jo, QStringLiteral("after_limit"), pod.afterLimit);
-        addParam<IfNotEmpty>(jo, QStringLiteral("include_profile"), pod.includeProfile);
+        addParam<IfNotEmpty>(jo, "before_limit"_L1, pod.beforeLimit);
+        addParam<IfNotEmpty>(jo, "after_limit"_L1, pod.afterLimit);
+        addParam<IfNotEmpty>(jo, "include_profile"_L1, pod.includeProfile);
     }
 };
 
@@ -214,7 +214,7 @@ template <>
 struct QUOTIENT_API JsonObjectConverter<SearchJob::Group> {
     static void dumpTo(QJsonObject& jo, const SearchJob::Group& pod)
     {
-        addParam<IfNotEmpty>(jo, QStringLiteral("key"), pod.key);
+        addParam<IfNotEmpty>(jo, "key"_L1, pod.key);
     }
 };
 
@@ -222,7 +222,7 @@ template <>
 struct QUOTIENT_API JsonObjectConverter<SearchJob::Groupings> {
     static void dumpTo(QJsonObject& jo, const SearchJob::Groupings& pod)
     {
-        addParam<IfNotEmpty>(jo, QStringLiteral("group_by"), pod.groupBy);
+        addParam<IfNotEmpty>(jo, "group_by"_L1, pod.groupBy);
     }
 };
 
@@ -230,13 +230,13 @@ template <>
 struct QUOTIENT_API JsonObjectConverter<SearchJob::RoomEventsCriteria> {
     static void dumpTo(QJsonObject& jo, const SearchJob::RoomEventsCriteria& pod)
     {
-        addParam<>(jo, QStringLiteral("search_term"), pod.searchTerm);
-        addParam<IfNotEmpty>(jo, QStringLiteral("keys"), pod.keys);
-        addParam<IfNotEmpty>(jo, QStringLiteral("filter"), pod.filter);
-        addParam<IfNotEmpty>(jo, QStringLiteral("order_by"), pod.orderBy);
-        addParam<IfNotEmpty>(jo, QStringLiteral("event_context"), pod.eventContext);
-        addParam<IfNotEmpty>(jo, QStringLiteral("include_state"), pod.includeState);
-        addParam<IfNotEmpty>(jo, QStringLiteral("groupings"), pod.groupings);
+        addParam<>(jo, "search_term"_L1, pod.searchTerm);
+        addParam<IfNotEmpty>(jo, "keys"_L1, pod.keys);
+        addParam<IfNotEmpty>(jo, "filter"_L1, pod.filter);
+        addParam<IfNotEmpty>(jo, "order_by"_L1, pod.orderBy);
+        addParam<IfNotEmpty>(jo, "event_context"_L1, pod.eventContext);
+        addParam<IfNotEmpty>(jo, "include_state"_L1, pod.includeState);
+        addParam<IfNotEmpty>(jo, "groupings"_L1, pod.groupings);
     }
 };
 
@@ -244,7 +244,7 @@ template <>
 struct QUOTIENT_API JsonObjectConverter<SearchJob::Categories> {
     static void dumpTo(QJsonObject& jo, const SearchJob::Categories& pod)
     {
-        addParam<IfNotEmpty>(jo, QStringLiteral("room_events"), pod.roomEvents);
+        addParam<IfNotEmpty>(jo, "room_events"_L1, pod.roomEvents);
     }
 };
 
@@ -252,8 +252,8 @@ template <>
 struct QUOTIENT_API JsonObjectConverter<SearchJob::UserProfile> {
     static void fillFrom(const QJsonObject& jo, SearchJob::UserProfile& result)
     {
-        fillFromJson(jo.value("displayname"_ls), result.displayname);
-        fillFromJson(jo.value("avatar_url"_ls), result.avatarUrl);
+        fillFromJson(jo.value("displayname"_L1), result.displayname);
+        fillFromJson(jo.value("avatar_url"_L1), result.avatarUrl);
     }
 };
 
@@ -261,11 +261,11 @@ template <>
 struct QUOTIENT_API JsonObjectConverter<SearchJob::EventContext> {
     static void fillFrom(const QJsonObject& jo, SearchJob::EventContext& result)
     {
-        fillFromJson(jo.value("start"_ls), result.begin);
-        fillFromJson(jo.value("end"_ls), result.end);
-        fillFromJson(jo.value("profile_info"_ls), result.profileInfo);
-        fillFromJson(jo.value("events_before"_ls), result.eventsBefore);
-        fillFromJson(jo.value("events_after"_ls), result.eventsAfter);
+        fillFromJson(jo.value("start"_L1), result.begin);
+        fillFromJson(jo.value("end"_L1), result.end);
+        fillFromJson(jo.value("profile_info"_L1), result.profileInfo);
+        fillFromJson(jo.value("events_before"_L1), result.eventsBefore);
+        fillFromJson(jo.value("events_after"_L1), result.eventsAfter);
     }
 };
 
@@ -273,9 +273,9 @@ template <>
 struct QUOTIENT_API JsonObjectConverter<SearchJob::Result> {
     static void fillFrom(const QJsonObject& jo, SearchJob::Result& result)
     {
-        fillFromJson(jo.value("rank"_ls), result.rank);
-        fillFromJson(jo.value("result"_ls), result.result);
-        fillFromJson(jo.value("context"_ls), result.context);
+        fillFromJson(jo.value("rank"_L1), result.rank);
+        fillFromJson(jo.value("result"_L1), result.result);
+        fillFromJson(jo.value("context"_L1), result.context);
     }
 };
 
@@ -283,9 +283,9 @@ template <>
 struct QUOTIENT_API JsonObjectConverter<SearchJob::GroupValue> {
     static void fillFrom(const QJsonObject& jo, SearchJob::GroupValue& result)
     {
-        fillFromJson(jo.value("next_batch"_ls), result.nextBatch);
-        fillFromJson(jo.value("order"_ls), result.order);
-        fillFromJson(jo.value("results"_ls), result.results);
+        fillFromJson(jo.value("next_batch"_L1), result.nextBatch);
+        fillFromJson(jo.value("order"_L1), result.order);
+        fillFromJson(jo.value("results"_L1), result.results);
     }
 };
 
@@ -293,12 +293,12 @@ template <>
 struct QUOTIENT_API JsonObjectConverter<SearchJob::ResultRoomEvents> {
     static void fillFrom(const QJsonObject& jo, SearchJob::ResultRoomEvents& result)
     {
-        fillFromJson(jo.value("count"_ls), result.count);
-        fillFromJson(jo.value("highlights"_ls), result.highlights);
-        fillFromJson(jo.value("results"_ls), result.results);
-        fillFromJson(jo.value("state"_ls), result.state);
-        fillFromJson(jo.value("groups"_ls), result.groups);
-        fillFromJson(jo.value("next_batch"_ls), result.nextBatch);
+        fillFromJson(jo.value("count"_L1), result.count);
+        fillFromJson(jo.value("highlights"_L1), result.highlights);
+        fillFromJson(jo.value("results"_L1), result.results);
+        fillFromJson(jo.value("state"_L1), result.state);
+        fillFromJson(jo.value("groups"_L1), result.groups);
+        fillFromJson(jo.value("next_batch"_L1), result.nextBatch);
     }
 };
 
@@ -306,7 +306,7 @@ template <>
 struct QUOTIENT_API JsonObjectConverter<SearchJob::ResultCategories> {
     static void fillFrom(const QJsonObject& jo, SearchJob::ResultCategories& result)
     {
-        fillFromJson(jo.value("room_events"_ls), result.roomEvents);
+        fillFromJson(jo.value("room_events"_L1), result.roomEvents);
     }
 };
 

--- a/Quotient/csapi/space_hierarchy.cpp
+++ b/Quotient/csapi/space_hierarchy.cpp
@@ -8,10 +8,10 @@ auto queryToGetSpaceHierarchy(std::optional<bool> suggestedOnly, std::optional<i
                               std::optional<int> maxDepth, const QString& from)
 {
     QUrlQuery _q;
-    addParam<IfNotEmpty>(_q, QStringLiteral("suggested_only"), suggestedOnly);
-    addParam<IfNotEmpty>(_q, QStringLiteral("limit"), limit);
-    addParam<IfNotEmpty>(_q, QStringLiteral("max_depth"), maxDepth);
-    addParam<IfNotEmpty>(_q, QStringLiteral("from"), from);
+    addParam<IfNotEmpty>(_q, u"suggested_only"_s, suggestedOnly);
+    addParam<IfNotEmpty>(_q, u"limit"_s, limit);
+    addParam<IfNotEmpty>(_q, u"max_depth"_s, maxDepth);
+    addParam<IfNotEmpty>(_q, u"from"_s, from);
     return _q;
 }
 
@@ -28,7 +28,7 @@ QUrl GetSpaceHierarchyJob::makeRequestUrl(const HomeserverData& hsData, const QS
 GetSpaceHierarchyJob::GetSpaceHierarchyJob(const QString& roomId, std::optional<bool> suggestedOnly,
                                            std::optional<int> limit, std::optional<int> maxDepth,
                                            const QString& from)
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetSpaceHierarchyJob"),
+    : BaseJob(HttpVerb::Get, u"GetSpaceHierarchyJob"_s,
               makePath("/_matrix/client/v1", "/rooms/", roomId, "/hierarchy"),
               queryToGetSpaceHierarchy(suggestedOnly, limit, maxDepth, from))
 {

--- a/Quotient/csapi/space_hierarchy.h
+++ b/Quotient/csapi/space_hierarchy.h
@@ -109,12 +109,12 @@ public:
     //! The rooms for the current page, with the current filters.
     std::vector<SpaceHierarchyRoomsChunk> rooms()
     {
-        return takeFromJson<std::vector<SpaceHierarchyRoomsChunk>>("rooms"_ls);
+        return takeFromJson<std::vector<SpaceHierarchyRoomsChunk>>("rooms"_L1);
     }
 
     //! A token to supply to `from` to keep paginating the responses. Not present when there are
     //! no further results.
-    QString nextBatch() const { return loadFromJson<QString>("next_batch"_ls); }
+    QString nextBatch() const { return loadFromJson<QString>("next_batch"_L1); }
 
     struct Response {
         //! The rooms for the current page, with the current filters.
@@ -135,17 +135,17 @@ struct QUOTIENT_API JsonObjectConverter<GetSpaceHierarchyJob::SpaceHierarchyRoom
     static void fillFrom(const QJsonObject& jo,
                          GetSpaceHierarchyJob::SpaceHierarchyRoomsChunk& result)
     {
-        fillFromJson(jo.value("num_joined_members"_ls), result.numJoinedMembers);
-        fillFromJson(jo.value("room_id"_ls), result.roomId);
-        fillFromJson(jo.value("world_readable"_ls), result.worldReadable);
-        fillFromJson(jo.value("guest_can_join"_ls), result.guestCanJoin);
-        fillFromJson(jo.value("children_state"_ls), result.childrenState);
-        fillFromJson(jo.value("canonical_alias"_ls), result.canonicalAlias);
-        fillFromJson(jo.value("name"_ls), result.name);
-        fillFromJson(jo.value("topic"_ls), result.topic);
-        fillFromJson(jo.value("avatar_url"_ls), result.avatarUrl);
-        fillFromJson(jo.value("join_rule"_ls), result.joinRule);
-        fillFromJson(jo.value("room_type"_ls), result.roomType);
+        fillFromJson(jo.value("num_joined_members"_L1), result.numJoinedMembers);
+        fillFromJson(jo.value("room_id"_L1), result.roomId);
+        fillFromJson(jo.value("world_readable"_L1), result.worldReadable);
+        fillFromJson(jo.value("guest_can_join"_L1), result.guestCanJoin);
+        fillFromJson(jo.value("children_state"_L1), result.childrenState);
+        fillFromJson(jo.value("canonical_alias"_L1), result.canonicalAlias);
+        fillFromJson(jo.value("name"_L1), result.name);
+        fillFromJson(jo.value("topic"_L1), result.topic);
+        fillFromJson(jo.value("avatar_url"_L1), result.avatarUrl);
+        fillFromJson(jo.value("join_rule"_L1), result.joinRule);
+        fillFromJson(jo.value("room_type"_L1), result.roomType);
     }
 };
 

--- a/Quotient/csapi/sso_login_redirect.cpp
+++ b/Quotient/csapi/sso_login_redirect.cpp
@@ -7,7 +7,7 @@ using namespace Quotient;
 auto queryToRedirectToSSO(const QString& redirectUrl)
 {
     QUrlQuery _q;
-    addParam<>(_q, QStringLiteral("redirectUrl"), redirectUrl);
+    addParam<>(_q, u"redirectUrl"_s, redirectUrl);
     return _q;
 }
 
@@ -18,7 +18,7 @@ QUrl RedirectToSSOJob::makeRequestUrl(const HomeserverData& hsData, const QStrin
 }
 
 RedirectToSSOJob::RedirectToSSOJob(const QString& redirectUrl)
-    : BaseJob(HttpVerb::Get, QStringLiteral("RedirectToSSOJob"),
+    : BaseJob(HttpVerb::Get, u"RedirectToSSOJob"_s,
               makePath("/_matrix/client/v3", "/login/sso/redirect"),
               queryToRedirectToSSO(redirectUrl), {}, false)
 {}
@@ -26,7 +26,7 @@ RedirectToSSOJob::RedirectToSSOJob(const QString& redirectUrl)
 auto queryToRedirectToIdP(const QString& redirectUrl)
 {
     QUrlQuery _q;
-    addParam<>(_q, QStringLiteral("redirectUrl"), redirectUrl);
+    addParam<>(_q, u"redirectUrl"_s, redirectUrl);
     return _q;
 }
 
@@ -39,7 +39,7 @@ QUrl RedirectToIdPJob::makeRequestUrl(const HomeserverData& hsData, const QStrin
 }
 
 RedirectToIdPJob::RedirectToIdPJob(const QString& idpId, const QString& redirectUrl)
-    : BaseJob(HttpVerb::Get, QStringLiteral("RedirectToIdPJob"),
+    : BaseJob(HttpVerb::Get, u"RedirectToIdPJob"_s,
               makePath("/_matrix/client/v3", "/login/sso/redirect/", idpId),
               queryToRedirectToIdP(redirectUrl), {}, false)
 {}

--- a/Quotient/csapi/support.cpp
+++ b/Quotient/csapi/support.cpp
@@ -10,6 +10,6 @@ QUrl GetWellknownSupportJob::makeRequestUrl(const HomeserverData& hsData)
 }
 
 GetWellknownSupportJob::GetWellknownSupportJob()
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetWellknownSupportJob"),
+    : BaseJob(HttpVerb::Get, u"GetWellknownSupportJob"_s,
               makePath("/.well-known", "/matrix/support"), false)
 {}

--- a/Quotient/csapi/support.h
+++ b/Quotient/csapi/support.h
@@ -69,13 +69,13 @@ public:
     //! At least one of `contacts` or `support_page` is required.
     //! If only `contacts` is set, it must contain at least one
     //! item.
-    QVector<Contact> contacts() const { return loadFromJson<QVector<Contact>>("contacts"_ls); }
+    QVector<Contact> contacts() const { return loadFromJson<QVector<Contact>>("contacts"_L1); }
 
     //! The URL of a page to give users help specific to the
     //! homeserver, like extra login/registration steps.
     //!
     //! At least one of `contacts` or `support_page` is required.
-    QString supportPage() const { return loadFromJson<QString>("support_page"_ls); }
+    QString supportPage() const { return loadFromJson<QString>("support_page"_L1); }
 
     struct Response {
         //! Ways to contact the server administrator.
@@ -101,9 +101,9 @@ template <>
 struct QUOTIENT_API JsonObjectConverter<GetWellknownSupportJob::Contact> {
     static void fillFrom(const QJsonObject& jo, GetWellknownSupportJob::Contact& result)
     {
-        fillFromJson(jo.value("role"_ls), result.role);
-        fillFromJson(jo.value("matrix_id"_ls), result.matrixId);
-        fillFromJson(jo.value("email_address"_ls), result.emailAddress);
+        fillFromJson(jo.value("role"_L1), result.role);
+        fillFromJson(jo.value("matrix_id"_L1), result.matrixId);
+        fillFromJson(jo.value("email_address"_L1), result.emailAddress);
     }
 };
 

--- a/Quotient/csapi/tags.cpp
+++ b/Quotient/csapi/tags.cpp
@@ -12,13 +12,13 @@ QUrl GetRoomTagsJob::makeRequestUrl(const HomeserverData& hsData, const QString&
 }
 
 GetRoomTagsJob::GetRoomTagsJob(const QString& userId, const QString& roomId)
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetRoomTagsJob"),
+    : BaseJob(HttpVerb::Get, u"GetRoomTagsJob"_s,
               makePath("/_matrix/client/v3", "/user/", userId, "/rooms/", roomId, "/tags"))
 {}
 
 SetRoomTagJob::SetRoomTagJob(const QString& userId, const QString& roomId, const QString& tag,
                              const Tag& data)
-    : BaseJob(HttpVerb::Put, QStringLiteral("SetRoomTagJob"),
+    : BaseJob(HttpVerb::Put, u"SetRoomTagJob"_s,
               makePath("/_matrix/client/v3", "/user/", userId, "/rooms/", roomId, "/tags/", tag))
 {
     setRequestData({ toJson(data) });
@@ -32,6 +32,6 @@ QUrl DeleteRoomTagJob::makeRequestUrl(const HomeserverData& hsData, const QStrin
 }
 
 DeleteRoomTagJob::DeleteRoomTagJob(const QString& userId, const QString& roomId, const QString& tag)
-    : BaseJob(HttpVerb::Delete, QStringLiteral("DeleteRoomTagJob"),
+    : BaseJob(HttpVerb::Delete, u"DeleteRoomTagJob"_s,
               makePath("/_matrix/client/v3", "/user/", userId, "/rooms/", roomId, "/tags/", tag))
 {}

--- a/Quotient/csapi/tags.h
+++ b/Quotient/csapi/tags.h
@@ -30,7 +30,7 @@ public:
 
     // Result properties
 
-    QHash<QString, Tag> tags() const { return loadFromJson<QHash<QString, Tag>>("tags"_ls); }
+    QHash<QString, Tag> tags() const { return loadFromJson<QHash<QString, Tag>>("tags"_L1); }
 };
 
 inline auto collectResponse(const GetRoomTagsJob* job) { return job->tags(); }

--- a/Quotient/csapi/third_party_lookup.cpp
+++ b/Quotient/csapi/third_party_lookup.cpp
@@ -10,7 +10,7 @@ QUrl GetProtocolsJob::makeRequestUrl(const HomeserverData& hsData)
 }
 
 GetProtocolsJob::GetProtocolsJob()
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetProtocolsJob"),
+    : BaseJob(HttpVerb::Get, u"GetProtocolsJob"_s,
               makePath("/_matrix/client/v3", "/thirdparty/protocols"))
 {}
 
@@ -21,14 +21,14 @@ QUrl GetProtocolMetadataJob::makeRequestUrl(const HomeserverData& hsData, const 
 }
 
 GetProtocolMetadataJob::GetProtocolMetadataJob(const QString& protocol)
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetProtocolMetadataJob"),
+    : BaseJob(HttpVerb::Get, u"GetProtocolMetadataJob"_s,
               makePath("/_matrix/client/v3", "/thirdparty/protocol/", protocol))
 {}
 
 auto queryToQueryLocationByProtocol(const QString& searchFields)
 {
     QUrlQuery _q;
-    addParam<IfNotEmpty>(_q, QStringLiteral("searchFields"), searchFields);
+    addParam<IfNotEmpty>(_q, u"searchFields"_s, searchFields);
     return _q;
 }
 
@@ -42,7 +42,7 @@ QUrl QueryLocationByProtocolJob::makeRequestUrl(const HomeserverData& hsData,
 
 QueryLocationByProtocolJob::QueryLocationByProtocolJob(const QString& protocol,
                                                        const QString& searchFields)
-    : BaseJob(HttpVerb::Get, QStringLiteral("QueryLocationByProtocolJob"),
+    : BaseJob(HttpVerb::Get, u"QueryLocationByProtocolJob"_s,
               makePath("/_matrix/client/v3", "/thirdparty/location/", protocol),
               queryToQueryLocationByProtocol(searchFields))
 {}
@@ -50,7 +50,7 @@ QueryLocationByProtocolJob::QueryLocationByProtocolJob(const QString& protocol,
 auto queryToQueryUserByProtocol(const QHash<QString, QString>& fields)
 {
     QUrlQuery _q;
-    addParam<IfNotEmpty>(_q, QStringLiteral("fields"), fields);
+    addParam<IfNotEmpty>(_q, u"fields"_s, fields);
     return _q;
 }
 
@@ -64,7 +64,7 @@ QUrl QueryUserByProtocolJob::makeRequestUrl(const HomeserverData& hsData, const 
 
 QueryUserByProtocolJob::QueryUserByProtocolJob(const QString& protocol,
                                                const QHash<QString, QString>& fields)
-    : BaseJob(HttpVerb::Get, QStringLiteral("QueryUserByProtocolJob"),
+    : BaseJob(HttpVerb::Get, u"QueryUserByProtocolJob"_s,
               makePath("/_matrix/client/v3", "/thirdparty/user/", protocol),
               queryToQueryUserByProtocol(fields))
 {}
@@ -72,7 +72,7 @@ QueryUserByProtocolJob::QueryUserByProtocolJob(const QString& protocol,
 auto queryToQueryLocationByAlias(const QString& alias)
 {
     QUrlQuery _q;
-    addParam<>(_q, QStringLiteral("alias"), alias);
+    addParam<>(_q, u"alias"_s, alias);
     return _q;
 }
 
@@ -83,7 +83,7 @@ QUrl QueryLocationByAliasJob::makeRequestUrl(const HomeserverData& hsData, const
 }
 
 QueryLocationByAliasJob::QueryLocationByAliasJob(const QString& alias)
-    : BaseJob(HttpVerb::Get, QStringLiteral("QueryLocationByAliasJob"),
+    : BaseJob(HttpVerb::Get, u"QueryLocationByAliasJob"_s,
               makePath("/_matrix/client/v3", "/thirdparty/location"),
               queryToQueryLocationByAlias(alias))
 {}
@@ -91,7 +91,7 @@ QueryLocationByAliasJob::QueryLocationByAliasJob(const QString& alias)
 auto queryToQueryUserByID(const QString& userid)
 {
     QUrlQuery _q;
-    addParam<>(_q, QStringLiteral("userid"), userid);
+    addParam<>(_q, u"userid"_s, userid);
     return _q;
 }
 
@@ -102,6 +102,6 @@ QUrl QueryUserByIDJob::makeRequestUrl(const HomeserverData& hsData, const QStrin
 }
 
 QueryUserByIDJob::QueryUserByIDJob(const QString& userid)
-    : BaseJob(HttpVerb::Get, QStringLiteral("QueryUserByIDJob"),
+    : BaseJob(HttpVerb::Get, u"QueryUserByIDJob"_s,
               makePath("/_matrix/client/v3", "/thirdparty/user"), queryToQueryUserByID(userid))
 {}

--- a/Quotient/csapi/third_party_membership.cpp
+++ b/Quotient/csapi/third_party_membership.cpp
@@ -7,13 +7,13 @@ using namespace Quotient;
 InviteBy3PIDJob::InviteBy3PIDJob(const QString& roomId, const QString& idServer,
                                  const QString& idAccessToken, const QString& medium,
                                  const QString& address)
-    : BaseJob(HttpVerb::Post, QStringLiteral("InviteBy3PIDJob"),
+    : BaseJob(HttpVerb::Post, u"InviteBy3PIDJob"_s,
               makePath("/_matrix/client/v3", "/rooms/", roomId, "/invite"))
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, QStringLiteral("id_server"), idServer);
-    addParam<>(_dataJson, QStringLiteral("id_access_token"), idAccessToken);
-    addParam<>(_dataJson, QStringLiteral("medium"), medium);
-    addParam<>(_dataJson, QStringLiteral("address"), address);
+    addParam<>(_dataJson, "id_server"_L1, idServer);
+    addParam<>(_dataJson, "id_access_token"_L1, idAccessToken);
+    addParam<>(_dataJson, "medium"_L1, medium);
+    addParam<>(_dataJson, "address"_L1, address);
     setRequestData({ _dataJson });
 }

--- a/Quotient/csapi/threads_list.cpp
+++ b/Quotient/csapi/threads_list.cpp
@@ -7,9 +7,9 @@ using namespace Quotient;
 auto queryToGetThreadRoots(const QString& include, std::optional<int> limit, const QString& from)
 {
     QUrlQuery _q;
-    addParam<IfNotEmpty>(_q, QStringLiteral("include"), include);
-    addParam<IfNotEmpty>(_q, QStringLiteral("limit"), limit);
-    addParam<IfNotEmpty>(_q, QStringLiteral("from"), from);
+    addParam<IfNotEmpty>(_q, u"include"_s, include);
+    addParam<IfNotEmpty>(_q, u"limit"_s, limit);
+    addParam<IfNotEmpty>(_q, u"from"_s, from);
     return _q;
 }
 
@@ -24,7 +24,7 @@ QUrl GetThreadRootsJob::makeRequestUrl(const HomeserverData& hsData, const QStri
 
 GetThreadRootsJob::GetThreadRootsJob(const QString& roomId, const QString& include,
                                      std::optional<int> limit, const QString& from)
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetThreadRootsJob"),
+    : BaseJob(HttpVerb::Get, u"GetThreadRootsJob"_s,
               makePath("/_matrix/client/v1", "/rooms/", roomId, "/threads"),
               queryToGetThreadRoots(include, limit, from))
 {

--- a/Quotient/csapi/threads_list.h
+++ b/Quotient/csapi/threads_list.h
@@ -56,11 +56,11 @@ public:
     //! If the thread root event was sent by an [ignored user](/client-server-api/#ignoring-users),
     //! the event is returned redacted to the caller. This is to simulate the same behaviour of a
     //! client doing aggregation locally on the thread.
-    RoomEvents chunk() { return takeFromJson<RoomEvents>("chunk"_ls); }
+    RoomEvents chunk() { return takeFromJson<RoomEvents>("chunk"_L1); }
 
     //! A token to supply to `from` to keep paginating the responses. Not present when there are
     //! no further results.
-    QString nextBatch() const { return loadFromJson<QString>("next_batch"_ls); }
+    QString nextBatch() const { return loadFromJson<QString>("next_batch"_L1); }
 
     struct Response {
         //! The thread roots, ordered by the `latest_event` in each event's aggregated children. All

--- a/Quotient/csapi/to_device.cpp
+++ b/Quotient/csapi/to_device.cpp
@@ -6,10 +6,10 @@ using namespace Quotient;
 
 SendToDeviceJob::SendToDeviceJob(const QString& eventType, const QString& txnId,
                                  const QHash<UserId, QHash<QString, QJsonObject>>& messages)
-    : BaseJob(HttpVerb::Put, QStringLiteral("SendToDeviceJob"),
+    : BaseJob(HttpVerb::Put, u"SendToDeviceJob"_s,
               makePath("/_matrix/client/v3", "/sendToDevice/", eventType, "/", txnId))
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, QStringLiteral("messages"), messages);
+    addParam<>(_dataJson, "messages"_L1, messages);
     setRequestData({ _dataJson });
 }

--- a/Quotient/csapi/typing.cpp
+++ b/Quotient/csapi/typing.cpp
@@ -6,11 +6,11 @@ using namespace Quotient;
 
 SetTypingJob::SetTypingJob(const QString& userId, const QString& roomId, bool typing,
                            std::optional<int> timeout)
-    : BaseJob(HttpVerb::Put, QStringLiteral("SetTypingJob"),
+    : BaseJob(HttpVerb::Put, u"SetTypingJob"_s,
               makePath("/_matrix/client/v3", "/rooms/", roomId, "/typing/", userId))
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, QStringLiteral("typing"), typing);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("timeout"), timeout);
+    addParam<>(_dataJson, "typing"_L1, typing);
+    addParam<IfNotEmpty>(_dataJson, "timeout"_L1, timeout);
     setRequestData({ _dataJson });
 }

--- a/Quotient/csapi/users.cpp
+++ b/Quotient/csapi/users.cpp
@@ -5,12 +5,12 @@
 using namespace Quotient;
 
 SearchUserDirectoryJob::SearchUserDirectoryJob(const QString& searchTerm, std::optional<int> limit)
-    : BaseJob(HttpVerb::Post, QStringLiteral("SearchUserDirectoryJob"),
+    : BaseJob(HttpVerb::Post, u"SearchUserDirectoryJob"_s,
               makePath("/_matrix/client/v3", "/user_directory/search"))
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, QStringLiteral("search_term"), searchTerm);
-    addParam<IfNotEmpty>(_dataJson, QStringLiteral("limit"), limit);
+    addParam<>(_dataJson, "search_term"_L1, searchTerm);
+    addParam<IfNotEmpty>(_dataJson, "limit"_L1, limit);
     setRequestData({ _dataJson });
     addExpectedKey("results");
     addExpectedKey("limited");

--- a/Quotient/csapi/users.h
+++ b/Quotient/csapi/users.h
@@ -47,10 +47,10 @@ public:
     // Result properties
 
     //! Ordered by rank and then whether or not profile info is available.
-    QVector<User> results() const { return loadFromJson<QVector<User>>("results"_ls); }
+    QVector<User> results() const { return loadFromJson<QVector<User>>("results"_L1); }
 
     //! Indicates if the result list has been truncated by the limit.
-    bool limited() const { return loadFromJson<bool>("limited"_ls); }
+    bool limited() const { return loadFromJson<bool>("limited"_L1); }
 
     struct Response {
         //! Ordered by rank and then whether or not profile info is available.
@@ -69,9 +69,9 @@ template <>
 struct QUOTIENT_API JsonObjectConverter<SearchUserDirectoryJob::User> {
     static void fillFrom(const QJsonObject& jo, SearchUserDirectoryJob::User& result)
     {
-        fillFromJson(jo.value("user_id"_ls), result.userId);
-        fillFromJson(jo.value("display_name"_ls), result.displayName);
-        fillFromJson(jo.value("avatar_url"_ls), result.avatarUrl);
+        fillFromJson(jo.value("user_id"_L1), result.userId);
+        fillFromJson(jo.value("display_name"_L1), result.displayName);
+        fillFromJson(jo.value("avatar_url"_L1), result.avatarUrl);
     }
 };
 

--- a/Quotient/csapi/versions.cpp
+++ b/Quotient/csapi/versions.cpp
@@ -10,8 +10,7 @@ QUrl GetVersionsJob::makeRequestUrl(const HomeserverData& hsData)
 }
 
 GetVersionsJob::GetVersionsJob()
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetVersionsJob"),
-              makePath("/_matrix/client", "/versions"))
+    : BaseJob(HttpVerb::Get, u"GetVersionsJob"_s, makePath("/_matrix/client", "/versions"))
 {
     addExpectedKey("versions");
 }

--- a/Quotient/csapi/versions.h
+++ b/Quotient/csapi/versions.h
@@ -43,14 +43,14 @@ public:
     // Result properties
 
     //! The supported versions.
-    QStringList versions() const { return loadFromJson<QStringList>("versions"_ls); }
+    QStringList versions() const { return loadFromJson<QStringList>("versions"_L1); }
 
     //! Experimental features the server supports. Features not listed here,
     //! or the lack of this property all together, indicate that a feature is
     //! not supported.
     QHash<QString, bool> unstableFeatures() const
     {
-        return loadFromJson<QHash<QString, bool>>("unstable_features"_ls);
+        return loadFromJson<QHash<QString, bool>>("unstable_features"_L1);
     }
 
     struct Response {

--- a/Quotient/csapi/voip.cpp
+++ b/Quotient/csapi/voip.cpp
@@ -10,6 +10,6 @@ QUrl GetTurnServerJob::makeRequestUrl(const HomeserverData& hsData)
 }
 
 GetTurnServerJob::GetTurnServerJob()
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetTurnServerJob"),
+    : BaseJob(HttpVerb::Get, u"GetTurnServerJob"_s,
               makePath("/_matrix/client/v3", "/voip/turnServer"))
 {}

--- a/Quotient/csapi/wellknown.cpp
+++ b/Quotient/csapi/wellknown.cpp
@@ -10,6 +10,5 @@ QUrl GetWellknownJob::makeRequestUrl(const HomeserverData& hsData)
 }
 
 GetWellknownJob::GetWellknownJob()
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetWellknownJob"),
-              makePath("/.well-known", "/matrix/client"), false)
+    : BaseJob(HttpVerb::Get, u"GetWellknownJob"_s, makePath("/.well-known", "/matrix/client"), false)
 {}

--- a/Quotient/csapi/whoami.cpp
+++ b/Quotient/csapi/whoami.cpp
@@ -10,7 +10,7 @@ QUrl GetTokenOwnerJob::makeRequestUrl(const HomeserverData& hsData)
 }
 
 GetTokenOwnerJob::GetTokenOwnerJob()
-    : BaseJob(HttpVerb::Get, QStringLiteral("GetTokenOwnerJob"),
+    : BaseJob(HttpVerb::Get, u"GetTokenOwnerJob"_s,
               makePath("/_matrix/client/v3", "/account/whoami"))
 {
     addExpectedKey("user_id");

--- a/Quotient/csapi/whoami.h
+++ b/Quotient/csapi/whoami.h
@@ -29,18 +29,18 @@ public:
     // Result properties
 
     //! The user ID that owns the access token.
-    QString userId() const { return loadFromJson<QString>("user_id"_ls); }
+    QString userId() const { return loadFromJson<QString>("user_id"_L1); }
 
     //! Device ID associated with the access token. If no device
     //! is associated with the access token (such as in the case
     //! of application services) then this field can be omitted.
     //! Otherwise this is required.
-    QString deviceId() const { return loadFromJson<QString>("device_id"_ls); }
+    QString deviceId() const { return loadFromJson<QString>("device_id"_L1); }
 
     //! When `true`, the user is a [Guest User](#guest-access). When
     //! not present or `false`, the user is presumed to be a non-guest
     //! user.
-    std::optional<bool> isGuest() const { return loadFromJson<std::optional<bool>>("is_guest"_ls); }
+    std::optional<bool> isGuest() const { return loadFromJson<std::optional<bool>>("is_guest"_L1); }
 
     struct Response {
         //! The user ID that owns the access token.

--- a/Quotient/database.cpp
+++ b/Quotient/database.cpp
@@ -27,14 +27,14 @@ Database::Database(const QString& userId, const QString& deviceId,
     , m_picklingKey(std::move(picklingKey))
 {
     auto db = QSqlDatabase::addDatabase(QStringLiteral("QSQLITE"),
-                                        "Quotient_"_ls + m_userId);
+                                        "Quotient_"_L1 + m_userId);
     auto dbDir = m_userId;
     dbDir.replace(u':', u'_');
     const QString databasePath{ QStandardPaths::writableLocation(
                                     QStandardPaths::AppDataLocation)
                                 % u'/' % dbDir };
-    QDir(databasePath).mkpath("."_ls);
-    db.setDatabaseName(databasePath + "/quotient_%1.db3"_ls.arg(m_deviceId));
+    QDir(databasePath).mkpath("."_L1);
+    db.setDatabaseName(databasePath + "/quotient_%1.db3"_L1.arg(m_deviceId));
     db.open(); // Further accessed via database()
 
     switch(version()) {
@@ -196,21 +196,21 @@ void Database::migrateTo8()
     transaction();
 
     execute(QStringLiteral("ALTER TABLE inbound_megolm_sessions ADD senderKey TEXT;"));
-    auto query = prepareQuery("SELECT sessionId, olmSessionId FROM inbound_megolm_sessions;"_ls);
+    auto query = prepareQuery("SELECT sessionId, olmSessionId FROM inbound_megolm_sessions;"_L1);
     execute(query);
     while (query.next()) {
-        if (query.value("olmSessionId"_ls).toString().startsWith("BACKUP"_ls)) {
+        if (query.value("olmSessionId"_L1).toString().startsWith("BACKUP"_L1)) {
             continue;
         }
-        auto senderKeyQuery = prepareQuery("SELECT senderKey FROM olm_sessions WHERE sessionId=:olmSessionId;"_ls);
-        senderKeyQuery.bindValue(":olmSessionId"_ls, query.value("olmSessionId"_ls).toByteArray());
+        auto senderKeyQuery = prepareQuery("SELECT senderKey FROM olm_sessions WHERE sessionId=:olmSessionId;"_L1);
+        senderKeyQuery.bindValue(":olmSessionId"_L1, query.value("olmSessionId"_L1).toByteArray());
         execute(senderKeyQuery);
         if (!senderKeyQuery.next()) {
             continue;
         }
-        auto updateQuery = prepareQuery("UPDATE inbound_megolm_sessions SET senderKey=:senderKey WHERE sessionId=:sessionId;"_ls);
-        updateQuery.bindValue(":sessionId"_ls, query.value("sessionId"_ls).toByteArray());
-        updateQuery.bindValue(":senderKey"_ls, senderKeyQuery.value("senderKey"_ls).toByteArray());
+        auto updateQuery = prepareQuery("UPDATE inbound_megolm_sessions SET senderKey=:senderKey WHERE sessionId=:sessionId;"_L1);
+        updateQuery.bindValue(":sessionId"_L1, query.value("sessionId"_L1).toByteArray());
+        updateQuery.bindValue(":senderKey"_L1, senderKeyQuery.value("senderKey"_L1).toByteArray());
 
         execute(updateQuery);
     }
@@ -223,17 +223,17 @@ void Database::migrateTo9()
     qCDebug(DATABASE) << "Migrating database to version 9";
     transaction();
 
-    auto query = prepareQuery("SELECT curveKey FROM tracked_devices WHERE matrixId=:matrixId AND deviceId=:deviceId;"_ls);
-    query.bindValue(":matrixId"_ls, m_userId);
-    query.bindValue(":deviceId"_ls, m_deviceId);
+    auto query = prepareQuery("SELECT curveKey FROM tracked_devices WHERE matrixId=:matrixId AND deviceId=:deviceId;"_L1);
+    query.bindValue(":matrixId"_L1, m_userId);
+    query.bindValue(":deviceId"_L1, m_deviceId);
     execute(query);
     if (!query.next()) {
         return;
     }
-    auto curveKey = query.value("curveKey"_ls).toByteArray();
-    query = prepareQuery("UPDATE inbound_megolm_sessions SET senderKey=:senderKey WHERE olmSessionId=:self;"_ls);
-    query.bindValue(":senderKey"_ls, curveKey);
-    query.bindValue(":self"_ls, QByteArrayLiteral("SELF"));
+    auto curveKey = query.value("curveKey"_L1).toByteArray();
+    query = prepareQuery("UPDATE inbound_megolm_sessions SET senderKey=:senderKey WHERE olmSessionId=:self;"_L1);
+    query.bindValue(":senderKey"_L1, curveKey);
+    query.bindValue(":self"_L1, QByteArrayLiteral("SELF"));
     execute(QStringLiteral("PRAGMA user_version = 9;"));
     execute(query);
     commit();
@@ -247,25 +247,25 @@ void Database::migrateTo10()
 
     execute(QStringLiteral("ALTER TABLE inbound_megolm_sessions ADD senderClaimedEd25519Key TEXT;"));
 
-    auto query = prepareQuery("SELECT DISTINCT senderKey FROM inbound_megolm_sessions;"_ls);
+    auto query = prepareQuery("SELECT DISTINCT senderKey FROM inbound_megolm_sessions;"_L1);
     execute(query);
 
     QStringList keys;
     while (query.next()) {
-        keys += query.value("senderKey"_ls).toString();
+        keys += query.value("senderKey"_L1).toString();
     }
     for (const auto& key : keys) {
-        auto edKeyQuery = prepareQuery("SELECT edKey FROM tracked_devices WHERE curveKey=:curveKey;"_ls);
-        edKeyQuery.bindValue(":curveKey"_ls, key);
+        auto edKeyQuery = prepareQuery("SELECT edKey FROM tracked_devices WHERE curveKey=:curveKey;"_L1);
+        edKeyQuery.bindValue(":curveKey"_L1, key);
         execute(edKeyQuery);
         if (!edKeyQuery.next()) {
             continue;
         }
-        const auto &edKey = edKeyQuery.value("edKey"_ls).toByteArray();
+        const auto &edKey = edKeyQuery.value("edKey"_L1).toByteArray();
 
-        auto updateQuery = prepareQuery("UPDATE inbound_megolm_sessions SET senderClaimedEd25519Key=:senderClaimedEd25519Key WHERE senderKey=:senderKey;"_ls);
-        updateQuery.bindValue(":senderKey"_ls, key.toLatin1());
-        updateQuery.bindValue(":senderClaimedEd25519Key"_ls, edKey);
+        auto updateQuery = prepareQuery("UPDATE inbound_megolm_sessions SET senderClaimedEd25519Key=:senderClaimedEd25519Key WHERE senderKey=:senderKey;"_L1);
+        updateQuery.bindValue(":senderKey"_L1, key.toLatin1());
+        updateQuery.bindValue(":senderClaimedEd25519Key"_L1, edKey);
         execute(updateQuery);
     }
 
@@ -278,7 +278,7 @@ void Database::storeOlmAccount(const QOlmAccount& olmAccount)
 {
     auto deleteQuery = prepareQuery(QStringLiteral("DELETE FROM accounts;"));
     auto query = prepareQuery(QStringLiteral("INSERT INTO accounts(pickle) VALUES(:pickle);"));
-    query.bindValue(":pickle"_ls, olmAccount.pickle(m_picklingKey));
+    query.bindValue(":pickle"_L1, olmAccount.pickle(m_picklingKey));
     transaction();
     execute(deleteQuery);
     execute(query);
@@ -318,10 +318,10 @@ void Database::saveOlmSession(const QByteArray& senderKey,
                               const QDateTime& timestamp)
 {
     auto query = prepareQuery(QStringLiteral("INSERT INTO olm_sessions(senderKey, sessionId, pickle, lastReceived) VALUES(:senderKey, :sessionId, :pickle, :lastReceived);"));
-    query.bindValue(":senderKey"_ls, senderKey);
-    query.bindValue(":sessionId"_ls, session.sessionId());
-    query.bindValue(":pickle"_ls, session.pickle(m_picklingKey));
-    query.bindValue(":lastReceived"_ls, timestamp);
+    query.bindValue(":senderKey"_L1, senderKey);
+    query.bindValue(":sessionId"_L1, session.sessionId());
+    query.bindValue(":pickle"_L1, session.pickle(m_picklingKey));
+    query.bindValue(":lastReceived"_L1, timestamp);
     transaction();
     execute(query);
     commit();
@@ -337,9 +337,9 @@ std::unordered_map<QByteArray, std::vector<QOlmSession> > Database::loadOlmSessi
     std::unordered_map<QByteArray, std::vector<QOlmSession>> sessions;
     while (query.next()) {
         if (auto&& expectedSession =
-                QOlmSession::unpickle(query.value("pickle"_ls).toByteArray(),
+                QOlmSession::unpickle(query.value("pickle"_L1).toByteArray(),
                                       m_picklingKey)) {
-            sessions[query.value("senderKey"_ls).toByteArray()].emplace_back(
+            sessions[query.value("senderKey"_L1).toByteArray()].emplace_back(
                 std::move(*expectedSession));
         } else
             qCWarning(E2EE)
@@ -352,15 +352,15 @@ std::unordered_map<QByteArray, QOlmInboundGroupSession> Database::loadMegolmSess
     const QString& roomId)
 {
     auto query = prepareQuery(QStringLiteral("SELECT * FROM inbound_megolm_sessions WHERE roomId=:roomId;"));
-    query.bindValue(":roomId"_ls, roomId);
+    query.bindValue(":roomId"_L1, roomId);
     transaction();
     execute(query);
     commit();
     decltype(Database::loadMegolmSessions({})) sessions;
     while (query.next()) {
         if (auto&& expectedSession = QOlmInboundGroupSession::unpickle(
-                query.value("pickle"_ls).toByteArray(), m_picklingKey)) {
-            const auto sessionId = query.value("sessionId"_ls).toByteArray();
+                query.value("pickle"_L1).toByteArray(), m_picklingKey)) {
+            const auto sessionId = query.value("sessionId"_L1).toByteArray();
             if (const auto it = sessions.find(sessionId); it != sessions.end()) {
                 qCritical(DATABASE) << "More than one inbound group session "
                                        "with the same session id"
@@ -373,9 +373,9 @@ std::unordered_map<QByteArray, QOlmInboundGroupSession> Database::loadMegolmSess
                 sessions.erase(it);
             }
             expectedSession->setOlmSessionId(
-                query.value("olmSessionId"_ls).toByteArray());
-            expectedSession->setSenderId(query.value("senderId"_ls).toString());
-            sessions.try_emplace(query.value("sessionId"_ls).toByteArray(),
+                query.value("olmSessionId"_L1).toByteArray());
+            expectedSession->setSenderId(query.value("senderId"_L1).toString());
+            sessions.try_emplace(query.value("sessionId"_L1).toByteArray(),
                                  std::move(*expectedSession));
         } else
             qCWarning(E2EE) << "Failed to unpickle megolm session:"
@@ -388,17 +388,17 @@ void Database::saveMegolmSession(const QString& roomId,
                                  const QOlmInboundGroupSession& session, const QByteArray &senderKey, const QByteArray& senderClaimedEdKey)
 {
     auto deleteQuery = prepareQuery(QStringLiteral("DELETE FROM inbound_megolm_sessions WHERE roomId=:roomId AND sessionId=:sessionId;"));
-    deleteQuery.bindValue(":roomId"_ls, roomId);
-    deleteQuery.bindValue(":sessionId"_ls, session.sessionId());
+    deleteQuery.bindValue(":roomId"_L1, roomId);
+    deleteQuery.bindValue(":sessionId"_L1, session.sessionId());
     auto query = prepareQuery(
         QStringLiteral("INSERT INTO inbound_megolm_sessions(roomId, sessionId, pickle, senderId, olmSessionId, senderKey, senderClaimedEd25519Key) VALUES(:roomId, :sessionId, :pickle, :senderId, :olmSessionId, :senderKey, :senderClaimedEd25519Key);"));
-    query.bindValue(":roomId"_ls, roomId);
-    query.bindValue(":sessionId"_ls, session.sessionId());
-    query.bindValue(":pickle"_ls, session.pickle(m_picklingKey));
-    query.bindValue(":senderId"_ls, session.senderId());
-    query.bindValue(":olmSessionId"_ls, session.olmSessionId());
-    query.bindValue(":senderKey"_ls, senderKey);
-    query.bindValue(":senderClaimedEd25519Key"_ls, senderClaimedEdKey);
+    query.bindValue(":roomId"_L1, roomId);
+    query.bindValue(":sessionId"_L1, session.sessionId());
+    query.bindValue(":pickle"_L1, session.pickle(m_picklingKey));
+    query.bindValue(":senderId"_L1, session.senderId());
+    query.bindValue(":olmSessionId"_L1, session.olmSessionId());
+    query.bindValue(":senderKey"_L1, senderKey);
+    query.bindValue(":senderClaimedEd25519Key"_L1, senderClaimedEdKey);
     transaction();
     execute(deleteQuery);
     execute(query);
@@ -407,12 +407,12 @@ void Database::saveMegolmSession(const QString& roomId,
 
 void Database::addGroupSessionIndexRecord(const QString& roomId, const QString& sessionId, uint32_t index, const QString& eventId, qint64 ts)
 {
-    auto query = prepareQuery("INSERT INTO group_session_record_index(roomId, sessionId, i, eventId, ts) VALUES(:roomId, :sessionId, :index, :eventId, :ts);"_ls);
-    query.bindValue(":roomId"_ls, roomId);
-    query.bindValue(":sessionId"_ls, sessionId);
-    query.bindValue(":index"_ls, index);
-    query.bindValue(":eventId"_ls, eventId);
-    query.bindValue(":ts"_ls, ts);
+    auto query = prepareQuery("INSERT INTO group_session_record_index(roomId, sessionId, i, eventId, ts) VALUES(:roomId, :sessionId, :index, :eventId, :ts);"_L1);
+    query.bindValue(":roomId"_L1, roomId);
+    query.bindValue(":sessionId"_L1, sessionId);
+    query.bindValue(":index"_L1, index);
+    query.bindValue(":eventId"_L1, eventId);
+    query.bindValue(":ts"_L1, ts);
     transaction();
     execute(query);
     commit();
@@ -421,21 +421,21 @@ void Database::addGroupSessionIndexRecord(const QString& roomId, const QString& 
 std::pair<QString, qint64> Database::groupSessionIndexRecord(const QString& roomId, const QString& sessionId, qint64 index)
 {
     auto query = prepareQuery(QStringLiteral("SELECT * FROM group_session_record_index WHERE roomId=:roomId AND sessionId=:sessionId AND i=:index;"));
-    query.bindValue(":roomId"_ls, roomId);
-    query.bindValue(":sessionId"_ls, sessionId);
-    query.bindValue(":index"_ls, index);
+    query.bindValue(":roomId"_L1, roomId);
+    query.bindValue(":sessionId"_L1, sessionId);
+    query.bindValue(":index"_L1, index);
     transaction();
     execute(query);
     commit();
     if (!query.next()) {
         return {};
     }
-    return {query.value("eventId"_ls).toString(), query.value("ts"_ls).toLongLong()};
+    return {query.value("eventId"_L1).toString(), query.value("ts"_L1).toLongLong()};
 }
 
 QSqlDatabase Database::database() const
 {
-    return QSqlDatabase::database("Quotient_"_ls + m_userId);
+    return QSqlDatabase::database("Quotient_"_L1 + m_userId);
 }
 
 QSqlQuery Database::prepareQuery(const QString& queryString) const
@@ -465,8 +465,8 @@ void Database::clearRoomData(const QString& roomId)
 void Database::setOlmSessionLastReceived(const QByteArray& sessionId, const QDateTime& timestamp)
 {
     auto query = prepareQuery(QStringLiteral("UPDATE olm_sessions SET lastReceived=:lastReceived WHERE sessionId=:sessionId;"));
-    query.bindValue(":lastReceived"_ls, timestamp);
-    query.bindValue(":sessionId"_ls, sessionId);
+    query.bindValue(":lastReceived"_L1, timestamp);
+    query.bindValue(":sessionId"_L1, sessionId);
     transaction();
     execute(query);
     commit();
@@ -478,16 +478,16 @@ void Database::saveCurrentOutboundMegolmSession(const QString& roomId,
     const auto pickle = session.pickle(m_picklingKey);
     auto deleteQuery = prepareQuery(
         QStringLiteral("DELETE FROM outbound_megolm_sessions WHERE roomId=:roomId AND sessionId=:sessionId;"));
-    deleteQuery.bindValue(":roomId"_ls, roomId);
-    deleteQuery.bindValue(":sessionId"_ls, session.sessionId());
+    deleteQuery.bindValue(":roomId"_L1, roomId);
+    deleteQuery.bindValue(":sessionId"_L1, session.sessionId());
 
     auto insertQuery = prepareQuery(
         QStringLiteral("INSERT INTO outbound_megolm_sessions(roomId, sessionId, pickle, creationTime, messageCount) VALUES(:roomId, :sessionId, :pickle, :creationTime, :messageCount);"));
-    insertQuery.bindValue(":roomId"_ls, roomId);
-    insertQuery.bindValue(":sessionId"_ls, session.sessionId());
-    insertQuery.bindValue(":pickle"_ls, pickle);
-    insertQuery.bindValue(":creationTime"_ls, session.creationTime());
-    insertQuery.bindValue(":messageCount"_ls, session.messageCount());
+    insertQuery.bindValue(":roomId"_L1, roomId);
+    insertQuery.bindValue(":sessionId"_L1, session.sessionId());
+    insertQuery.bindValue(":pickle"_L1, pickle);
+    insertQuery.bindValue(":creationTime"_L1, session.creationTime());
+    insertQuery.bindValue(":messageCount"_L1, session.messageCount());
 
     transaction();
     execute(deleteQuery);
@@ -500,14 +500,14 @@ std::optional<QOlmOutboundGroupSession> Database::loadCurrentOutboundMegolmSessi
 {
     auto query = prepareQuery(
         QStringLiteral("SELECT * FROM outbound_megolm_sessions WHERE roomId=:roomId ORDER BY creationTime DESC;"));
-    query.bindValue(":roomId"_ls, roomId);
+    query.bindValue(":roomId"_L1, roomId);
     execute(query);
     if (query.next()) {
         if (auto&& session = QOlmOutboundGroupSession::unpickle(
-                query.value("pickle"_ls).toByteArray(), m_picklingKey)) {
+                query.value("pickle"_L1).toByteArray(), m_picklingKey)) {
             session->setCreationTime(
-                query.value("creationTime"_ls).toDateTime());
-            session->setMessageCount(query.value("messageCount"_ls).toInt());
+                query.value("creationTime"_L1).toDateTime());
+            session->setMessageCount(query.value("messageCount"_L1).toInt());
             return std::move(*session);
         }
     }
@@ -522,12 +522,12 @@ void Database::setDevicesReceivedKey(
     transaction();
     for (const auto& [user, device, curveKey] : devices) {
         auto query = prepareQuery(QStringLiteral("INSERT INTO sent_megolm_sessions(roomId, userId, deviceId, identityKey, sessionId, i) VALUES(:roomId, :userId, :deviceId, :identityKey, :sessionId, :i);"));
-        query.bindValue(":roomId"_ls, roomId);
-        query.bindValue(":userId"_ls, user);
-        query.bindValue(":deviceId"_ls, device);
-        query.bindValue(":identityKey"_ls, curveKey);
-        query.bindValue(":sessionId"_ls, sessionId);
-        query.bindValue(":i"_ls, index);
+        query.bindValue(":roomId"_L1, roomId);
+        query.bindValue(":userId"_L1, user);
+        query.bindValue(":deviceId"_L1, device);
+        query.bindValue(":identityKey"_L1, curveKey);
+        query.bindValue(":sessionId"_L1, sessionId);
+        query.bindValue(":i"_L1, index);
         execute(query);
     }
     commit();
@@ -538,14 +538,14 @@ QMultiHash<QString, QString> Database::devicesWithoutKey(
     const QByteArray& sessionId)
 {
     auto query = prepareQuery(QStringLiteral("SELECT userId, deviceId FROM sent_megolm_sessions WHERE roomId=:roomId AND sessionId=:sessionId"));
-    query.bindValue(":roomId"_ls, roomId);
-    query.bindValue(":sessionId"_ls, sessionId);
+    query.bindValue(":roomId"_L1, roomId);
+    query.bindValue(":sessionId"_L1, sessionId);
     transaction();
     execute(query);
     commit();
     while (query.next()) {
-        devices.remove(query.value("userId"_ls).toString(),
-                       query.value("deviceId"_ls).toString());
+        devices.remove(query.value("userId"_L1).toString(),
+                       query.value("deviceId"_L1).toString());
     }
     return devices;
 }
@@ -555,9 +555,9 @@ void Database::updateOlmSession(const QByteArray& senderKey,
 {
     auto query = prepareQuery(
         QStringLiteral("UPDATE olm_sessions SET pickle=:pickle WHERE senderKey=:senderKey AND sessionId=:sessionId;"));
-    query.bindValue(":pickle"_ls, session.pickle(m_picklingKey));
-    query.bindValue(":senderKey"_ls, senderKey);
-    query.bindValue(":sessionId"_ls, session.sessionId());
+    query.bindValue(":pickle"_L1, session.pickle(m_picklingKey));
+    query.bindValue(":senderKey"_L1, senderKey);
+    query.bindValue(":sessionId"_L1, session.sessionId());
     transaction();
     execute(query);
     commit();
@@ -566,7 +566,7 @@ void Database::updateOlmSession(const QByteArray& senderKey,
 void Database::setSessionVerified(const QString& edKeyId)
 {
     auto query = prepareQuery(QStringLiteral("UPDATE tracked_devices SET verified=true WHERE edKeyId=:edKeyId;"));
-    query.bindValue(":edKeyId"_ls, edKeyId);
+    query.bindValue(":edKeyId"_L1, edKeyId);
     transaction();
     execute(query);
     commit();
@@ -575,21 +575,21 @@ void Database::setSessionVerified(const QString& edKeyId)
 bool Database::isSessionVerified(const QString& edKey)
 {
     auto query = prepareQuery(QStringLiteral("SELECT verified FROM tracked_devices WHERE edKey=:edKey"));
-    query.bindValue(":edKey"_ls, edKey);
+    query.bindValue(":edKey"_L1, edKey);
     execute(query);
-    return query.next() && query.value("verified"_ls).toBool();
+    return query.next() && query.value("verified"_L1).toBool();
 }
 
 QString Database::edKeyForKeyId(const QString& userId, const QString& edKeyId)
 {
     auto query = prepareQuery(QStringLiteral("SELECT edKey FROM tracked_devices WHERE matrixId=:userId and edKeyId=:edKeyId;"));
-    query.bindValue(":matrixId"_ls, userId);
-    query.bindValue(":edKeyId"_ls, edKeyId);
+    query.bindValue(":matrixId"_L1, userId);
+    query.bindValue(":edKeyId"_L1, edKeyId);
     execute(query);
     if (!query.next()) {
         return {};
     }
-    return query.value("edKey"_ls).toString();
+    return query.value("edKey"_L1).toString();
 }
 
 void Database::storeEncrypted(const QString& name, const QByteArray& key)
@@ -604,10 +604,10 @@ void Database::storeEncrypted(const QString& name, const QByteArray& key)
     auto cipher = result.value().toBase64();
     auto query = prepareQuery(QStringLiteral("INSERT INTO encrypted(name, cipher, iv) VALUES(:name, :cipher, :iv);"));
     auto deleteQuery = prepareQuery(QStringLiteral("DELETE FROM encrypted WHERE name=:name;"));
-    deleteQuery.bindValue(":name"_ls, name);
-    query.bindValue(":name"_ls, name);
-    query.bindValue(":cipher"_ls, cipher);
-    query.bindValue(":iv"_ls, iv.toBase64());
+    deleteQuery.bindValue(":name"_L1, name);
+    query.bindValue(":name"_L1, name);
+    query.bindValue(":cipher"_L1, cipher);
+    query.bindValue(":iv"_L1, iv.toBase64());
     transaction();
     execute(deleteQuery);
     execute(query);
@@ -616,14 +616,14 @@ void Database::storeEncrypted(const QString& name, const QByteArray& key)
 
 QByteArray Database::loadEncrypted(const QString& name)
 {
-    auto query = prepareQuery("SELECT cipher, iv FROM encrypted WHERE name=:name;"_ls);
-    query.bindValue(":name"_ls, name);
+    auto query = prepareQuery("SELECT cipher, iv FROM encrypted WHERE name=:name;"_L1);
+    query.bindValue(":name"_L1, name);
     execute(query);
     if (!query.next()) {
         return {};
     }
-    auto cipher = QByteArray::fromBase64(query.value("cipher"_ls).toString().toLatin1());
-    auto iv = QByteArray::fromBase64(query.value("iv"_ls).toString().toLatin1());
+    auto cipher = QByteArray::fromBase64(query.value("cipher"_L1).toString().toLatin1());
+    auto iv = QByteArray::fromBase64(query.value("iv"_L1).toString().toLatin1());
     if (iv.size() < AesBlockSize) {
         qCWarning(E2EE) << "Corrupt iv at the database record for" << name;
         return {};
@@ -637,7 +637,7 @@ QByteArray Database::loadEncrypted(const QString& name)
 void Database::setMasterKeyVerified(const QString& masterKey)
 {
     auto query = prepareQuery(QStringLiteral("UPDATE master_keys SET verified=true WHERE key=:key;"));
-    query.bindValue(":key"_ls, masterKey);
+    query.bindValue(":key"_L1, masterKey);
     transaction();
     execute(query);
     commit();
@@ -646,31 +646,31 @@ void Database::setMasterKeyVerified(const QString& masterKey)
 QString Database::userSigningPublicKey()
 {
     auto query = prepareQuery(QStringLiteral("SELECT key FROM user_signing_keys WHERE userId=:userId;"));
-    query.bindValue(":userId"_ls, m_userId);
+    query.bindValue(":userId"_L1, m_userId);
     execute(query);
-    return query.next() ? query.value("key"_ls).toString() : QString();
+    return query.next() ? query.value("key"_L1).toString() : QString();
 }
 
 QString Database::selfSigningPublicKey()
 {
     auto query = prepareQuery(QStringLiteral("SELECT key FROM self_signing_keys WHERE userId=:userId;"));
-    query.bindValue(":userId"_ls, m_userId);
+    query.bindValue(":userId"_L1, m_userId);
     execute(query);
-    return query.next() ? query.value("key"_ls).toString() : QString();
+    return query.next() ? query.value("key"_L1).toString() : QString();
 }
 
 QString Database::edKeyForMegolmSession(const QString& sessionId)
 {
     auto query = prepareQuery(QStringLiteral("SELECT senderClaimedEd25519Key FROM inbound_megolm_sessions WHERE sessionId=:sessionId;"));
-    query.bindValue(":sessionId"_ls, sessionId.toLatin1());
+    query.bindValue(":sessionId"_L1, sessionId.toLatin1());
     execute(query);
-    return query.next() ? query.value("senderClaimedEd25519Key"_ls).toString() : QString();
+    return query.next() ? query.value("senderClaimedEd25519Key"_L1).toString() : QString();
 }
 
 QString Database::senderKeyForMegolmSession(const QString& sessionId)
 {
     auto query = prepareQuery(QStringLiteral("SELECT senderKey FROM inbound_megolm_sessions WHERE sessionId=:sessionId;"));
-    query.bindValue(":sessionId"_ls, sessionId.toLatin1());
+    query.bindValue(":sessionId"_L1, sessionId.toLatin1());
     execute(query);
-    return query.next() ? query.value("senderKey"_ls).toString() : QString();
+    return query.next() ? query.value("senderKey"_L1).toString() : QString();
 }

--- a/Quotient/database.cpp
+++ b/Quotient/database.cpp
@@ -26,12 +26,10 @@ Database::Database(const QString& userId, const QString& deviceId,
     , m_deviceId(deviceId)
     , m_picklingKey(std::move(picklingKey))
 {
-    auto db = QSqlDatabase::addDatabase(QStringLiteral("QSQLITE"),
-                                        "Quotient_"_L1 + m_userId);
+    auto db = QSqlDatabase::addDatabase(u"QSQLITE"_s, "Quotient_"_L1 + m_userId);
     auto dbDir = m_userId;
     dbDir.replace(u':', u'_');
-    const QString databasePath{ QStandardPaths::writableLocation(
-                                    QStandardPaths::AppDataLocation)
+    const QString databasePath{ QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)
                                 % u'/' % dbDir };
     QDir(databasePath).mkpath("."_L1);
     db.setDatabaseName(databasePath + "/quotient_%1.db3"_L1.arg(m_deviceId));
@@ -53,7 +51,7 @@ Database::Database(const QString& userId, const QString& deviceId,
 
 int Database::version()
 {
-    auto query = execute(QStringLiteral("PRAGMA user_version;"));
+    auto query = execute(u"PRAGMA user_version;"_s);
     if (query.next()) {
         bool ok = false;
         int value = query.value(0).toInt(&ok);
@@ -100,16 +98,16 @@ void Database::migrateTo1()
 {
     qCDebug(DATABASE) << "Migrating database to version 1";
     transaction();
-    execute(QStringLiteral("CREATE TABLE accounts (pickle TEXT);"));
-    execute(QStringLiteral("CREATE TABLE olm_sessions (senderKey TEXT, sessionId TEXT, pickle TEXT);"));
-    execute(QStringLiteral("CREATE TABLE inbound_megolm_sessions (roomId TEXT, senderKey TEXT, sessionId TEXT, pickle TEXT);"));
-    execute(QStringLiteral("CREATE TABLE outbound_megolm_sessions (roomId TEXT, senderKey TEXT, sessionId TEXT, pickle TEXT);"));
-    execute(QStringLiteral("CREATE TABLE group_session_record_index (roomId TEXT, sessionId TEXT, i INTEGER, eventId TEXT, ts INTEGER);"));
-    execute(QStringLiteral("CREATE TABLE tracked_users (matrixId TEXT);"));
-    execute(QStringLiteral("CREATE TABLE outdated_users (matrixId TEXT);"));
-    execute(QStringLiteral("CREATE TABLE tracked_devices (matrixId TEXT, deviceId TEXT, curveKeyId TEXT, curveKey TEXT, edKeyId TEXT, edKey TEXT);"));
+    execute(u"CREATE TABLE accounts (pickle TEXT);"_s);
+    execute(u"CREATE TABLE olm_sessions (senderKey TEXT, sessionId TEXT, pickle TEXT);"_s);
+    execute(u"CREATE TABLE inbound_megolm_sessions (roomId TEXT, senderKey TEXT, sessionId TEXT, pickle TEXT);"_s);
+    execute(u"CREATE TABLE outbound_megolm_sessions (roomId TEXT, senderKey TEXT, sessionId TEXT, pickle TEXT);"_s);
+    execute(u"CREATE TABLE group_session_record_index (roomId TEXT, sessionId TEXT, i INTEGER, eventId TEXT, ts INTEGER);"_s);
+    execute(u"CREATE TABLE tracked_users (matrixId TEXT);"_s);
+    execute(u"CREATE TABLE outdated_users (matrixId TEXT);"_s);
+    execute(u"CREATE TABLE tracked_devices (matrixId TEXT, deviceId TEXT, curveKeyId TEXT, curveKey TEXT, edKeyId TEXT, edKey TEXT);"_s);
 
-    execute(QStringLiteral("PRAGMA user_version = 1;"));
+    execute(u"PRAGMA user_version = 1;"_s);
     commit();
 }
 
@@ -118,15 +116,15 @@ void Database::migrateTo2()
     qCDebug(DATABASE) << "Migrating database to version 2";
     transaction();
 
-    execute(QStringLiteral("ALTER TABLE inbound_megolm_sessions ADD ed25519Key TEXT"));
-    execute(QStringLiteral("ALTER TABLE olm_sessions ADD lastReceived TEXT"));
+    execute(u"ALTER TABLE inbound_megolm_sessions ADD ed25519Key TEXT"_s);
+    execute(u"ALTER TABLE olm_sessions ADD lastReceived TEXT"_s);
 
     // Add indexes for improving queries speed on larger database
-    execute(QStringLiteral("CREATE INDEX sessions_session_idx ON olm_sessions(sessionId)"));
-    execute(QStringLiteral("CREATE INDEX outbound_room_idx ON outbound_megolm_sessions(roomId)"));
-    execute(QStringLiteral("CREATE INDEX inbound_room_idx ON inbound_megolm_sessions(roomId)"));
-    execute(QStringLiteral("CREATE INDEX group_session_idx ON group_session_record_index(roomId, sessionId, i)"));
-    execute(QStringLiteral("PRAGMA user_version = 2;"));
+    execute(u"CREATE INDEX sessions_session_idx ON olm_sessions(sessionId)"_s);
+    execute(u"CREATE INDEX outbound_room_idx ON outbound_megolm_sessions(roomId)"_s);
+    execute(u"CREATE INDEX inbound_room_idx ON inbound_megolm_sessions(roomId)"_s);
+    execute(u"CREATE INDEX group_session_idx ON group_session_record_index(roomId, sessionId, i)"_s);
+    execute(u"PRAGMA user_version = 2;"_s);
     commit();
 }
 
@@ -135,12 +133,12 @@ void Database::migrateTo3()
     qCDebug(DATABASE) << "Migrating database to version 3";
     transaction();
 
-    execute(QStringLiteral("CREATE TABLE inbound_megolm_sessions_temp AS SELECT roomId, sessionId, pickle FROM inbound_megolm_sessions;"));
-    execute(QStringLiteral("DROP TABLE inbound_megolm_sessions;"));
-    execute(QStringLiteral("ALTER TABLE inbound_megolm_sessions_temp RENAME TO inbound_megolm_sessions;"));
-    execute(QStringLiteral("ALTER TABLE inbound_megolm_sessions ADD olmSessionId TEXT;"));
-    execute(QStringLiteral("ALTER TABLE inbound_megolm_sessions ADD senderId TEXT;"));
-    execute(QStringLiteral("PRAGMA user_version = 3;"));
+    execute(u"CREATE TABLE inbound_megolm_sessions_temp AS SELECT roomId, sessionId, pickle FROM inbound_megolm_sessions;"_s);
+    execute(u"DROP TABLE inbound_megolm_sessions;"_s);
+    execute(u"ALTER TABLE inbound_megolm_sessions_temp RENAME TO inbound_megolm_sessions;"_s);
+    execute(u"ALTER TABLE inbound_megolm_sessions ADD olmSessionId TEXT;"_s);
+    execute(u"ALTER TABLE inbound_megolm_sessions ADD senderId TEXT;"_s);
+    execute(u"PRAGMA user_version = 3;"_s);
     commit();
 }
 
@@ -149,10 +147,10 @@ void Database::migrateTo4()
     qCDebug(DATABASE) << "Migrating database to version 4";
     transaction();
 
-    execute(QStringLiteral("CREATE TABLE sent_megolm_sessions (roomId TEXT, userId TEXT, deviceId TEXT, identityKey TEXT, sessionId TEXT, i INTEGER);"));
-    execute(QStringLiteral("ALTER TABLE outbound_megolm_sessions ADD creationTime TEXT;"));
-    execute(QStringLiteral("ALTER TABLE outbound_megolm_sessions ADD messageCount INTEGER;"));
-    execute(QStringLiteral("PRAGMA user_version = 4;"));
+    execute(u"CREATE TABLE sent_megolm_sessions (roomId TEXT, userId TEXT, deviceId TEXT, identityKey TEXT, sessionId TEXT, i INTEGER);"_s);
+    execute(u"ALTER TABLE outbound_megolm_sessions ADD creationTime TEXT;"_s);
+    execute(u"ALTER TABLE outbound_megolm_sessions ADD messageCount INTEGER;"_s);
+    execute(u"PRAGMA user_version = 4;"_s);
     commit();
 }
 
@@ -161,8 +159,8 @@ void Database::migrateTo5()
     qCDebug(DATABASE) << "Migrating database to version 5";
     transaction();
 
-    execute(QStringLiteral("ALTER TABLE tracked_devices ADD verified BOOL;"));
-    execute(QStringLiteral("PRAGMA user_version = 5"));
+    execute(u"ALTER TABLE tracked_devices ADD verified BOOL;"_s);
+    execute(u"PRAGMA user_version = 5"_s);
     commit();
 }
 
@@ -171,8 +169,8 @@ void Database::migrateTo6()
     qCDebug(DATABASE) << "Migrating database to version 6";
     transaction();
 
-    execute(QStringLiteral("CREATE TABLE encrypted (name TEXT, cipher TEXT, iv TEXT);"));
-    execute(QStringLiteral("PRAGMA user_version = 6"));
+    execute(u"CREATE TABLE encrypted (name TEXT, cipher TEXT, iv TEXT);"_s);
+    execute(u"PRAGMA user_version = 6"_s);
     commit();
 }
 
@@ -180,12 +178,12 @@ void Database::migrateTo7()
 {
     qCDebug(DATABASE) << "Migrating database to version 7";
     transaction();
-    execute(QStringLiteral("CREATE TABLE master_keys (userId TEXT, key TEXT, verified INTEGER);"));
-    execute(QStringLiteral("CREATE TABLE self_signing_keys (userId TEXT, key TEXT);"));
-    execute(QStringLiteral("CREATE TABLE user_signing_keys (userId TEXT, key TEXT);"));
-    execute(QStringLiteral("INSERT INTO outdated_users SELECT * FROM tracked_users;"));
-    execute(QStringLiteral("ALTER TABLE tracked_devices ADD selfVerified INTEGER;"));
-    execute(QStringLiteral("PRAGMA user_version = 7;"));
+    execute(u"CREATE TABLE master_keys (userId TEXT, key TEXT, verified INTEGER);"_s);
+    execute(u"CREATE TABLE self_signing_keys (userId TEXT, key TEXT);"_s);
+    execute(u"CREATE TABLE user_signing_keys (userId TEXT, key TEXT);"_s);
+    execute(u"INSERT INTO outdated_users SELECT * FROM tracked_users;"_s);
+    execute(u"ALTER TABLE tracked_devices ADD selfVerified INTEGER;"_s);
+    execute(u"PRAGMA user_version = 7;"_s);
 
     commit();
 }
@@ -195,26 +193,26 @@ void Database::migrateTo8()
     qCDebug(DATABASE) << "Migrating database to version 8";
     transaction();
 
-    execute(QStringLiteral("ALTER TABLE inbound_megolm_sessions ADD senderKey TEXT;"));
-    auto query = prepareQuery("SELECT sessionId, olmSessionId FROM inbound_megolm_sessions;"_L1);
+    execute(u"ALTER TABLE inbound_megolm_sessions ADD senderKey TEXT;"_s);
+    auto query = prepareQuery(u"SELECT sessionId, olmSessionId FROM inbound_megolm_sessions;"_s);
     execute(query);
     while (query.next()) {
-        if (query.value("olmSessionId"_L1).toString().startsWith("BACKUP"_L1)) {
+        if (query.value(u"olmSessionId"_s).toString().startsWith(u"BACKUP")) {
             continue;
         }
-        auto senderKeyQuery = prepareQuery("SELECT senderKey FROM olm_sessions WHERE sessionId=:olmSessionId;"_L1);
-        senderKeyQuery.bindValue(":olmSessionId"_L1, query.value("olmSessionId"_L1).toByteArray());
+        auto senderKeyQuery = prepareQuery(u"SELECT senderKey FROM olm_sessions WHERE sessionId=:olmSessionId;"_s);
+        senderKeyQuery.bindValue(u":olmSessionId"_s, query.value(u"olmSessionId"_s).toByteArray());
         execute(senderKeyQuery);
         if (!senderKeyQuery.next()) {
             continue;
         }
-        auto updateQuery = prepareQuery("UPDATE inbound_megolm_sessions SET senderKey=:senderKey WHERE sessionId=:sessionId;"_L1);
-        updateQuery.bindValue(":sessionId"_L1, query.value("sessionId"_L1).toByteArray());
-        updateQuery.bindValue(":senderKey"_L1, senderKeyQuery.value("senderKey"_L1).toByteArray());
+        auto updateQuery = prepareQuery(u"UPDATE inbound_megolm_sessions SET senderKey=:senderKey WHERE sessionId=:sessionId;"_s);
+        updateQuery.bindValue(u":sessionId"_s, query.value(u"sessionId"_s).toByteArray());
+        updateQuery.bindValue(u":senderKey"_s, senderKeyQuery.value(u"senderKey"_s).toByteArray());
 
         execute(updateQuery);
     }
-    execute(QStringLiteral("PRAGMA user_version = 8;"));
+    execute(u"PRAGMA user_version = 8;"_s);
     commit();
 }
 
@@ -223,18 +221,18 @@ void Database::migrateTo9()
     qCDebug(DATABASE) << "Migrating database to version 9";
     transaction();
 
-    auto query = prepareQuery("SELECT curveKey FROM tracked_devices WHERE matrixId=:matrixId AND deviceId=:deviceId;"_L1);
-    query.bindValue(":matrixId"_L1, m_userId);
-    query.bindValue(":deviceId"_L1, m_deviceId);
+    auto query = prepareQuery(u"SELECT curveKey FROM tracked_devices WHERE matrixId=:matrixId AND deviceId=:deviceId;"_s);
+    query.bindValue(u":matrixId"_s, m_userId);
+    query.bindValue(u":deviceId"_s, m_deviceId);
     execute(query);
     if (!query.next()) {
         return;
     }
-    auto curveKey = query.value("curveKey"_L1).toByteArray();
-    query = prepareQuery("UPDATE inbound_megolm_sessions SET senderKey=:senderKey WHERE olmSessionId=:self;"_L1);
-    query.bindValue(":senderKey"_L1, curveKey);
-    query.bindValue(":self"_L1, QByteArrayLiteral("SELF"));
-    execute(QStringLiteral("PRAGMA user_version = 9;"));
+    auto curveKey = query.value(u"curveKey"_s).toByteArray();
+    query = prepareQuery(u"UPDATE inbound_megolm_sessions SET senderKey=:senderKey WHERE olmSessionId=:self;"_s);
+    query.bindValue(u":senderKey"_s, curveKey);
+    query.bindValue(u":self"_s, "SELF"_ba);
+    execute(u"PRAGMA user_version = 9;"_s);
     execute(query);
     commit();
 }
@@ -245,40 +243,40 @@ void Database::migrateTo10()
 
     transaction();
 
-    execute(QStringLiteral("ALTER TABLE inbound_megolm_sessions ADD senderClaimedEd25519Key TEXT;"));
+    execute(u"ALTER TABLE inbound_megolm_sessions ADD senderClaimedEd25519Key TEXT;"_s);
 
-    auto query = prepareQuery("SELECT DISTINCT senderKey FROM inbound_megolm_sessions;"_L1);
+    auto query = prepareQuery(u"SELECT DISTINCT senderKey FROM inbound_megolm_sessions;"_s);
     execute(query);
 
     QStringList keys;
     while (query.next()) {
-        keys += query.value("senderKey"_L1).toString();
+        keys += query.value(u"senderKey"_s).toString();
     }
     for (const auto& key : keys) {
-        auto edKeyQuery = prepareQuery("SELECT edKey FROM tracked_devices WHERE curveKey=:curveKey;"_L1);
-        edKeyQuery.bindValue(":curveKey"_L1, key);
+        auto edKeyQuery = prepareQuery(u"SELECT edKey FROM tracked_devices WHERE curveKey=:curveKey;"_s);
+        edKeyQuery.bindValue(u":curveKey"_s, key);
         execute(edKeyQuery);
         if (!edKeyQuery.next()) {
             continue;
         }
-        const auto &edKey = edKeyQuery.value("edKey"_L1).toByteArray();
+        const auto &edKey = edKeyQuery.value(u"edKey"_s).toByteArray();
 
-        auto updateQuery = prepareQuery("UPDATE inbound_megolm_sessions SET senderClaimedEd25519Key=:senderClaimedEd25519Key WHERE senderKey=:senderKey;"_L1);
-        updateQuery.bindValue(":senderKey"_L1, key.toLatin1());
-        updateQuery.bindValue(":senderClaimedEd25519Key"_L1, edKey);
+        auto updateQuery = prepareQuery(u"UPDATE inbound_megolm_sessions SET senderClaimedEd25519Key=:senderClaimedEd25519Key WHERE senderKey=:senderKey;"_s);
+        updateQuery.bindValue(u":senderKey"_s, key.toLatin1());
+        updateQuery.bindValue(u":senderClaimedEd25519Key"_s, edKey);
         execute(updateQuery);
     }
 
-    execute(QStringLiteral("pragma user_version = 10"));
+    execute(u"pragma user_version = 10"_s);
     commit();
 
 }
 
 void Database::storeOlmAccount(const QOlmAccount& olmAccount)
 {
-    auto deleteQuery = prepareQuery(QStringLiteral("DELETE FROM accounts;"));
-    auto query = prepareQuery(QStringLiteral("INSERT INTO accounts(pickle) VALUES(:pickle);"));
-    query.bindValue(":pickle"_L1, olmAccount.pickle(m_picklingKey));
+    auto deleteQuery = prepareQuery(u"DELETE FROM accounts;"_s);
+    auto query = prepareQuery(u"INSERT INTO accounts(pickle) VALUES(:pickle);"_s);
+    query.bindValue(u":pickle"_s, olmAccount.pickle(m_picklingKey));
     transaction();
     execute(deleteQuery);
     execute(query);
@@ -287,11 +285,10 @@ void Database::storeOlmAccount(const QOlmAccount& olmAccount)
 
 std::optional<OlmErrorCode> Database::setupOlmAccount(QOlmAccount& olmAccount)
 {
-    auto query = prepareQuery(QStringLiteral("SELECT pickle FROM accounts;"));
+    auto query = prepareQuery(u"SELECT pickle FROM accounts;"_s);
     execute(query);
     if (query.next())
-        return olmAccount.unpickle(
-            query.value(QStringLiteral("pickle")).toByteArray(), m_picklingKey);
+        return olmAccount.unpickle(query.value(u"pickle"_s).toByteArray(), m_picklingKey);
 
     olmAccount.setupNewAccount();
     return {};
@@ -301,13 +298,13 @@ void Database::clear()
 {
     // SQLite driver only supports one query at a time, so feed them one by one
     transaction();
-    for (auto&& q : { QStringLiteral("DELETE FROM accounts;"), // @clang-format: one per line, plz
-                      QStringLiteral("DELETE FROM olm_sessions;"),
-                      QStringLiteral("DELETE FROM inbound_megolm_sessions;"),
-                      QStringLiteral("DELETE FROM group_session_record_index;"),
-                      QStringLiteral("DELETE FROM master_keys;"),
-                      QStringLiteral("DELETE FROM self_signing_keys;"),
-                      QStringLiteral("DELETE FROM user_signing_keys;") })
+    for (auto&& q : { u"DELETE FROM accounts;"_s, // @clang-format: one per line, plz
+                      u"DELETE FROM olm_sessions;"_s, //
+                      u"DELETE FROM inbound_megolm_sessions;"_s, //
+                      u"DELETE FROM group_session_record_index;"_s, //
+                      u"DELETE FROM master_keys;"_s, //
+                      u"DELETE FROM self_signing_keys;"_s, //
+                      u"DELETE FROM user_signing_keys;"_s })
         execute(q);
     commit();
 
@@ -317,11 +314,11 @@ void Database::saveOlmSession(const QByteArray& senderKey,
                               const QOlmSession& session,
                               const QDateTime& timestamp)
 {
-    auto query = prepareQuery(QStringLiteral("INSERT INTO olm_sessions(senderKey, sessionId, pickle, lastReceived) VALUES(:senderKey, :sessionId, :pickle, :lastReceived);"));
-    query.bindValue(":senderKey"_L1, senderKey);
-    query.bindValue(":sessionId"_L1, session.sessionId());
-    query.bindValue(":pickle"_L1, session.pickle(m_picklingKey));
-    query.bindValue(":lastReceived"_L1, timestamp);
+    auto query = prepareQuery(u"INSERT INTO olm_sessions(senderKey, sessionId, pickle, lastReceived) VALUES(:senderKey, :sessionId, :pickle, :lastReceived);"_s);
+    query.bindValue(u":senderKey"_s, senderKey);
+    query.bindValue(u":sessionId"_s, session.sessionId());
+    query.bindValue(u":pickle"_s, session.pickle(m_picklingKey));
+    query.bindValue(u":lastReceived"_s, timestamp);
     transaction();
     execute(query);
     commit();
@@ -329,17 +326,15 @@ void Database::saveOlmSession(const QByteArray& senderKey,
 
 std::unordered_map<QByteArray, std::vector<QOlmSession> > Database::loadOlmSessions()
 {
-    auto query = prepareQuery(QStringLiteral(
-        "SELECT * FROM olm_sessions ORDER BY lastReceived DESC;"));
+    auto query = prepareQuery(u"SELECT * FROM olm_sessions ORDER BY lastReceived DESC;"_s);
     transaction();
     execute(query);
     commit();
     std::unordered_map<QByteArray, std::vector<QOlmSession>> sessions;
     while (query.next()) {
         if (auto&& expectedSession =
-                QOlmSession::unpickle(query.value("pickle"_L1).toByteArray(),
-                                      m_picklingKey)) {
-            sessions[query.value("senderKey"_L1).toByteArray()].emplace_back(
+                QOlmSession::unpickle(query.value(u"pickle"_s).toByteArray(), m_picklingKey)) {
+            sessions[query.value(u"senderKey"_s).toByteArray()].emplace_back(
                 std::move(*expectedSession));
         } else
             qCWarning(E2EE)
@@ -351,16 +346,16 @@ std::unordered_map<QByteArray, std::vector<QOlmSession> > Database::loadOlmSessi
 std::unordered_map<QByteArray, QOlmInboundGroupSession> Database::loadMegolmSessions(
     const QString& roomId)
 {
-    auto query = prepareQuery(QStringLiteral("SELECT * FROM inbound_megolm_sessions WHERE roomId=:roomId;"));
-    query.bindValue(":roomId"_L1, roomId);
+    auto query = prepareQuery(u"SELECT * FROM inbound_megolm_sessions WHERE roomId=:roomId;"_s);
+    query.bindValue(u":roomId"_s, roomId);
     transaction();
     execute(query);
     commit();
     decltype(Database::loadMegolmSessions({})) sessions;
     while (query.next()) {
         if (auto&& expectedSession = QOlmInboundGroupSession::unpickle(
-                query.value("pickle"_L1).toByteArray(), m_picklingKey)) {
-            const auto sessionId = query.value("sessionId"_L1).toByteArray();
+                query.value(u"pickle"_s).toByteArray(), m_picklingKey)) {
+            const auto sessionId = query.value(u"sessionId"_s).toByteArray();
             if (const auto it = sessions.find(sessionId); it != sessions.end()) {
                 qCritical(DATABASE) << "More than one inbound group session "
                                        "with the same session id"
@@ -373,9 +368,9 @@ std::unordered_map<QByteArray, QOlmInboundGroupSession> Database::loadMegolmSess
                 sessions.erase(it);
             }
             expectedSession->setOlmSessionId(
-                query.value("olmSessionId"_L1).toByteArray());
-            expectedSession->setSenderId(query.value("senderId"_L1).toString());
-            sessions.try_emplace(query.value("sessionId"_L1).toByteArray(),
+                query.value(u"olmSessionId"_s).toByteArray());
+            expectedSession->setSenderId(query.value(u"senderId"_s).toString());
+            sessions.try_emplace(query.value(u"sessionId"_s).toByteArray(),
                                  std::move(*expectedSession));
         } else
             qCWarning(E2EE) << "Failed to unpickle megolm session:"
@@ -387,18 +382,18 @@ std::unordered_map<QByteArray, QOlmInboundGroupSession> Database::loadMegolmSess
 void Database::saveMegolmSession(const QString& roomId,
                                  const QOlmInboundGroupSession& session, const QByteArray &senderKey, const QByteArray& senderClaimedEdKey)
 {
-    auto deleteQuery = prepareQuery(QStringLiteral("DELETE FROM inbound_megolm_sessions WHERE roomId=:roomId AND sessionId=:sessionId;"));
-    deleteQuery.bindValue(":roomId"_L1, roomId);
-    deleteQuery.bindValue(":sessionId"_L1, session.sessionId());
+    auto deleteQuery = prepareQuery(u"DELETE FROM inbound_megolm_sessions WHERE roomId=:roomId AND sessionId=:sessionId;"_s);
+    deleteQuery.bindValue(u":roomId"_s, roomId);
+    deleteQuery.bindValue(u":sessionId"_s, session.sessionId());
     auto query = prepareQuery(
-        QStringLiteral("INSERT INTO inbound_megolm_sessions(roomId, sessionId, pickle, senderId, olmSessionId, senderKey, senderClaimedEd25519Key) VALUES(:roomId, :sessionId, :pickle, :senderId, :olmSessionId, :senderKey, :senderClaimedEd25519Key);"));
-    query.bindValue(":roomId"_L1, roomId);
-    query.bindValue(":sessionId"_L1, session.sessionId());
-    query.bindValue(":pickle"_L1, session.pickle(m_picklingKey));
-    query.bindValue(":senderId"_L1, session.senderId());
-    query.bindValue(":olmSessionId"_L1, session.olmSessionId());
-    query.bindValue(":senderKey"_L1, senderKey);
-    query.bindValue(":senderClaimedEd25519Key"_L1, senderClaimedEdKey);
+        u"INSERT INTO inbound_megolm_sessions(roomId, sessionId, pickle, senderId, olmSessionId, senderKey, senderClaimedEd25519Key) VALUES(:roomId, :sessionId, :pickle, :senderId, :olmSessionId, :senderKey, :senderClaimedEd25519Key);"_s);
+    query.bindValue(u":roomId"_s, roomId);
+    query.bindValue(u":sessionId"_s, session.sessionId());
+    query.bindValue(u":pickle"_s, session.pickle(m_picklingKey));
+    query.bindValue(u":senderId"_s, session.senderId());
+    query.bindValue(u":olmSessionId"_s, session.olmSessionId());
+    query.bindValue(u":senderKey"_s, senderKey);
+    query.bindValue(u":senderClaimedEd25519Key"_s, senderClaimedEdKey);
     transaction();
     execute(deleteQuery);
     execute(query);
@@ -407,12 +402,12 @@ void Database::saveMegolmSession(const QString& roomId,
 
 void Database::addGroupSessionIndexRecord(const QString& roomId, const QString& sessionId, uint32_t index, const QString& eventId, qint64 ts)
 {
-    auto query = prepareQuery("INSERT INTO group_session_record_index(roomId, sessionId, i, eventId, ts) VALUES(:roomId, :sessionId, :index, :eventId, :ts);"_L1);
-    query.bindValue(":roomId"_L1, roomId);
-    query.bindValue(":sessionId"_L1, sessionId);
-    query.bindValue(":index"_L1, index);
-    query.bindValue(":eventId"_L1, eventId);
-    query.bindValue(":ts"_L1, ts);
+    auto query = prepareQuery(u"INSERT INTO group_session_record_index(roomId, sessionId, i, eventId, ts) VALUES(:roomId, :sessionId, :index, :eventId, :ts);"_s);
+    query.bindValue(u":roomId"_s, roomId);
+    query.bindValue(u":sessionId"_s, sessionId);
+    query.bindValue(u":index"_s, index);
+    query.bindValue(u":eventId"_s, eventId);
+    query.bindValue(u":ts"_s, ts);
     transaction();
     execute(query);
     commit();
@@ -420,17 +415,17 @@ void Database::addGroupSessionIndexRecord(const QString& roomId, const QString& 
 
 std::pair<QString, qint64> Database::groupSessionIndexRecord(const QString& roomId, const QString& sessionId, qint64 index)
 {
-    auto query = prepareQuery(QStringLiteral("SELECT * FROM group_session_record_index WHERE roomId=:roomId AND sessionId=:sessionId AND i=:index;"));
-    query.bindValue(":roomId"_L1, roomId);
-    query.bindValue(":sessionId"_L1, sessionId);
-    query.bindValue(":index"_L1, index);
+    auto query = prepareQuery(u"SELECT * FROM group_session_record_index WHERE roomId=:roomId AND sessionId=:sessionId AND i=:index;"_s);
+    query.bindValue(u":roomId"_s, roomId);
+    query.bindValue(u":sessionId"_s, sessionId);
+    query.bindValue(u":index"_s, index);
     transaction();
     execute(query);
     commit();
     if (!query.next()) {
         return {};
     }
-    return {query.value("eventId"_L1).toString(), query.value("ts"_L1).toLongLong()};
+    return {query.value(u"eventId"_s).toString(), query.value(u"ts"_s).toLongLong()};
 }
 
 QSqlDatabase Database::database() const
@@ -449,14 +444,11 @@ void Database::clearRoomData(const QString& roomId)
 {
     transaction();
     for (const auto& queryText :
-         { QStringLiteral(
-               "DELETE FROM inbound_megolm_sessions WHERE roomId=:roomId;"),
-           QStringLiteral(
-               "DELETE FROM outbound_megolm_sessions WHERE roomId=:roomId;"),
-           QStringLiteral("DELETE FROM group_session_record_index WHERE "
-                          "roomId=:roomId;") }) {
+         { u"DELETE FROM inbound_megolm_sessions WHERE roomId=:roomId;"_s,
+           u"DELETE FROM outbound_megolm_sessions WHERE roomId=:roomId;"_s,
+           u"DELETE FROM group_session_record_index WHERE roomId=:roomId;"_s }) {
         auto q = prepareQuery(queryText);
-        q.bindValue(QStringLiteral(":roomId"), roomId);
+        q.bindValue(u":roomId"_s, roomId);
         execute(q);
     }
     commit();
@@ -464,9 +456,9 @@ void Database::clearRoomData(const QString& roomId)
 
 void Database::setOlmSessionLastReceived(const QByteArray& sessionId, const QDateTime& timestamp)
 {
-    auto query = prepareQuery(QStringLiteral("UPDATE olm_sessions SET lastReceived=:lastReceived WHERE sessionId=:sessionId;"));
-    query.bindValue(":lastReceived"_L1, timestamp);
-    query.bindValue(":sessionId"_L1, sessionId);
+    auto query = prepareQuery(u"UPDATE olm_sessions SET lastReceived=:lastReceived WHERE sessionId=:sessionId;"_s);
+    query.bindValue(u":lastReceived"_s, timestamp);
+    query.bindValue(u":sessionId"_s, sessionId);
     transaction();
     execute(query);
     commit();
@@ -477,17 +469,17 @@ void Database::saveCurrentOutboundMegolmSession(const QString& roomId,
 {
     const auto pickle = session.pickle(m_picklingKey);
     auto deleteQuery = prepareQuery(
-        QStringLiteral("DELETE FROM outbound_megolm_sessions WHERE roomId=:roomId AND sessionId=:sessionId;"));
-    deleteQuery.bindValue(":roomId"_L1, roomId);
-    deleteQuery.bindValue(":sessionId"_L1, session.sessionId());
+        u"DELETE FROM outbound_megolm_sessions WHERE roomId=:roomId AND sessionId=:sessionId;"_s);
+    deleteQuery.bindValue(u":roomId"_s, roomId);
+    deleteQuery.bindValue(u":sessionId"_s, session.sessionId());
 
     auto insertQuery = prepareQuery(
-        QStringLiteral("INSERT INTO outbound_megolm_sessions(roomId, sessionId, pickle, creationTime, messageCount) VALUES(:roomId, :sessionId, :pickle, :creationTime, :messageCount);"));
-    insertQuery.bindValue(":roomId"_L1, roomId);
-    insertQuery.bindValue(":sessionId"_L1, session.sessionId());
-    insertQuery.bindValue(":pickle"_L1, pickle);
-    insertQuery.bindValue(":creationTime"_L1, session.creationTime());
-    insertQuery.bindValue(":messageCount"_L1, session.messageCount());
+        u"INSERT INTO outbound_megolm_sessions(roomId, sessionId, pickle, creationTime, messageCount) VALUES(:roomId, :sessionId, :pickle, :creationTime, :messageCount);"_s);
+    insertQuery.bindValue(u":roomId"_s, roomId);
+    insertQuery.bindValue(u":sessionId"_s, session.sessionId());
+    insertQuery.bindValue(u":pickle"_s, pickle);
+    insertQuery.bindValue(u":creationTime"_s, session.creationTime());
+    insertQuery.bindValue(u":messageCount"_s, session.messageCount());
 
     transaction();
     execute(deleteQuery);
@@ -499,15 +491,15 @@ std::optional<QOlmOutboundGroupSession> Database::loadCurrentOutboundMegolmSessi
     const QString& roomId)
 {
     auto query = prepareQuery(
-        QStringLiteral("SELECT * FROM outbound_megolm_sessions WHERE roomId=:roomId ORDER BY creationTime DESC;"));
-    query.bindValue(":roomId"_L1, roomId);
+        u"SELECT * FROM outbound_megolm_sessions WHERE roomId=:roomId ORDER BY creationTime DESC;"_s);
+    query.bindValue(u":roomId"_s, roomId);
     execute(query);
     if (query.next()) {
-        if (auto&& session = QOlmOutboundGroupSession::unpickle(
-                query.value("pickle"_L1).toByteArray(), m_picklingKey)) {
-            session->setCreationTime(
-                query.value("creationTime"_L1).toDateTime());
-            session->setMessageCount(query.value("messageCount"_L1).toInt());
+        if (auto&& session =
+                QOlmOutboundGroupSession::unpickle(query.value(u"pickle"_s).toByteArray(),
+                                                   m_picklingKey)) {
+            session->setCreationTime(query.value(u"creationTime"_s).toDateTime());
+            session->setMessageCount(query.value(u"messageCount"_s).toInt());
             return std::move(*session);
         }
     }
@@ -521,13 +513,13 @@ void Database::setDevicesReceivedKey(
 {
     transaction();
     for (const auto& [user, device, curveKey] : devices) {
-        auto query = prepareQuery(QStringLiteral("INSERT INTO sent_megolm_sessions(roomId, userId, deviceId, identityKey, sessionId, i) VALUES(:roomId, :userId, :deviceId, :identityKey, :sessionId, :i);"));
-        query.bindValue(":roomId"_L1, roomId);
-        query.bindValue(":userId"_L1, user);
-        query.bindValue(":deviceId"_L1, device);
-        query.bindValue(":identityKey"_L1, curveKey);
-        query.bindValue(":sessionId"_L1, sessionId);
-        query.bindValue(":i"_L1, index);
+        auto query = prepareQuery(u"INSERT INTO sent_megolm_sessions(roomId, userId, deviceId, identityKey, sessionId, i) VALUES(:roomId, :userId, :deviceId, :identityKey, :sessionId, :i);"_s);
+        query.bindValue(u":roomId"_s, roomId);
+        query.bindValue(u":userId"_s, user);
+        query.bindValue(u":deviceId"_s, device);
+        query.bindValue(u":identityKey"_s, curveKey);
+        query.bindValue(u":sessionId"_s, sessionId);
+        query.bindValue(u":i"_s, index);
         execute(query);
     }
     commit();
@@ -537,16 +529,15 @@ QMultiHash<QString, QString> Database::devicesWithoutKey(
     const QString& roomId, QMultiHash<QString, QString> devices,
     const QByteArray& sessionId)
 {
-    auto query = prepareQuery(QStringLiteral("SELECT userId, deviceId FROM sent_megolm_sessions WHERE roomId=:roomId AND sessionId=:sessionId"));
-    query.bindValue(":roomId"_L1, roomId);
-    query.bindValue(":sessionId"_L1, sessionId);
+    auto query = prepareQuery(u"SELECT userId, deviceId FROM sent_megolm_sessions WHERE roomId=:roomId AND sessionId=:sessionId"_s);
+    query.bindValue(u":roomId"_s, roomId);
+    query.bindValue(u":sessionId"_s, sessionId);
     transaction();
     execute(query);
     commit();
-    while (query.next()) {
-        devices.remove(query.value("userId"_L1).toString(),
-                       query.value("deviceId"_L1).toString());
-    }
+    while (query.next())
+        devices.remove(query.value(u"userId"_s).toString(), query.value(u"deviceId"_s).toString());
+
     return devices;
 }
 
@@ -554,10 +545,10 @@ void Database::updateOlmSession(const QByteArray& senderKey,
                                 const QOlmSession& session)
 {
     auto query = prepareQuery(
-        QStringLiteral("UPDATE olm_sessions SET pickle=:pickle WHERE senderKey=:senderKey AND sessionId=:sessionId;"));
-    query.bindValue(":pickle"_L1, session.pickle(m_picklingKey));
-    query.bindValue(":senderKey"_L1, senderKey);
-    query.bindValue(":sessionId"_L1, session.sessionId());
+        u"UPDATE olm_sessions SET pickle=:pickle WHERE senderKey=:senderKey AND sessionId=:sessionId;"_s);
+    query.bindValue(u":pickle"_s, session.pickle(m_picklingKey));
+    query.bindValue(u":senderKey"_s, senderKey);
+    query.bindValue(u":sessionId"_s, session.sessionId());
     transaction();
     execute(query);
     commit();
@@ -565,8 +556,8 @@ void Database::updateOlmSession(const QByteArray& senderKey,
 
 void Database::setSessionVerified(const QString& edKeyId)
 {
-    auto query = prepareQuery(QStringLiteral("UPDATE tracked_devices SET verified=true WHERE edKeyId=:edKeyId;"));
-    query.bindValue(":edKeyId"_L1, edKeyId);
+    auto query = prepareQuery(u"UPDATE tracked_devices SET verified=true WHERE edKeyId=:edKeyId;"_s);
+    query.bindValue(u":edKeyId"_s, edKeyId);
     transaction();
     execute(query);
     commit();
@@ -574,22 +565,22 @@ void Database::setSessionVerified(const QString& edKeyId)
 
 bool Database::isSessionVerified(const QString& edKey)
 {
-    auto query = prepareQuery(QStringLiteral("SELECT verified FROM tracked_devices WHERE edKey=:edKey"));
-    query.bindValue(":edKey"_L1, edKey);
+    auto query = prepareQuery(u"SELECT verified FROM tracked_devices WHERE edKey=:edKey"_s);
+    query.bindValue(u":edKey"_s, edKey);
     execute(query);
-    return query.next() && query.value("verified"_L1).toBool();
+    return query.next() && query.value(u"verified"_s).toBool();
 }
 
 QString Database::edKeyForKeyId(const QString& userId, const QString& edKeyId)
 {
-    auto query = prepareQuery(QStringLiteral("SELECT edKey FROM tracked_devices WHERE matrixId=:userId and edKeyId=:edKeyId;"));
-    query.bindValue(":matrixId"_L1, userId);
-    query.bindValue(":edKeyId"_L1, edKeyId);
+    auto query = prepareQuery(u"SELECT edKey FROM tracked_devices WHERE matrixId=:userId and edKeyId=:edKeyId;"_s);
+    query.bindValue(u":matrixId"_s, userId);
+    query.bindValue(u":edKeyId"_s, edKeyId);
     execute(query);
     if (!query.next()) {
         return {};
     }
-    return query.value("edKey"_L1).toString();
+    return query.value(u"edKey"_s).toString();
 }
 
 void Database::storeEncrypted(const QString& name, const QByteArray& key)
@@ -602,12 +593,12 @@ void Database::storeEncrypted(const QString& name, const QByteArray& key)
         return;
 
     auto cipher = result.value().toBase64();
-    auto query = prepareQuery(QStringLiteral("INSERT INTO encrypted(name, cipher, iv) VALUES(:name, :cipher, :iv);"));
-    auto deleteQuery = prepareQuery(QStringLiteral("DELETE FROM encrypted WHERE name=:name;"));
-    deleteQuery.bindValue(":name"_L1, name);
-    query.bindValue(":name"_L1, name);
-    query.bindValue(":cipher"_L1, cipher);
-    query.bindValue(":iv"_L1, iv.toBase64());
+    auto query = prepareQuery(u"INSERT INTO encrypted(name, cipher, iv) VALUES(:name, :cipher, :iv);"_s);
+    auto deleteQuery = prepareQuery(u"DELETE FROM encrypted WHERE name=:name;"_s);
+    deleteQuery.bindValue(u":name"_s, name);
+    query.bindValue(u":name"_s, name);
+    query.bindValue(u":cipher"_s, cipher);
+    query.bindValue(u":iv"_s, iv.toBase64());
     transaction();
     execute(deleteQuery);
     execute(query);
@@ -616,14 +607,14 @@ void Database::storeEncrypted(const QString& name, const QByteArray& key)
 
 QByteArray Database::loadEncrypted(const QString& name)
 {
-    auto query = prepareQuery("SELECT cipher, iv FROM encrypted WHERE name=:name;"_L1);
-    query.bindValue(":name"_L1, name);
+    auto query = prepareQuery(u"SELECT cipher, iv FROM encrypted WHERE name=:name;"_s);
+    query.bindValue(u":name"_s, name);
     execute(query);
     if (!query.next()) {
         return {};
     }
-    auto cipher = QByteArray::fromBase64(query.value("cipher"_L1).toString().toLatin1());
-    auto iv = QByteArray::fromBase64(query.value("iv"_L1).toString().toLatin1());
+    auto cipher = QByteArray::fromBase64(query.value(u"cipher"_s).toString().toLatin1());
+    auto iv = QByteArray::fromBase64(query.value(u"iv"_s).toString().toLatin1());
     if (iv.size() < AesBlockSize) {
         qCWarning(E2EE) << "Corrupt iv at the database record for" << name;
         return {};
@@ -636,8 +627,8 @@ QByteArray Database::loadEncrypted(const QString& name)
 
 void Database::setMasterKeyVerified(const QString& masterKey)
 {
-    auto query = prepareQuery(QStringLiteral("UPDATE master_keys SET verified=true WHERE key=:key;"));
-    query.bindValue(":key"_L1, masterKey);
+    auto query = prepareQuery(u"UPDATE master_keys SET verified=true WHERE key=:key;"_s);
+    query.bindValue(u":key"_s, masterKey);
     transaction();
     execute(query);
     commit();
@@ -645,32 +636,32 @@ void Database::setMasterKeyVerified(const QString& masterKey)
 
 QString Database::userSigningPublicKey()
 {
-    auto query = prepareQuery(QStringLiteral("SELECT key FROM user_signing_keys WHERE userId=:userId;"));
-    query.bindValue(":userId"_L1, m_userId);
+    auto query = prepareQuery(u"SELECT key FROM user_signing_keys WHERE userId=:userId;"_s);
+    query.bindValue(u":userId"_s, m_userId);
     execute(query);
-    return query.next() ? query.value("key"_L1).toString() : QString();
+    return query.next() ? query.value(u"key"_s).toString() : QString();
 }
 
 QString Database::selfSigningPublicKey()
 {
-    auto query = prepareQuery(QStringLiteral("SELECT key FROM self_signing_keys WHERE userId=:userId;"));
-    query.bindValue(":userId"_L1, m_userId);
+    auto query = prepareQuery(u"SELECT key FROM self_signing_keys WHERE userId=:userId;"_s);
+    query.bindValue(u":userId"_s, m_userId);
     execute(query);
-    return query.next() ? query.value("key"_L1).toString() : QString();
+    return query.next() ? query.value(u"key"_s).toString() : QString();
 }
 
 QString Database::edKeyForMegolmSession(const QString& sessionId)
 {
-    auto query = prepareQuery(QStringLiteral("SELECT senderClaimedEd25519Key FROM inbound_megolm_sessions WHERE sessionId=:sessionId;"));
-    query.bindValue(":sessionId"_L1, sessionId.toLatin1());
+    auto query = prepareQuery(u"SELECT senderClaimedEd25519Key FROM inbound_megolm_sessions WHERE sessionId=:sessionId;"_s);
+    query.bindValue(u":sessionId"_s, sessionId.toLatin1());
     execute(query);
-    return query.next() ? query.value("senderClaimedEd25519Key"_L1).toString() : QString();
+    return query.next() ? query.value(u"senderClaimedEd25519Key"_s).toString() : QString();
 }
 
 QString Database::senderKeyForMegolmSession(const QString& sessionId)
 {
-    auto query = prepareQuery(QStringLiteral("SELECT senderKey FROM inbound_megolm_sessions WHERE sessionId=:sessionId;"));
-    query.bindValue(":sessionId"_L1, sessionId.toLatin1());
+    auto query = prepareQuery(u"SELECT senderKey FROM inbound_megolm_sessions WHERE sessionId=:sessionId;"_s);
+    query.bindValue(u":sessionId"_s, sessionId.toLatin1());
     execute(query);
-    return query.next() ? query.value("senderKey"_L1).toString() : QString();
+    return query.next() ? query.value(u"senderKey"_s).toString() : QString();
 }

--- a/Quotient/e2ee/cryptoutils.cpp
+++ b/Quotient/e2ee/cryptoutils.cpp
@@ -65,17 +65,16 @@ inline std::pair<int, bool> checkedSize(
 
 // NOLINTBEGIN(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
 // TODO: remove NOLINT brackets once we're on clang-tidy 18
-#define CLAMP_SIZE(SizeVar_, ByteArray_, ...)                                             \
-    const auto [SizeVar_, ByteArray_##Clamped] =                                          \
-        checkedSize((ByteArray_).size() __VA_OPT__(, ) __VA_ARGS__);                      \
-    if (QUO_ALARM_X(ByteArray_##Clamped,                                                  \
-                    QStringLiteral(                                                       \
-                        #ByteArray_                                                       \
-                        " is %1 bytes long, too much for OpenSSL and overall suspicious") \
-                        .arg((ByteArray_).size())))                                       \
-        return SslPayloadTooLong;                                                         \
-    do {                                                                                  \
-    } while (false) // End of macro
+#define CLAMP_SIZE(SizeVar_, ByteArray_, ...)                                               \
+    const auto [SizeVar_, ByteArray_##Clamped] =                                            \
+        checkedSize((ByteArray_).size() __VA_OPT__(, ) __VA_ARGS__);                        \
+    if (QUO_ALARM_X(ByteArray_##Clamped,                                                    \
+                    u"" #ByteArray_                                                         \
+                    " is %1 bytes long, too much for OpenSSL and overall suspicious"_s.arg( \
+                        (ByteArray_).size())))                                              \
+        return SslPayloadTooLong;                                                           \
+    do {} while (false)                                                                     \
+// End of macro
 
 #define CALL_OPENSSL(Call_)                                                    \
     do {                                                                       \

--- a/Quotient/e2ee/e2ee_common.h
+++ b/Quotient/e2ee/e2ee_common.h
@@ -19,20 +19,20 @@
 
 namespace Quotient {
 
-constexpr inline auto AlgorithmKeyL = "algorithm"_ls;
-constexpr inline auto RotationPeriodMsKeyL = "rotation_period_ms"_ls;
-constexpr inline auto RotationPeriodMsgsKeyL = "rotation_period_msgs"_ls;
+constexpr inline auto AlgorithmKeyL = "algorithm"_L1;
+constexpr inline auto RotationPeriodMsKeyL = "rotation_period_ms"_L1;
+constexpr inline auto RotationPeriodMsgsKeyL = "rotation_period_msgs"_L1;
 
-constexpr inline auto AlgorithmKey = "algorithm"_ls;
-constexpr inline auto RotationPeriodMsKey = "rotation_period_ms"_ls;
-constexpr inline auto RotationPeriodMsgsKey = "rotation_period_msgs"_ls;
+constexpr inline auto AlgorithmKey = "algorithm"_L1;
+constexpr inline auto RotationPeriodMsKey = "rotation_period_ms"_L1;
+constexpr inline auto RotationPeriodMsgsKey = "rotation_period_msgs"_L1;
 
-constexpr inline auto Ed25519Key = "ed25519"_ls;
-constexpr inline auto Curve25519Key = "curve25519"_ls;
-constexpr inline auto SignedCurve25519Key = "signed_curve25519"_ls;
+constexpr inline auto Ed25519Key = "ed25519"_L1;
+constexpr inline auto Curve25519Key = "curve25519"_L1;
+constexpr inline auto SignedCurve25519Key = "signed_curve25519"_L1;
 
-constexpr inline auto OlmV1Curve25519AesSha2AlgoKey = "m.olm.v1.curve25519-aes-sha2"_ls;
-constexpr inline auto MegolmV1AesSha2AlgoKey = "m.megolm.v1.aes-sha2"_ls;
+constexpr inline auto OlmV1Curve25519AesSha2AlgoKey = "m.olm.v1.curve25519-aes-sha2"_L1;
+constexpr inline auto MegolmV1AesSha2AlgoKey = "m.megolm.v1.aes-sha2"_L1;
 
 constexpr std::array SupportedAlgorithms { OlmV1Curve25519AesSha2AlgoKey,
                                            MegolmV1AesSha2AlgoKey };
@@ -308,10 +308,10 @@ public:
                               const QString& deviceId,
                               const QByteArray& signature)
         : payload{
-            { "key"_ls, unsignedKey },
-            { "signatures"_ls,
+            { "key"_L1, unsignedKey },
+            { "signatures"_L1,
               QJsonObject{
-                  { userId, QJsonObject{ { "ed25519:"_ls % deviceId,
+                  { userId, QJsonObject{ { "ed25519:"_L1 % deviceId,
                                            QString::fromUtf8(signature) } } } } }
         }
     {}
@@ -320,7 +320,7 @@ public:
     {}
 
     //! Unpadded Base64-encoded 32-byte Curve25519 public key
-    QByteArray key() const { return payload["key"_ls].toString().toLatin1(); }
+    QByteArray key() const { return payload["key"_L1].toString().toLatin1(); }
 
     //! \brief Signatures of the key object
     //!
@@ -329,24 +329,24 @@ public:
     auto signatures() const
     {
         return fromJson<QHash<QString, QHash<QString, QString>>>(
-            payload["signatures"_ls]);
+            payload["signatures"_L1]);
     }
 
     QByteArray signature(QStringView userId, QStringView deviceId) const
     {
-        return payload["signatures"_ls][userId]["ed25519:"_ls % deviceId]
+        return payload["signatures"_L1][userId]["ed25519:"_L1 % deviceId]
             .toString()
             .toLatin1();
     }
 
     //! Whether the key is a fallback key
-    bool isFallback() const { return payload["fallback"_ls].toBool(); }
+    bool isFallback() const { return payload["fallback"_L1].toBool(); }
     auto toJson() const { return payload; }
     auto toJsonForVerification() const
     {
         auto json = payload;
-        json.remove("signatures"_ls);
-        json.remove("unsigned"_ls);
+        json.remove("signatures"_L1);
+        json.remove("unsigned"_L1);
         return QJsonDocument(json).toJson(QJsonDocument::Compact);
     }
 

--- a/Quotient/e2ee/qolmaccount.cpp
+++ b/Quotient/e2ee/qolmaccount.cpp
@@ -101,7 +101,7 @@ QByteArray QOlmAccount::pickle(const PicklingKey& key) const
     if (olm_pickle_account(olmData, key.data(), key.size(),
                            pickleBuffer.data(), pickleLength)
         == olm_error())
-        QOLM_INTERNAL_ERROR("Failed to pickle Olm account "_ls + accountId());
+        QOLM_INTERNAL_ERROR("Failed to pickle Olm account "_L1 + accountId());
 
     return pickleBuffer;
 }
@@ -112,7 +112,7 @@ IdentityKeys QOlmAccount::identityKeys() const
     auto keyBuffer = byteArrayForOlm(keyLength);
     if (olm_account_identity_keys(olmData, keyBuffer.data(), keyLength)
         == olm_error()) {
-        QOLM_INTERNAL_ERROR("Failed to get "_ls % accountId() % " identity keys"_ls);
+        QOLM_INTERNAL_ERROR("Failed to get "_L1 % accountId() % " identity keys"_L1);
     }
     const auto key = QJsonDocument::fromJson(keyBuffer).object();
     return { key.value(QStringLiteral("curve25519")).toString(),
@@ -142,10 +142,10 @@ QByteArray QOlmAccount::signIdentityKeys() const
     const auto keys = identityKeys();
     static const auto& Algorithms = toJson(SupportedAlgorithms);
     return sign(QJsonObject{
-        { "algorithms"_ls, Algorithms },
-        { "user_id"_ls, m_userId },
-        { "device_id"_ls, m_deviceId },
-        { "keys"_ls,
+        { "algorithms"_L1, Algorithms },
+        { "user_id"_L1, m_userId },
+        { "device_id"_L1, m_deviceId },
+        { "keys"_L1,
           QJsonObject{
               { QStringLiteral("curve25519:") + m_deviceId, keys.curve25519 },
               { QStringLiteral("ed25519:") + m_deviceId, keys.ed25519 } } } });
@@ -164,7 +164,7 @@ size_t QOlmAccount::generateOneTimeKeys(size_t numberOfKeys)
         olmData, numberOfKeys, getRandom(randomLength).data(), randomLength);
 
     if (result == olm_error())
-        QOLM_INTERNAL_ERROR("Failed to generate one-time keys for account "_ls + accountId());
+        QOLM_INTERNAL_ERROR("Failed to generate one-time keys for account "_L1 + accountId());
 
     emit needsSave();
     return result;
@@ -178,7 +178,7 @@ UnsignedOneTimeKeys QOlmAccount::oneTimeKeys() const
     if (olm_account_one_time_keys(olmData, oneTimeKeysBuffer.data(),
                                   oneTimeKeyLength)
         == olm_error())
-        QOLM_INTERNAL_ERROR("Failed to obtain one-time keys for account"_ls % accountId());
+        QOLM_INTERNAL_ERROR("Failed to obtain one-time keys for account"_L1 % accountId());
 
     const auto json = QJsonDocument::fromJson(oneTimeKeysBuffer).object();
     UnsignedOneTimeKeys oneTimeKeys;
@@ -190,10 +190,10 @@ OneTimeKeys QOlmAccount::signOneTimeKeys(const UnsignedOneTimeKeys &keys) const
 {
     OneTimeKeys signedOneTimeKeys;
     for (const auto& [keyId, key] : keys.curve25519().asKeyValueRange())
-        signedOneTimeKeys.insert("signed_curve25519:"_ls % keyId,
+        signedOneTimeKeys.insert("signed_curve25519:"_L1 % keyId,
                                  SignedOneTimeKey {
                                      key, m_userId, m_deviceId,
-                                     sign(QJsonObject { { "key"_ls, key } }) });
+                                     sign(QJsonObject { { "key"_L1, key } }) });
     return signedOneTimeKeys;
 }
 
@@ -202,7 +202,7 @@ OlmErrorCode QOlmAccount::removeOneTimeKeys(const QOlmSession& session)
     if (olm_remove_one_time_keys(olmData, session.olmData) == olm_error()) {
         qWarning(E2EE).nospace()
             << "Failed to remove one-time keys for session "
-            << session.sessionId() << ": "_ls << lastError();
+            << session.sessionId() << ": "_L1 << lastError();
         return lastErrorCode();
     }
     emit needsSave();
@@ -219,10 +219,10 @@ DeviceKeys QOlmAccount::deviceKeys() const
         .userId = m_userId,
         .deviceId = m_deviceId,
         .algorithms = Algorithms,
-        .keys{ { "curve25519:"_ls + m_deviceId, idKeys.curve25519 },
-               { "ed25519:"_ls + m_deviceId, idKeys.ed25519 } },
+        .keys{ { "curve25519:"_L1 + m_deviceId, idKeys.curve25519 },
+               { "ed25519:"_L1 + m_deviceId, idKeys.ed25519 } },
         .signatures{ { m_userId,
-                       { { "ed25519:"_ls + m_deviceId,
+                       { { "ed25519:"_L1 + m_deviceId,
                            QString::fromLatin1(signIdentityKeys()) } } } }
     };
 }
@@ -260,7 +260,7 @@ QOlmExpected<QOlmSession> QOlmAccount::createOutboundSession(
         == olm_error()) {
         const auto errorCode = olmOutboundSession.lastErrorCode();
         QOLM_FAIL_OR_LOG_X(errorCode == OLM_NOT_ENOUGH_RANDOM,
-                           "Failed to create an outbound Olm session"_ls,
+                           "Failed to create an outbound Olm session"_L1,
                            olmOutboundSession.lastError());
         return errorCode;
     }
@@ -277,7 +277,7 @@ bool Quotient::verifyIdentitySignature(const DeviceKeys& deviceKeys,
                                        const QString& deviceId,
                                        const QString& userId)
 {
-    const auto signKeyId = "ed25519:"_ls + deviceId;
+    const auto signKeyId = "ed25519:"_L1 + deviceId;
     const auto signingKey = deviceKeys.keys[signKeyId];
     const auto signature = deviceKeys.signatures[userId][signKeyId];
 
@@ -293,8 +293,8 @@ bool Quotient::ed25519VerifySignature(const QString& signingKey,
 
     QJsonObject obj1 = obj;
 
-    obj1.remove("unsigned"_ls);
-    obj1.remove("signatures"_ls);
+    obj1.remove("unsigned"_L1);
+    obj1.remove("signatures"_L1);
 
     auto canonicalJson = QJsonDocument(obj1).toJson(QJsonDocument::Compact);
 

--- a/Quotient/e2ee/qolmaccount.h
+++ b/Quotient/e2ee/qolmaccount.h
@@ -26,8 +26,7 @@ class QUOTIENT_API QOlmAccount : public QObject
 {
     Q_OBJECT
 public:
-    QOlmAccount(QStringView userId, QStringView deviceId,
-                QObject* parent = nullptr);
+    QOlmAccount(QString userId, QString deviceId, QObject* parent = nullptr);
 
     //! Creates a new instance of OlmAccount. During the instantiation
     //! the Ed25519 fingerprint key pair and the Curve25519 identity key

--- a/Quotient/e2ee/qolminboundsession.cpp
+++ b/Quotient/e2ee/qolminboundsession.cpp
@@ -122,7 +122,7 @@ QOlmExpected<QByteArray> QOlmInboundGroupSession::exportSession(
                                          messageIndex)
         == olm_error()) {
         QOLM_FAIL_OR_LOG(OLM_OUTPUT_BUFFER_TOO_SMALL,
-                         "Failed to export the inbound group session"_ls);
+                         "Failed to export the inbound group session"_L1);
         return lastErrorCode();
     }
     return keyBuf;

--- a/Quotient/e2ee/qolmsession.cpp
+++ b/Quotient/e2ee/qolmsession.cpp
@@ -40,7 +40,7 @@ QOlmExpected<QOlmSession> QOlmSession::unpickle(QByteArray&& pickled,
         == olm_error()) {
         const auto errorCode = olmSession.lastErrorCode();
         QOLM_FAIL_OR_LOG_X(errorCode == OLM_OUTPUT_BUFFER_TOO_SMALL,
-                           "Failed to unpickle an Olm session"_ls,
+                           "Failed to unpickle an Olm session"_L1,
                            olmSession.lastError());
         return errorCode;
     }
@@ -89,7 +89,7 @@ QOlmExpected<QByteArray> QOlmSession::decrypt(const QOlmMessage& message) const
                                           unsignedSize(ciphertext),
                                           plaintextBuf.data(), plaintextMaxLen);
     if (actualLength == olm_error()) {
-        QOLM_FAIL_OR_LOG(OLM_OUTPUT_BUFFER_TOO_SMALL, "Failed to decrypt the message"_ls);
+        QOLM_FAIL_OR_LOG(OLM_OUTPUT_BUFFER_TOO_SMALL, "Failed to decrypt the message"_L1);
         return lastErrorCode();
     }
     // actualLength cannot be more than plainTextLength because the resulting

--- a/Quotient/events/accountdataevents.h
+++ b/Quotient/events/accountdataevents.h
@@ -8,9 +8,9 @@
 #include "../csapi/definitions/tag.h"
 
 namespace Quotient {
-constexpr inline auto FavouriteTag = "m.favourite"_ls;
-constexpr inline auto LowPriorityTag = "m.lowpriority"_ls;
-constexpr inline auto ServerNoticeTag = "m.server_notice"_ls;
+constexpr inline auto FavouriteTag = "m.favourite"_L1;
+constexpr inline auto LowPriorityTag = "m.lowpriority"_L1;
+constexpr inline auto ServerNoticeTag = "m.server_notice"_L1;
 
 using TagRecord [[deprecated("Use Tag from csapi/definitions/tag.h instead")]] = Tag;
 

--- a/Quotient/events/callevents.cpp
+++ b/Quotient/events/callevents.cpp
@@ -11,8 +11,8 @@ QJsonObject CallEvent::basicJson(const QString& matrixType,
                                  const QString& callId, int version,
                                  QJsonObject contentJson)
 {
-    contentJson.insert(QStringLiteral("call_id"), callId);
-    contentJson.insert(QStringLiteral("version"), version);
+    contentJson.insert("call_id"_L1, callId);
+    contentJson.insert("version"_L1, version);
     return RoomEvent::basicJson(matrixType, contentJson);
 }
 
@@ -44,14 +44,10 @@ m.call.invite
 }
 */
 
-CallInviteEvent::CallInviteEvent(const QString& callId, int lifetime,
-                                 const QString& sdp)
-    : EventTemplate(
-        callId,
-        { { QStringLiteral("lifetime"), lifetime },
-          { QStringLiteral("offer"),
-            QJsonObject{ { QStringLiteral("type"), QStringLiteral("offer") },
-                         { QStringLiteral("sdp"), sdp } } } })
+CallInviteEvent::CallInviteEvent(const QString& callId, int lifetime, const QString& sdp)
+    : EventTemplate(callId,
+                    { { u"lifetime"_s, lifetime },
+                      { u"offer"_s, QJsonObject{ { u"type"_s, u"offer"_s }, { u"sdp"_s, sdp } } } })
 {}
 
 /*
@@ -75,8 +71,6 @@ m.call.answer
 */
 
 CallAnswerEvent::CallAnswerEvent(const QString& callId, const QString& sdp)
-    : EventTemplate(callId, { { QStringLiteral("answer"),
-                            QJsonObject { { QStringLiteral("type"),
-                                            QStringLiteral("answer") },
-                                          { QStringLiteral("sdp"), sdp } } } })
+    : EventTemplate(callId, { { u"answer"_s,
+                                QJsonObject{ { u"type"_s, u"answer"_s }, { u"sdp"_s, sdp } } } })
 {}

--- a/Quotient/events/callevents.h
+++ b/Quotient/events/callevents.h
@@ -59,7 +59,7 @@ public:
     QUO_CONTENT_GETTER(int, lifetime)
     QString sdp() const
     {
-        return contentPart<QJsonObject>("offer"_ls).value("sdp"_ls).toString();
+        return contentPart<QJsonObject>("offer"_L1).value("sdp"_L1).toString();
     }
 };
 
@@ -77,7 +77,7 @@ public:
 
     QString sdp() const
     {
-        return contentPart<QJsonObject>("answer"_ls).value("sdp"_ls).toString();
+        return contentPart<QJsonObject>("answer"_L1).value("sdp"_L1).toString();
     }
 };
 

--- a/Quotient/events/encryptedevent.cpp
+++ b/Quotient/events/encryptedevent.cpp
@@ -33,16 +33,16 @@ QString EncryptedEvent::algorithm() const
 RoomEventPtr EncryptedEvent::createDecrypted(const QString &decrypted) const
 {
     auto eventObject = QJsonDocument::fromJson(decrypted.toUtf8()).object();
-    eventObject["event_id"_ls] = id();
-    eventObject["sender"_ls] = senderId();
-    eventObject["origin_server_ts"_ls] = originTimestamp().toMSecsSinceEpoch();
+    eventObject["event_id"_L1] = id();
+    eventObject["sender"_L1] = senderId();
+    eventObject["origin_server_ts"_L1] = originTimestamp().toMSecsSinceEpoch();
     if (const auto relatesToJson = contentPart<QJsonObject>(RelatesToKey);
         !relatesToJson.isEmpty()) {
         replaceSubvalue(eventObject, ContentKey, RelatesToKey, relatesToJson);
     }
-    if (const auto redactsJson = unsignedPart<QString>("redacts"_ls);
+    if (const auto redactsJson = unsignedPart<QString>("redacts"_L1);
         !redactsJson.isEmpty()) {
-        replaceSubvalue(eventObject, UnsignedKey, "redacts"_ls, redactsJson);
+        replaceSubvalue(eventObject, UnsignedKey, "redacts"_L1, redactsJson);
     }
     return loadEvent<RoomEvent>(eventObject);
 }

--- a/Quotient/events/encryptedevent.h
+++ b/Quotient/events/encryptedevent.h
@@ -7,10 +7,10 @@
 
 namespace Quotient {
 
-constexpr inline auto CiphertextKey = "ciphertext"_ls;
-constexpr inline auto SenderKeyKey = "sender_key"_ls;
-constexpr inline auto DeviceIdKey = "device_id"_ls;
-constexpr inline auto SessionIdKey = "session_id"_ls;
+constexpr inline auto CiphertextKey = "ciphertext"_L1;
+constexpr inline auto SenderKeyKey = "sender_key"_L1;
+constexpr inline auto DeviceIdKey = "device_id"_L1;
+constexpr inline auto SessionIdKey = "session_id"_L1;
 
 /*
  * While the specification states:

--- a/Quotient/events/event.h
+++ b/Quotient/events/event.h
@@ -15,10 +15,10 @@ using event_ptr_tt = std::unique_ptr<EventT>;
 
 // === Standard Matrix key names ===
 
-constexpr inline auto TypeKey = "type"_ls;
-constexpr inline auto BodyKey = "body"_ls;
-constexpr inline auto ContentKey = "content"_ls;
-constexpr inline auto SenderKey = "sender"_ls;
+constexpr inline auto TypeKey = "type"_L1;
+constexpr inline auto BodyKey = "body"_L1;
+constexpr inline auto ContentKey = "content"_L1;
+constexpr inline auto SenderKey = "sender"_L1;
 
 using event_type_t = QLatin1String;
 
@@ -457,10 +457,10 @@ public:
 //! <tt>toSnakeCase(PartName_)</tt> (sic) and converts it to the type
 //! \p PartType_. Effectively, the generated method is an equivalent of
 //! \code
-//! contentPart<PartType_>(Quotient::toSnakeCase(#PartName_##_ls));
+//! contentPart<PartType_>(Quotient::toSnakeCase(#PartName_##_L1));
 //! \endcode
 #define QUO_CONTENT_GETTER(PartType_, PartName_) \
-    QUO_CONTENT_GETTER_X(PartType_, PartName_, toSnakeCase(#PartName_##_ls))
+    QUO_CONTENT_GETTER_X(PartType_, PartName_, toSnakeCase(#PartName_##_L1))
 
 /// \brief Define a new event class with a single key-value pair in the content
 ///
@@ -472,7 +472,7 @@ public:
 /// in camelCase, no quotes (an identifier, not a literal).
 #define DEFINE_SIMPLE_EVENT(Name_, Base_, TypeId_, ValueType_, GetterName_,  \
                             JsonKey_)                                        \
-    constexpr inline auto Name_##ContentKey = JsonKey_##_ls;                 \
+    constexpr inline auto Name_##ContentKey = JsonKey_##_L1;                 \
     class QUOTIENT_API Name_                                                 \
         : public EventTemplate<                                              \
               Name_, Base_,                                                  \

--- a/Quotient/events/eventcontent.cpp
+++ b/Quotient/events/eventcontent.cpp
@@ -70,9 +70,9 @@ QJsonObject Quotient::EventContent::toInfoJson(const FileInfo& info)
 {
     QJsonObject infoJson;
     if (info.payloadSize != -1)
-        infoJson.insert(QStringLiteral("size"), info.payloadSize);
+        infoJson.insert("size"_L1, info.payloadSize);
     if (info.mimeType.isValid())
-        infoJson.insert(QStringLiteral("mimetype"), info.mimeType.name());
+        infoJson.insert("mimetype"_L1, info.mimeType.name());
     return infoJson;
 }
 
@@ -97,9 +97,9 @@ QJsonObject Quotient::EventContent::toInfoJson(const ImageInfo& info)
 {
     auto infoJson = toInfoJson(static_cast<const FileInfo&>(info));
     if (info.imageSize.width() != -1)
-        infoJson.insert(QStringLiteral("w"), info.imageSize.width());
+        infoJson.insert("w"_L1, info.imageSize.width());
     if (info.imageSize.height() != -1)
-        infoJson.insert(QStringLiteral("h"), info.imageSize.height());
+        infoJson.insert("h"_L1, info.imageSize.height());
     return infoJson;
 }
 
@@ -117,6 +117,5 @@ void Thumbnail::dumpTo(QJsonObject& infoJson) const
     if (url().isValid())
         fillJson(infoJson, { "thumbnail_url"_L1, "thumbnail_file"_L1 }, source);
     if (!imageSize.isEmpty())
-        infoJson.insert(QStringLiteral("thumbnail_info"),
-                         toInfoJson(*this));
+        infoJson.insert("thumbnail_info"_L1, toInfoJson(*this));
 }

--- a/Quotient/events/eventcontent.cpp
+++ b/Quotient/events/eventcontent.cpp
@@ -47,8 +47,8 @@ FileInfo::FileInfo(FileSourceInfo sourceInfo, const QJsonObject& infoJson,
     : source(std::move(sourceInfo))
     , originalInfoJson(infoJson)
     , mimeType(
-          QMimeDatabase().mimeTypeForName(infoJson["mimetype"_ls].toString()))
-    , payloadSize(fromJson<qint64>(infoJson["size"_ls]))
+          QMimeDatabase().mimeTypeForName(infoJson["mimetype"_L1].toString()))
+    , payloadSize(fromJson<qint64>(infoJson["size"_L1]))
     , originalName(std::move(originalFilename))
 {
     if (!mimeType.isValid())
@@ -58,7 +58,7 @@ FileInfo::FileInfo(FileSourceInfo sourceInfo, const QJsonObject& infoJson,
 bool FileInfo::isValid() const
 {
     const auto& u = url();
-    return u.scheme() == "mxc"_ls && QString(u.authority() + u.path()).count(u'/') == 1;
+    return u.scheme() == "mxc"_L1 && QString(u.authority() + u.path()).count(u'/') == 1;
 }
 
 QUrl FileInfo::url() const
@@ -90,7 +90,7 @@ ImageInfo::ImageInfo(FileSourceInfo sourceInfo, qint64 fileSize,
 ImageInfo::ImageInfo(FileSourceInfo sourceInfo, const QJsonObject& infoJson,
                      const QString& originalFilename)
     : FileInfo(std::move(sourceInfo), infoJson, originalFilename)
-    , imageSize(infoJson["w"_ls].toInt(), infoJson["h"_ls].toInt())
+    , imageSize(infoJson["w"_L1].toInt(), infoJson["h"_L1].toInt())
 {}
 
 QJsonObject Quotient::EventContent::toInfoJson(const ImageInfo& info)
@@ -105,8 +105,8 @@ QJsonObject Quotient::EventContent::toInfoJson(const ImageInfo& info)
 
 Thumbnail::Thumbnail(const QJsonObject& infoJson,
                      const std::optional<EncryptedFileMetadata> &efm)
-    : ImageInfo(QUrl(infoJson["thumbnail_url"_ls].toString()),
-                infoJson["thumbnail_info"_ls].toObject())
+    : ImageInfo(QUrl(infoJson["thumbnail_url"_L1].toString()),
+                infoJson["thumbnail_info"_L1].toObject())
 {
     if (efm)
         source = *efm;
@@ -115,7 +115,7 @@ Thumbnail::Thumbnail(const QJsonObject& infoJson,
 void Thumbnail::dumpTo(QJsonObject& infoJson) const
 {
     if (url().isValid())
-        fillJson(infoJson, { "thumbnail_url"_ls, "thumbnail_file"_ls }, source);
+        fillJson(infoJson, { "thumbnail_url"_L1, "thumbnail_file"_L1 }, source);
     if (!imageSize.isEmpty())
         infoJson.insert(QStringLiteral("thumbnail_info"),
                          toInfoJson(*this));

--- a/Quotient/events/eventcontent.h
+++ b/Quotient/events/eventcontent.h
@@ -176,16 +176,16 @@ public:
     using InfoT::InfoT;
     explicit UrlBasedContent(const QJsonObject& json)
         : TypedBase(json)
-        , InfoT(QUrl(json["url"_ls].toString()), json["info"_ls].toObject(),
-                json["filename"_ls].toString())
+        , InfoT(QUrl(json["url"_L1].toString()), json["info"_L1].toObject(),
+                json["filename"_L1].toString())
         , thumbnail(FileInfo::originalInfoJson)
     {
-        if (const auto efmJson = json.value("file"_ls).toObject();
+        if (const auto efmJson = json.value("file"_L1).toObject();
                 !efmJson.isEmpty())
             InfoT::source = fromJson<EncryptedFileMetadata>(efmJson);
         // Two small hacks on originalJson to expose mediaIds to QML
-        originalJson.insert("mediaId"_ls, InfoT::mediaId());
-        originalJson.insert("thumbnailMediaId"_ls, thumbnail.mediaId());
+        originalJson.insert("mediaId"_L1, InfoT::mediaId());
+        originalJson.insert("thumbnailMediaId"_L1, thumbnail.mediaId());
     }
 
     QMimeType type() const override { return InfoT::mimeType; }
@@ -202,14 +202,14 @@ protected:
 
     void fillJson(QJsonObject& json) const override
     {
-        Quotient::fillJson(json, { "url"_ls, "file"_ls }, InfoT::source);
+        Quotient::fillJson(json, { "url"_L1, "file"_L1 }, InfoT::source);
         if (!InfoT::originalName.isEmpty())
-            json.insert("filename"_ls, InfoT::originalName);
+            json.insert("filename"_L1, InfoT::originalName);
         auto infoJson = toInfoJson(*this);
         if (thumbnail.isValid())
             thumbnail.dumpTo(infoJson);
         fillInfoJson(infoJson);
-        json.insert("info"_ls, infoJson);
+        json.insert("info"_L1, infoJson);
     }
 };
 

--- a/Quotient/events/eventrelation.cpp
+++ b/Quotient/events/eventrelation.cpp
@@ -33,6 +33,6 @@ void JsonObjectConverter<EventRelation>::fillFrom(const QJsonObject& jo,
         fromJson(jo[RelTypeKey], pod.type);
         fromJson(jo[EventIdKey], pod.eventId);
         if (pod.type == EventRelation::AnnotationType)
-            fromJson(jo["key"_ls], pod.key);
+            fromJson(jo["key"_L1], pod.key);
     }
 }

--- a/Quotient/events/eventrelation.cpp
+++ b/Quotient/events/eventrelation.cpp
@@ -18,7 +18,7 @@ void JsonObjectConverter<EventRelation>::dumpTo(QJsonObject& jo,
     jo.insert(RelTypeKey, pod.type);
     jo.insert(EventIdKey, pod.eventId);
     if (pod.type == EventRelation::AnnotationType)
-        jo.insert(QStringLiteral("key"), pod.key);
+        jo.insert("key"_L1, pod.key);
 }
 
 void JsonObjectConverter<EventRelation>::fillFrom(const QJsonObject& jo,

--- a/Quotient/events/eventrelation.h
+++ b/Quotient/events/eventrelation.h
@@ -7,7 +7,7 @@
 
 namespace Quotient {
 
-constexpr inline auto RelTypeKey = "rel_type"_ls;
+constexpr inline auto RelTypeKey = "rel_type"_L1;
 
 struct QUOTIENT_API EventRelation {
     using reltypeid_t = QLatin1String;
@@ -16,9 +16,9 @@ struct QUOTIENT_API EventRelation {
     QString eventId;
     QString key = {}; // Only used for m.annotation for now
 
-    static constexpr auto ReplyType = "m.in_reply_to"_ls;
-    static constexpr auto AnnotationType = "m.annotation"_ls;
-    static constexpr auto ReplacementType = "m.replace"_ls;
+    static constexpr auto ReplyType = "m.in_reply_to"_L1;
+    static constexpr auto AnnotationType = "m.annotation"_L1;
+    static constexpr auto ReplacementType = "m.replace"_L1;
 
     static EventRelation replyTo(QString eventId)
     {

--- a/Quotient/events/filesourceinfo.cpp
+++ b/Quotient/events/filesourceinfo.cpp
@@ -17,7 +17,7 @@ using namespace Quotient;
 QByteArray Quotient::decryptFile(const QByteArray& ciphertext,
                                  const EncryptedFileMetadata& metadata)
 {
-    if (QByteArray::fromBase64(metadata.hashes["sha256"_ls].toLatin1())
+    if (QByteArray::fromBase64(metadata.hashes["sha256"_L1].toLatin1())
         != QCryptographicHash::hash(ciphertext, QCryptographicHash::Sha256)) {
         qCWarning(E2EE) << "Hash verification failed for file";
         return {};
@@ -48,7 +48,7 @@ std::pair<EncryptedFileMetadata, QByteArray> Quotient::encryptFile(
                               | QByteArray::OmitTrailingEquals);
     auto iv = getRandom<AesBlockSize>();
     const JWK key = {
-        "oct"_ls, { "encrypt"_ls, "decrypt"_ls }, "A256CTR"_ls, QString::fromLatin1(kBase64), true
+        "oct"_L1, { "encrypt"_L1, "decrypt"_L1 }, "A256CTR"_L1, QString::fromLatin1(kBase64), true
     };
     auto result = aesCtr256Encrypt(plainText, k, iv);
     if (!result.has_value())
@@ -59,7 +59,7 @@ std::pair<EncryptedFileMetadata, QByteArray> Quotient::encryptFile(
     auto ivBase64 = iv.toBase64(QByteArray::OmitTrailingEquals);
     const EncryptedFileMetadata efm = {
         {}, key, QString::fromLatin1(ivBase64),
-        { { "sha256"_ls, QString::fromLatin1(hash) } }, "v2"_ls
+        { { "sha256"_L1, QString::fromLatin1(hash) } }, "v2"_L1
     };
     return { efm, result.value() };
 }
@@ -77,11 +77,11 @@ void JsonObjectConverter<EncryptedFileMetadata>::dumpTo(
 void JsonObjectConverter<EncryptedFileMetadata>::fillFrom(
     const QJsonObject& jo, EncryptedFileMetadata& pod)
 {
-    fromJson(jo.value("url"_ls), pod.url);
-    fromJson(jo.value("key"_ls), pod.key);
-    fromJson(jo.value("iv"_ls), pod.iv);
-    fromJson(jo.value("hashes"_ls), pod.hashes);
-    fromJson(jo.value("v"_ls), pod.v);
+    fromJson(jo.value("url"_L1), pod.url);
+    fromJson(jo.value("key"_L1), pod.key);
+    fromJson(jo.value("iv"_L1), pod.iv);
+    fromJson(jo.value("hashes"_L1), pod.hashes);
+    fromJson(jo.value("v"_L1), pod.v);
 }
 
 void JsonObjectConverter<JWK>::dumpTo(QJsonObject& jo, const JWK& pod)
@@ -95,11 +95,11 @@ void JsonObjectConverter<JWK>::dumpTo(QJsonObject& jo, const JWK& pod)
 
 void JsonObjectConverter<JWK>::fillFrom(const QJsonObject& jo, JWK& pod)
 {
-    fromJson(jo.value("kty"_ls), pod.kty);
-    fromJson(jo.value("key_ops"_ls), pod.keyOps);
-    fromJson(jo.value("alg"_ls), pod.alg);
-    fromJson(jo.value("k"_ls), pod.k);
-    fromJson(jo.value("ext"_ls), pod.ext);
+    fromJson(jo.value("kty"_L1), pod.kty);
+    fromJson(jo.value("key_ops"_L1), pod.keyOps);
+    fromJson(jo.value("alg"_L1), pod.alg);
+    fromJson(jo.value("k"_L1), pod.k);
+    fromJson(jo.value("ext"_L1), pod.ext);
 }
 
 QUrl Quotient::getUrlFromSourceInfo(const FileSourceInfo& fsi)

--- a/Quotient/events/filesourceinfo.cpp
+++ b/Quotient/events/filesourceinfo.cpp
@@ -67,11 +67,11 @@ std::pair<EncryptedFileMetadata, QByteArray> Quotient::encryptFile(
 void JsonObjectConverter<EncryptedFileMetadata>::dumpTo(
     QJsonObject& jo, const EncryptedFileMetadata& pod)
 {
-    addParam<>(jo, QStringLiteral("url"), pod.url);
-    addParam<>(jo, QStringLiteral("key"), pod.key);
-    addParam<>(jo, QStringLiteral("iv"), pod.iv);
-    addParam<>(jo, QStringLiteral("hashes"), pod.hashes);
-    addParam<>(jo, QStringLiteral("v"), pod.v);
+    addParam<>(jo, "url"_L1, pod.url);
+    addParam<>(jo, "key"_L1, pod.key);
+    addParam<>(jo, "iv"_L1, pod.iv);
+    addParam<>(jo, "hashes"_L1, pod.hashes);
+    addParam<>(jo, "v"_L1, pod.v);
 }
 
 void JsonObjectConverter<EncryptedFileMetadata>::fillFrom(
@@ -86,11 +86,11 @@ void JsonObjectConverter<EncryptedFileMetadata>::fillFrom(
 
 void JsonObjectConverter<JWK>::dumpTo(QJsonObject& jo, const JWK& pod)
 {
-    addParam<>(jo, QStringLiteral("kty"), pod.kty);
-    addParam<>(jo, QStringLiteral("key_ops"), pod.keyOps);
-    addParam<>(jo, QStringLiteral("alg"), pod.alg);
-    addParam<>(jo, QStringLiteral("k"), pod.k);
-    addParam<>(jo, QStringLiteral("ext"), pod.ext);
+    addParam<>(jo, "kty"_L1, pod.kty);
+    addParam<>(jo, "key_ops"_L1, pod.keyOps);
+    addParam<>(jo, "alg"_L1, pod.alg);
+    addParam<>(jo, "k"_L1, pod.k);
+    addParam<>(jo, "ext"_L1, pod.ext);
 }
 
 void JsonObjectConverter<JWK>::fillFrom(const QJsonObject& jo, JWK& pod)

--- a/Quotient/events/keyverificationevent.h
+++ b/Quotient/events/keyverificationevent.h
@@ -7,7 +7,7 @@
 
 namespace Quotient {
 
-constexpr inline auto SasV1Method = "m.sas.v1"_ls;
+constexpr inline auto SasV1Method = "m.sas.v1"_L1;
 
 // Same story as with EncryptedEvent: because KeyVerificationEvent inheritors can be sent both
 // in-room and out-of-room, and RoomEvent doesn't restrict the shape of the event, rather just
@@ -35,10 +35,10 @@ public:
                                 const QStringList& methods,
                                 const QDateTime& timestamp)
         : KeyVerificationRequestEvent(
-            basicJson(TypeId, { { "transaction_id"_ls, transactionId },
-                                { "from_device"_ls, fromDevice },
-                                { "methods"_ls, toJson(methods) },
-                                { "timestamp"_ls, toJson(timestamp) } }))
+            basicJson(TypeId, { { "transaction_id"_L1, transactionId },
+                                { "from_device"_L1, fromDevice },
+                                { "methods"_L1, toJson(methods) },
+                                { "timestamp"_L1, toJson(timestamp) } }))
     {}
 
     /// The device ID which is initiating the request.
@@ -63,9 +63,9 @@ public:
                               const QString& fromDevice,
                               const QStringList& methods)
         : KeyVerificationReadyEvent(
-            basicJson(TypeId, { { "transaction_id"_ls, transactionId },
-                                { "from_device"_ls, fromDevice },
-                                { "methods"_ls, toJson(methods) } }))
+            basicJson(TypeId, { { "transaction_id"_L1, transactionId },
+                                { "from_device"_L1, fromDevice },
+                                { "methods"_L1, toJson(methods) } }))
     {}
 
     /// The device ID which is accepting the request.
@@ -75,8 +75,8 @@ public:
     QUO_CONTENT_GETTER(QStringList, methods)
 };
 
-constexpr inline auto HmacSha256Code = "hkdf-hmac-sha256"_ls;
-constexpr inline auto HmacSha256V2Code = "hkdf-hmac-sha256.v2"_ls;
+constexpr inline auto HmacSha256Code = "hkdf-hmac-sha256"_L1;
+constexpr inline auto HmacSha256V2Code = "hkdf-hmac-sha256.v2"_L1;
 constexpr std::array SupportedMacs { HmacSha256Code, HmacSha256V2Code };
 
 /// Begins a key verification process.
@@ -88,16 +88,16 @@ public:
     KeyVerificationStartEvent(const QString& transactionId,
                               const QString& fromDevice)
         : KeyVerificationStartEvent(
-            basicJson(TypeId, { { "transaction_id"_ls, transactionId },
-                                { "from_device"_ls, fromDevice },
-                                { "method"_ls, SasV1Method },
-                                { "hashes"_ls, QJsonArray{ "sha256"_ls } },
-                                { "key_agreement_protocols"_ls,
-                                  QJsonArray{ "curve25519-hkdf-sha256"_ls } },
-                                { "message_authentication_codes"_ls,
+            basicJson(TypeId, { { "transaction_id"_L1, transactionId },
+                                { "from_device"_L1, fromDevice },
+                                { "method"_L1, SasV1Method },
+                                { "hashes"_L1, QJsonArray{ "sha256"_L1 } },
+                                { "key_agreement_protocols"_L1,
+                                  QJsonArray{ "curve25519-hkdf-sha256"_L1 } },
+                                { "message_authentication_codes"_L1,
                                   toJson(SupportedMacs) },
-                                { "short_authentication_string"_ls,
-                                  QJsonArray{ "decimal"_ls, "emoji"_ls } } }))
+                                { "short_authentication_string"_L1,
+                                  QJsonArray{ "decimal"_L1, "emoji"_L1 } } }))
     {}
 
     /// The device ID which is initiating the process.
@@ -116,7 +116,7 @@ public:
     QStringList keyAgreementProtocols() const
     {
         Q_ASSERT(method() == SasV1Method);
-        return contentPart<QStringList>("key_agreement_protocols"_ls);
+        return contentPart<QStringList>("key_agreement_protocols"_L1);
     }
 
     /// The hash methods the sending device understands.
@@ -124,7 +124,7 @@ public:
     QStringList hashes() const
     {
         Q_ASSERT(method() == SasV1Method);
-        return contentPart<QStringList>("hashes"_ls);
+        return contentPart<QStringList>("hashes"_L1);
     }
 
     /// The message authentication codes that the sending device understands.
@@ -132,7 +132,7 @@ public:
     QStringList messageAuthenticationCodes() const
     {
         Q_ASSERT(method() == SasV1Method);
-        return contentPart<QStringList>("message_authentication_codes"_ls);
+        return contentPart<QStringList>("message_authentication_codes"_L1);
     }
 
     /// The SAS methods the sending device (and the sending device's
@@ -141,7 +141,7 @@ public:
     QString shortAuthenticationString() const
     {
         Q_ASSERT(method() == SasV1Method);
-        return contentPart<QString>("short_authentication_string"_ls);
+        return contentPart<QString>("short_authentication_string"_L1);
     }
 };
 
@@ -154,14 +154,14 @@ public:
     KeyVerificationAcceptEvent(const QString& transactionId,
                                const QString& commitment)
         : KeyVerificationAcceptEvent(basicJson(
-            TypeId, { { "transaction_id"_ls, transactionId },
-                      { "method"_ls, SasV1Method },
-                      { "key_agreement_protocol"_ls, "curve25519-hkdf-sha256"_ls },
-                      { "hash"_ls, "sha256"_ls },
-                      { "message_authentication_code"_ls, HmacSha256V2Code },
-                      { "short_authentication_string"_ls,
-                        QJsonArray{ "decimal"_ls, "emoji"_ls, } },
-                      { "commitment"_ls, commitment } }))
+            TypeId, { { "transaction_id"_L1, transactionId },
+                      { "method"_L1, SasV1Method },
+                      { "key_agreement_protocol"_L1, "curve25519-hkdf-sha256"_L1 },
+                      { "hash"_L1, "sha256"_L1 },
+                      { "message_authentication_code"_L1, HmacSha256V2Code },
+                      { "short_authentication_string"_L1,
+                        QJsonArray{ "decimal"_L1, "emoji"_L1, } },
+                      { "commitment"_L1, commitment } }))
     {}
 
     /// The verification method to use. Must be 'm.sas.v1'.
@@ -173,7 +173,7 @@ public:
 
     /// The hash method the device is choosing to use, out of the
     /// options in the m.key.verification.start message.
-    QUO_CONTENT_GETTER_X(QString, hashData, "hash"_ls)
+    QUO_CONTENT_GETTER_X(QString, hashData, "hash"_L1)
 
     /// The message authentication code the device is choosing to use, out
     /// of the options in the m.key.verification.start message.
@@ -197,9 +197,9 @@ public:
                                const QString& reason)
         : KeyVerificationCancelEvent(
             basicJson(TypeId, {
-                                  { "transaction_id"_ls, transactionId },
-                                  { "reason"_ls, reason },
-                                  { "code"_ls, reason } // Not a typo
+                                  { "transaction_id"_L1, transactionId },
+                                  { "reason"_L1, reason },
+                                  { "code"_L1, reason } // Not a typo
                               }))
     {}
 
@@ -219,8 +219,8 @@ public:
     using KeyVerificationEvent::KeyVerificationEvent;
     KeyVerificationKeyEvent(const QString& transactionId, const QString& key)
         : KeyVerificationKeyEvent(
-            basicJson(TypeId, { { "transaction_id"_ls, transactionId },
-                                { "key"_ls, key } }))
+            basicJson(TypeId, { { "transaction_id"_L1, transactionId },
+                                { "key"_L1, key } }))
     {}
 
     /// The device's ephemeral public key, encoded as unpadded base64.
@@ -236,9 +236,9 @@ public:
     KeyVerificationMacEvent(const QString& transactionId, const QString& keys,
                             const QJsonObject& mac)
         : KeyVerificationMacEvent(
-            basicJson(TypeId, { { "transaction_id"_ls, transactionId },
-                                { "keys"_ls, keys },
-                                { "mac"_ls, mac } }))
+            basicJson(TypeId, { { "transaction_id"_L1, transactionId },
+                                { "keys"_L1, keys },
+                                { "mac"_L1, mac } }))
     {}
 
     /// The device's ephemeral public key, encoded as unpadded base64.
@@ -246,7 +246,7 @@ public:
 
     QHash<QString, QString> mac() const
     {
-        return contentPart<QHash<QString, QString>>("mac"_ls);
+        return contentPart<QHash<QString, QString>>("mac"_L1);
     }
 };
 
@@ -257,7 +257,7 @@ public:
     using KeyVerificationEvent::KeyVerificationEvent;
     explicit KeyVerificationDoneEvent(const QString& transactionId)
         : KeyVerificationDoneEvent(
-            basicJson(TypeId, { { "transaction_id"_ls, transactionId } }))
+            basicJson(TypeId, { { "transaction_id"_L1, transactionId } }))
     {}
 };
 } // namespace Quotient

--- a/Quotient/events/receiptevent.cpp
+++ b/Quotient/events/receiptevent.cpp
@@ -35,8 +35,8 @@ QJsonObject Quotient::toJson(const EventsWithReceipts& ewrs)
         QJsonObject receiptsJson;
         for (const auto& r : e.receipts)
             receiptsJson.insert(r.userId,
-                                QJsonObject { { "ts"_ls, toJson(r.timestamp) } });
-        json.insert(e.evtId, QJsonObject { { "m.read"_ls, receiptsJson } });
+                                QJsonObject { { "ts"_L1, toJson(r.timestamp) } });
+        json.insert(e.evtId, QJsonObject { { "m.read"_L1, receiptsJson } });
     }
     return json;
 }
@@ -54,13 +54,13 @@ EventsWithReceipts Quotient::fromJson(const QJsonObject& json)
             continue;
         }
         const auto reads =
-            eventIt.value().toObject().value("m.read"_ls).toObject();
+            eventIt.value().toObject().value("m.read"_L1).toObject();
         QVector<UserTimestamp> usersAtEvent;
         usersAtEvent.reserve(reads.size());
         for (auto userIt = reads.begin(); userIt != reads.end(); ++userIt) {
             const auto user = userIt.value().toObject();
             usersAtEvent.push_back(
-                { userIt.key(), fromJson<QDateTime>(user["ts"_ls]) });
+                { userIt.key(), fromJson<QDateTime>(user["ts"_L1]) });
         }
         result.push_back({ eventIt.key(), std::move(usersAtEvent) });
     }

--- a/Quotient/events/redactionevent.h
+++ b/Quotient/events/redactionevent.h
@@ -14,7 +14,7 @@ public:
 
     QString redactedEvent() const
     {
-        return fullJson()["redacts"_ls].toString();
+        return fullJson()["redacts"_L1].toString();
     }
     QUO_CONTENT_GETTER(QString, reason)
 };

--- a/Quotient/events/roomcanonicalaliasevent.h
+++ b/Quotient/events/roomcanonicalaliasevent.h
@@ -18,8 +18,8 @@ template<>
 inline EventContent::AliasesEventContent fromJson(const QJsonObject& jo)
 {
     return EventContent::AliasesEventContent {
-        fromJson<QString>(jo["alias"_ls]),
-        fromJson<QStringList>(jo["alt_aliases"_ls])
+        fromJson<QString>(jo["alias"_L1]),
+        fromJson<QStringList>(jo["alt_aliases"_L1])
     };
 }
 template<>

--- a/Quotient/events/roomcanonicalaliasevent.h
+++ b/Quotient/events/roomcanonicalaliasevent.h
@@ -26,8 +26,8 @@ template<>
 inline auto toJson(const EventContent::AliasesEventContent& c)
 {
     QJsonObject jo;
-    addParam<IfNotEmpty>(jo, QStringLiteral("alias"), c.canonicalAlias);
-    addParam<IfNotEmpty>(jo, QStringLiteral("alt_aliases"), c.altAliases);
+    addParam<IfNotEmpty>(jo, "alias"_L1, c.canonicalAlias);
+    addParam<IfNotEmpty>(jo, "alt_aliases"_L1, c.altAliases);
     return jo;
 }
 

--- a/Quotient/events/roomcreateevent.cpp
+++ b/Quotient/events/roomcreateevent.cpp
@@ -14,27 +14,27 @@ RoomType Quotient::fromJson(const QJsonValue& jv)
 
 bool RoomCreateEvent::isFederated() const
 {
-    return contentPart<bool>("m.federate"_ls);
+    return contentPart<bool>("m.federate"_L1);
 }
 
 QString RoomCreateEvent::version() const
 {
-    return contentPart<QString>("room_version"_ls);
+    return contentPart<QString>("room_version"_L1);
 }
 
 RoomCreateEvent::Predecessor RoomCreateEvent::predecessor() const
 {
-    const auto predJson = contentPart<QJsonObject>("predecessor"_ls);
+    const auto predJson = contentPart<QJsonObject>("predecessor"_L1);
     return { fromJson<QString>(predJson[RoomIdKey]),
              fromJson<QString>(predJson[EventIdKey]) };
 }
 
 bool RoomCreateEvent::isUpgrade() const
 {
-    return contentJson().contains("predecessor"_ls);
+    return contentJson().contains("predecessor"_L1);
 }
 
 RoomType RoomCreateEvent::roomType() const
 {
-    return contentPart<RoomType>("type"_ls);
+    return contentPart<RoomType>("type"_L1);
 }

--- a/Quotient/events/roomevent.cpp
+++ b/Quotient/events/roomevent.cpp
@@ -25,7 +25,7 @@ QString RoomEvent::id() const { return fullJson()[EventIdKey].toString(); }
 
 QDateTime RoomEvent::originTimestamp() const
 {
-    return Quotient::fromJson<QDateTime>(fullJson()["origin_server_ts"_ls]);
+    return Quotient::fromJson<QDateTime>(fullJson()["origin_server_ts"_L1]);
 }
 
 QString RoomEvent::roomId() const
@@ -45,7 +45,7 @@ QString RoomEvent::redactionReason() const
 
 QString RoomEvent::transactionId() const
 {
-    return unsignedPart<QString>("transaction_id"_ls);
+    return unsignedPart<QString>("transaction_id"_L1);
 }
 
 QString RoomEvent::stateKey() const

--- a/Quotient/events/roomevent.cpp
+++ b/Quotient/events/roomevent.cpp
@@ -66,7 +66,7 @@ void RoomEvent::setSender(const QString& senderId)
 void RoomEvent::setTransactionId(const QString& txnId)
 {
     auto unsignedData = fullJson()[UnsignedKey].toObject();
-    unsignedData.insert(QStringLiteral("transaction_id"), txnId);
+    unsignedData.insert("transaction_id"_L1, txnId);
     editJson().insert(UnsignedKey, unsignedData);
     Q_ASSERT(transactionId() == txnId);
 }

--- a/Quotient/events/roomevent.h
+++ b/Quotient/events/roomevent.h
@@ -9,12 +9,12 @@
 
 namespace Quotient {
 
-constexpr inline auto EventIdKey = "event_id"_ls;
-constexpr inline auto RoomIdKey = "room_id"_ls;
-constexpr inline auto StateKeyKey = "state_key"_ls;
-constexpr inline auto RedactedCauseKey = "redacted_because"_ls;
-constexpr inline auto RelatesToKey = "m.relates_to"_ls;
-constexpr inline auto UnsignedKey = "unsigned"_ls;
+constexpr inline auto EventIdKey = "event_id"_L1;
+constexpr inline auto RoomIdKey = "room_id"_L1;
+constexpr inline auto StateKeyKey = "state_key"_L1;
+constexpr inline auto RedactedCauseKey = "redacted_because"_L1;
+constexpr inline auto RelatesToKey = "m.relates_to"_L1;
+constexpr inline auto UnsignedKey = "unsigned"_L1;
 
 class RedactionEvent;
 class EncryptedEvent;

--- a/Quotient/events/roomkeyevent.h
+++ b/Quotient/events/roomkeyevent.h
@@ -15,10 +15,10 @@ public:
     explicit RoomKeyEvent(const QString& algorithm, const QString& roomId,
                           const QString& sessionId, const QString& sessionKey)
         : Event(basicJson(TypeId, {
-                                      { "algorithm"_ls, algorithm },
-                                      { "room_id"_ls, roomId },
-                                      { "session_id"_ls, sessionId },
-                                      { "session_key"_ls, sessionKey },
+                                      { "algorithm"_L1, algorithm },
+                                      { "room_id"_L1, roomId },
+                                      { "session_id"_L1, sessionId },
+                                      { "session_key"_L1, sessionKey },
                                   }))
     {}
 
@@ -27,7 +27,7 @@ public:
     QUO_CONTENT_GETTER(QString, sessionId)
     QByteArray sessionKey() const
     {
-        return contentPart<QString>("session_key"_ls).toLatin1();
+        return contentPart<QString>("session_key"_L1).toLatin1();
     }
 };
 } // namespace Quotient

--- a/Quotient/events/roommemberevent.cpp
+++ b/Quotient/events/roommemberevent.cpp
@@ -23,11 +23,11 @@ struct JsonConverter<Membership> {
 using namespace Quotient;
 
 MemberEventContent::MemberEventContent(const QJsonObject& json)
-    : membership(fromJson<Membership>(json["membership"_ls]))
-    , isDirect(json["is_direct"_ls].toBool())
-    , displayName(fromJson<std::optional<QString>>(json["displayname"_ls]))
-    , avatarUrl(fromJson<std::optional<QString>>(json["avatar_url"_ls]))
-    , reason(json["reason"_ls].toString())
+    : membership(fromJson<Membership>(json["membership"_L1]))
+    , isDirect(json["is_direct"_L1].toBool())
+    , displayName(fromJson<std::optional<QString>>(json["displayname"_L1]))
+    , avatarUrl(fromJson<std::optional<QString>>(json["avatar_url"_L1]))
+    , reason(json["reason"_L1].toString())
 {
     if (displayName)
         displayName = sanitized(*displayName);

--- a/Quotient/events/roommemberevent.cpp
+++ b/Quotient/events/roommemberevent.cpp
@@ -37,14 +37,13 @@ QJsonObject MemberEventContent::toJson() const
 {
     QJsonObject o;
     if (membership != Membership::Invalid)
-        o.insert(QStringLiteral("membership"),
-                 flagToJsonString(membership, MembershipStrings));
+        o.insert("membership"_L1, flagToJsonString(membership, MembershipStrings));
     if (displayName)
-        o.insert(QStringLiteral("displayname"), *displayName);
+        o.insert("displayname"_L1, *displayName);
     if (avatarUrl && avatarUrl->isValid())
-        o.insert(QStringLiteral("avatar_url"), avatarUrl->toString());
+        o.insert("avatar_url"_L1, avatarUrl->toString());
     if (!reason.isEmpty())
-        o.insert(QStringLiteral("reason"), reason);
+        o.insert("reason"_L1, reason);
     return o;
 }
 

--- a/Quotient/events/roommessageevent.cpp
+++ b/Quotient/events/roommessageevent.cpp
@@ -19,13 +19,13 @@ using namespace EventContent;
 using MsgType = RoomMessageEvent::MsgType;
 
 namespace { // Supporting internal definitions
-constexpr auto RelatesToKey = "m.relates_to"_ls;
-constexpr auto MsgTypeKey = "msgtype"_ls;
-constexpr auto FormattedBodyKey = "formatted_body"_ls;
-constexpr auto TextTypeKey = "m.text"_ls;
-constexpr auto EmoteTypeKey = "m.emote"_ls;
-constexpr auto NoticeTypeKey = "m.notice"_ls;
-constexpr auto HtmlContentTypeId = "org.matrix.custom.html"_ls;
+constexpr auto RelatesToKey = "m.relates_to"_L1;
+constexpr auto MsgTypeKey = "msgtype"_L1;
+constexpr auto FormattedBodyKey = "formatted_body"_L1;
+constexpr auto TextTypeKey = "m.text"_L1;
+constexpr auto EmoteTypeKey = "m.emote"_L1;
+constexpr auto NoticeTypeKey = "m.notice"_L1;
+constexpr auto HtmlContentTypeId = "org.matrix.custom.html"_L1;
 
 template <typename ContentT>
 std::unique_ptr<TypedBase> make(const QJsonObject& json)
@@ -51,12 +51,12 @@ constexpr auto msgTypes = std::to_array<MsgTypeDesc>({
     { TextTypeKey, MsgType::Text, make<TextContent> },
     { EmoteTypeKey, MsgType::Emote, make<TextContent> },
     { NoticeTypeKey, MsgType::Notice, make<TextContent> },
-    { "m.image"_ls, MsgType::Image, make<ImageContent> },
-    { "m.file"_ls, MsgType::File, make<FileContent> },
-    { "m.location"_ls, MsgType::Location, make<LocationContent> },
-    { "m.video"_ls, MsgType::Video, make<VideoContent> },
-    { "m.audio"_ls, MsgType::Audio, make<AudioContent> },
-    { "m.key.verification.request"_ls , MsgType::Text, make<TextContent> },
+    { "m.image"_L1, MsgType::Image, make<ImageContent> },
+    { "m.file"_L1, MsgType::File, make<FileContent> },
+    { "m.location"_L1, MsgType::Location, make<LocationContent> },
+    { "m.video"_L1, MsgType::Video, make<VideoContent> },
+    { "m.audio"_L1, MsgType::Audio, make<AudioContent> },
+    { "m.key.verification.request"_L1 , MsgType::Text, make<TextContent> },
 });
 
 QString msgTypeToJson(MsgType enumType)
@@ -104,12 +104,12 @@ QJsonObject RoomMessageEvent::assembleContentJson(const QString& plainBody,
                    textContent->relatesTo
                    && textContent->relatesTo->type
                           == EventRelation::ReplacementType) {
-            auto newContentJson = json.take("m.new_content"_ls).toObject();
+            auto newContentJson = json.take("m.new_content"_L1).toObject();
             newContentJson.insert(BodyKey, plainBody);
             newContentJson.insert(MsgTypeKey, jsonMsgType);
             json.insert(QStringLiteral("m.new_content"), newContentJson);
             json[MsgTypeKey] = jsonMsgType;
-            json[BodyKey] = "* "_ls + plainBody;
+            json[BodyKey] = "* "_L1 + plainBody;
             return json;
         }
     }
@@ -175,7 +175,7 @@ QString RoomMessageEvent::plainBody() const
 QMimeType RoomMessageEvent::mimeType() const
 {
     static const auto PlainTextMimeType =
-        QMimeDatabase().mimeTypeForName("text/plain"_ls);
+        QMimeDatabase().mimeTypeForName("text/plain"_L1);
     return _content ? _content->type() : PlainTextMimeType;
 }
 
@@ -207,14 +207,14 @@ QString RoomMessageEvent::replacedEvent() const
 
 bool RoomMessageEvent::isReplaced() const
 {
-    return unsignedPart<QJsonObject>("m.relations"_ls).contains("m.replace"_ls);
+    return unsignedPart<QJsonObject>("m.relations"_L1).contains("m.replace"_L1);
 }
 
 QString RoomMessageEvent::replacedBy() const
 {
     // clang-format off
-    return unsignedPart<QJsonObject>("m.relations"_ls)
-            .value("m.replace"_ls).toObject()
+    return unsignedPart<QJsonObject>("m.relations"_L1)
+            .value("m.replace"_L1).toObject()
             .value(EventIdKey).toString();
     // clang-format on
 }
@@ -222,8 +222,8 @@ QString RoomMessageEvent::replacedBy() const
 namespace {
 QString safeFileName(QString rawName)
 {
-    static auto safeFileNameRegex = QRegularExpression(R"([/\<>|"*?:])"_ls);
-    return rawName.replace(safeFileNameRegex, "_"_ls);
+    static auto safeFileNameRegex = QRegularExpression(R"([/\<>|"*?:])"_L1);
+    return rawName.replace(safeFileNameRegex, "_"_L1);
 }
 }
 
@@ -244,7 +244,7 @@ QString RoomMessageEvent::fileNameToDownload() const
         return safeFileName(fileInfo->mediaId()).replace(u'.', u'-') % u'.'
                % fileInfo->mimeType.preferredSuffix();
 
-    if (QSysInfo::productType() == "windows"_ls) {
+    if (QSysInfo::productType() == "windows"_L1) {
         if (const auto& suffixes = fileInfo->mimeType.suffixes();
             !suffixes.isEmpty() && std::ranges::none_of(suffixes, [&fileName](const QString& s) {
                 return fileName.endsWith(s);
@@ -257,11 +257,11 @@ QString RoomMessageEvent::fileNameToDownload() const
 QString rawMsgTypeForMimeType(const QMimeType& mimeType)
 {
     auto name = mimeType.name();
-    return name.startsWith("image/"_ls)
+    return name.startsWith("image/"_L1)
                ? QStringLiteral("m.image")
-               : name.startsWith("video/"_ls)
+               : name.startsWith("video/"_L1)
                      ? QStringLiteral("m.video")
-                     : name.startsWith("audio/"_ls) ? QStringLiteral("m.audio")
+                     : name.startsWith("audio/"_L1) ? QStringLiteral("m.audio")
                                                  : QStringLiteral("m.file");
 }
 
@@ -282,22 +282,22 @@ TextContent::TextContent(QString text, const QString& contentType,
     , relatesTo(std::move(relatesTo))
 {
     if (contentType == HtmlContentTypeId)
-        mimeType = QMimeDatabase().mimeTypeForName("text/html"_ls);
+        mimeType = QMimeDatabase().mimeTypeForName("text/html"_L1);
 }
 
 TextContent::TextContent(const QJsonObject& json)
     : relatesTo(fromJson<std::optional<EventRelation>>(json[RelatesToKey]))
 {
     QMimeDatabase db;
-    static const auto PlainTextMimeType = db.mimeTypeForName("text/plain"_ls);
-    static const auto HtmlMimeType = db.mimeTypeForName("text/html"_ls);
+    static const auto PlainTextMimeType = db.mimeTypeForName("text/plain"_L1);
+    static const auto HtmlMimeType = db.mimeTypeForName("text/html"_L1);
 
     const auto actualJson = isReplacement(relatesTo)
-                                ? json.value("m.new_content"_ls).toObject()
+                                ? json.value("m.new_content"_L1).toObject()
                                 : json;
     // Special-casing the custom matrix.org's (actually, Element's) way
     // of sending HTML messages.
-    if (actualJson["format"_ls].toString() == HtmlContentTypeId) {
+    if (actualJson["format"_L1].toString() == HtmlContentTypeId) {
         mimeType = HtmlMimeType;
         body = actualJson[FormattedBodyKey].toString();
     } else {
@@ -312,7 +312,7 @@ void TextContent::fillJson(QJsonObject &json) const
 {
     static const auto FormatKey = QStringLiteral("format");
 
-    if (mimeType.inherits("text/html"_ls)) {
+    if (mimeType.inherits("text/html"_L1)) {
         json.insert(FormatKey, HtmlContentTypeId);
         json.insert(FormattedBodyKey, body);
     }
@@ -327,7 +327,7 @@ void TextContent::fillJson(QJsonObject &json) const
                                 { EventIdKey, relatesTo->eventId } });
         if (relatesTo->type == EventRelation::ReplacementType) {
             QJsonObject newContentJson;
-            if (mimeType.inherits("text/html"_ls)) {
+            if (mimeType.inherits("text/html"_L1)) {
                 newContentJson.insert(FormatKey, HtmlContentTypeId);
                 newContentJson.insert(FormattedBodyKey, body);
             }
@@ -343,8 +343,8 @@ LocationContent::LocationContent(const QString& geoUri,
 
 LocationContent::LocationContent(const QJsonObject& json)
     : TypedBase(json)
-    , geoUri(json["geo_uri"_ls].toString())
-    , thumbnail(json["info"_ls].toObject())
+    , geoUri(json["geo_uri"_L1].toString())
+    , thumbnail(json["info"_L1].toObject())
 {}
 
 QMimeType LocationContent::type() const

--- a/Quotient/events/roommessageevent.cpp
+++ b/Quotient/events/roommessageevent.cpp
@@ -107,7 +107,7 @@ QJsonObject RoomMessageEvent::assembleContentJson(const QString& plainBody,
             auto newContentJson = json.take("m.new_content"_L1).toObject();
             newContentJson.insert(BodyKey, plainBody);
             newContentJson.insert(MsgTypeKey, jsonMsgType);
-            json.insert(QStringLiteral("m.new_content"), newContentJson);
+            json.insert("m.new_content"_L1, newContentJson);
             json[MsgTypeKey] = jsonMsgType;
             json[BodyKey] = "* "_L1 + plainBody;
             return json;
@@ -222,7 +222,7 @@ QString RoomMessageEvent::replacedBy() const
 namespace {
 QString safeFileName(QString rawName)
 {
-    static auto safeFileNameRegex = QRegularExpression(R"([/\<>|"*?:])"_L1);
+    static auto safeFileNameRegex = QRegularExpression(uR"([/\<>|"*?:])"_s);
     return rawName.replace(safeFileNameRegex, "_"_L1);
 }
 }
@@ -257,12 +257,10 @@ QString RoomMessageEvent::fileNameToDownload() const
 QString rawMsgTypeForMimeType(const QMimeType& mimeType)
 {
     auto name = mimeType.name();
-    return name.startsWith("image/"_L1)
-               ? QStringLiteral("m.image")
-               : name.startsWith("video/"_L1)
-                     ? QStringLiteral("m.video")
-                     : name.startsWith("audio/"_L1) ? QStringLiteral("m.audio")
-                                                 : QStringLiteral("m.file");
+    return name.startsWith("image/"_L1)   ? u"m.image"_s
+           : name.startsWith("video/"_L1) ? u"m.video"_s
+           : name.startsWith("audio/"_L1) ? u"m.audio"_s
+                                          : u"m.file"_s;
 }
 
 QString RoomMessageEvent::rawMsgTypeForUrl(const QUrl& url)
@@ -310,28 +308,26 @@ TextContent::TextContent(const QJsonObject& json)
 
 void TextContent::fillJson(QJsonObject &json) const
 {
-    static const auto FormatKey = QStringLiteral("format");
+    static const auto FormatKey = "format"_L1;
 
     if (mimeType.inherits("text/html"_L1)) {
         json.insert(FormatKey, HtmlContentTypeId);
         json.insert(FormattedBodyKey, body);
     }
     if (relatesTo) {
-        json.insert(
-            QStringLiteral("m.relates_to"),
-            relatesTo->type == EventRelation::ReplyType
-                ? QJsonObject { { relatesTo->type,
-                                  QJsonObject {
-                                      { EventIdKey, relatesTo->eventId } } } }
-                : QJsonObject { { RelTypeKey, relatesTo->type },
-                                { EventIdKey, relatesTo->eventId } });
+        json.insert("m.relates_to"_L1,
+                    relatesTo->type == EventRelation::ReplyType
+                        ? QJsonObject{ { relatesTo->type,
+                                         QJsonObject{ { EventIdKey, relatesTo->eventId } } } }
+                        : QJsonObject{ { RelTypeKey, relatesTo->type },
+                                       { EventIdKey, relatesTo->eventId } });
         if (relatesTo->type == EventRelation::ReplacementType) {
             QJsonObject newContentJson;
             if (mimeType.inherits("text/html"_L1)) {
                 newContentJson.insert(FormatKey, HtmlContentTypeId);
                 newContentJson.insert(FormattedBodyKey, body);
             }
-            json.insert(QStringLiteral("m.new_content"), newContentJson);
+            json.insert("m.new_content"_L1, newContentJson);
         }
     }
 }
@@ -354,6 +350,6 @@ QMimeType LocationContent::type() const
 
 void LocationContent::fillJson(QJsonObject& o) const
 {
-    o.insert(QStringLiteral("geo_uri"), geoUri);
-    o.insert(QStringLiteral("info"), toInfoJson(thumbnail));
+    o.insert("geo_uri"_L1, geoUri);
+    o.insert("info"_L1, toInfoJson(thumbnail));
 }

--- a/Quotient/events/roommessageevent.cpp
+++ b/Quotient/events/roommessageevent.cpp
@@ -212,11 +212,7 @@ bool RoomMessageEvent::isReplaced() const
 
 QString RoomMessageEvent::replacedBy() const
 {
-    // clang-format off
-    return unsignedPart<QJsonObject>("m.relations"_L1)
-            .value("m.replace"_L1).toObject()
-            .value(EventIdKey).toString();
-    // clang-format on
+    return unsignedPart<QJsonObject>("m.relations"_L1)["m.replace"_L1][EventIdKey].toString();
 }
 
 namespace {

--- a/Quotient/events/roommessageevent.h
+++ b/Quotient/events/roommessageevent.h
@@ -169,7 +169,7 @@ namespace EventContent {
     protected:
         void fillInfoJson(QJsonObject& infoJson) const override
         {
-            infoJson.insert(QStringLiteral("duration"), duration);
+            infoJson.insert("duration"_L1, duration);
         }
 
     public:

--- a/Quotient/events/roommessageevent.h
+++ b/Quotient/events/roommessageevent.h
@@ -163,7 +163,7 @@ namespace EventContent {
         using UrlBasedContent<InfoT>::UrlBasedContent;
         PlayableContent(const QJsonObject& json)
             : UrlBasedContent<InfoT>(json)
-            , duration(FileInfo::originalInfoJson["duration"_ls].toInt())
+            , duration(FileInfo::originalInfoJson["duration"_L1].toInt())
         {}
 
     protected:

--- a/Quotient/events/roompowerlevelsevent.cpp
+++ b/Quotient/events/roompowerlevelsevent.cpp
@@ -22,19 +22,16 @@ PowerLevelsEventContent::PowerLevelsEventContent(const QJsonObject& json) :
 
 QJsonObject PowerLevelsEventContent::toJson() const
 {
-    QJsonObject o;
-    o.insert(QStringLiteral("invite"), invite);
-    o.insert(QStringLiteral("kick"), kick);
-    o.insert(QStringLiteral("ban"), ban);
-    o.insert(QStringLiteral("redact"), redact);
-    o.insert(QStringLiteral("events"), Quotient::toJson(events));
-    o.insert(QStringLiteral("events_default"), eventsDefault);
-    o.insert(QStringLiteral("state_default"), stateDefault);
-    o.insert(QStringLiteral("users"), Quotient::toJson(users));
-    o.insert(QStringLiteral("users_default"), usersDefault);
-    o.insert(QStringLiteral("notifications"),
-             QJsonObject { { "room"_L1, notifications.room } });
-    return o;
+    return QJsonObject{ { u"invite"_s, invite },
+                        { u"kick"_s, kick },
+                        { u"ban"_s, ban },
+                        { u"redact"_s, redact },
+                        { u"events"_s, Quotient::toJson(events) },
+                        { u"events_default"_s, eventsDefault },
+                        { u"state_default"_s, stateDefault },
+                        { u"users"_s, Quotient::toJson(users) },
+                        { u"users_default"_s, usersDefault },
+                        { u"notifications"_s, QJsonObject{ { u"room"_s, notifications.room } } } };
 }
 
 int RoomPowerLevelsEvent::powerLevelForEvent(const QString& eventTypeId) const

--- a/Quotient/events/roompowerlevelsevent.cpp
+++ b/Quotient/events/roompowerlevelsevent.cpp
@@ -8,16 +8,16 @@ using namespace Quotient;
 // The default values used below are defined in
 // https://spec.matrix.org/v1.3/client-server-api/#mroompower_levels
 PowerLevelsEventContent::PowerLevelsEventContent(const QJsonObject& json) :
-    invite(json["invite"_ls].toInt(50)),
-    kick(json["kick"_ls].toInt(50)),
-    ban(json["ban"_ls].toInt(50)),
-    redact(json["redact"_ls].toInt(50)),
-    events(fromJson<QHash<QString, int>>(json["events"_ls])),
-    eventsDefault(json["events_default"_ls].toInt(0)),
-    stateDefault(json["state_default"_ls].toInt(0)),
-    users(fromJson<QHash<QString, int>>(json["users"_ls])),
-    usersDefault(json["users_default"_ls].toInt(0)),
-    notifications(Notifications{json["notifications"_ls].toObject()["room"_ls].toInt(50)})
+    invite(json["invite"_L1].toInt(50)),
+    kick(json["kick"_L1].toInt(50)),
+    ban(json["ban"_L1].toInt(50)),
+    redact(json["redact"_L1].toInt(50)),
+    events(fromJson<QHash<QString, int>>(json["events"_L1])),
+    eventsDefault(json["events_default"_L1].toInt(0)),
+    stateDefault(json["state_default"_L1].toInt(0)),
+    users(fromJson<QHash<QString, int>>(json["users"_L1])),
+    usersDefault(json["users_default"_L1].toInt(0)),
+    notifications(Notifications{json["notifications"_L1].toObject()["room"_L1].toInt(50)})
 {}
 
 QJsonObject PowerLevelsEventContent::toJson() const
@@ -33,7 +33,7 @@ QJsonObject PowerLevelsEventContent::toJson() const
     o.insert(QStringLiteral("users"), Quotient::toJson(users));
     o.insert(QStringLiteral("users_default"), usersDefault);
     o.insert(QStringLiteral("notifications"),
-             QJsonObject { { "room"_ls, notifications.room } });
+             QJsonObject { { "room"_L1, notifications.room } });
     return o;
 }
 

--- a/Quotient/events/roomtombstoneevent.cpp
+++ b/Quotient/events/roomtombstoneevent.cpp
@@ -7,10 +7,10 @@ using namespace Quotient;
 
 QString RoomTombstoneEvent::serverMessage() const
 {
-    return contentPart<QString>("body"_ls);
+    return contentPart<QString>("body"_L1);
 }
 
 QString RoomTombstoneEvent::successorRoomId() const
 {
-    return contentPart<QString>("replacement_room"_ls);
+    return contentPart<QString>("replacement_room"_L1);
 }

--- a/Quotient/events/simplestateevents.h
+++ b/Quotient/events/simplestateevents.h
@@ -11,7 +11,7 @@ namespace Quotient {
 
 #define DEFINE_SIMPLE_STATE_EVENT(Name_, TypeId_, ValueType_, GetterName_,   \
                                   JsonKey_)                                  \
-    constexpr inline auto Name_##Key = JsonKey_##_ls;                        \
+    constexpr inline auto Name_##Key = JsonKey_##_L1;                        \
     class QUOTIENT_API Name_                                                 \
         : public KeylessStateEventBase<                                      \
               Name_, EventContent::SingleKeyValue<ValueType_, Name_##Key>> { \

--- a/Quotient/events/stateevent.cpp
+++ b/Quotient/events/stateevent.cpp
@@ -24,7 +24,7 @@ bool StateEvent::repeatsState() const
 
 QString StateEvent::replacedState() const
 {
-    return unsignedPart<QString>("replaces_state"_ls);
+    return unsignedPart<QString>("replaces_state"_L1);
 }
 
 void StateEvent::dumpTo(QDebug dbg) const

--- a/Quotient/events/stateevent.h
+++ b/Quotient/events/stateevent.h
@@ -7,7 +7,7 @@
 
 namespace Quotient {
 
-constexpr inline auto PrevContentKey = "prev_content"_ls;
+constexpr inline auto PrevContentKey = "prev_content"_L1;
 
 class QUOTIENT_API StateEvent : public RoomEvent {
 public:
@@ -66,7 +66,7 @@ public:
     struct Prev {
         explicit Prev() = default;
         explicit Prev(const QJsonObject& unsignedJson)
-            : senderId(fromJson<QString>(unsignedJson["prev_sender"_ls]))
+            : senderId(fromJson<QString>(unsignedJson["prev_sender"_L1]))
             , content(fromJson<std::optional<ContentT>>(unsignedJson[PrevContentKey]))
         {}
 

--- a/Quotient/events/stickerevent.h
+++ b/Quotient/events/stickerevent.h
@@ -19,7 +19,7 @@ public:
     explicit StickerEvent(const QJsonObject& obj)
         : RoomEvent(obj)
         , m_imageContent(
-              EventContent::ImageContent(obj["content"_ls].toObject()))
+              EventContent::ImageContent(obj["content"_L1].toObject()))
     {}
 
     /// \brief A textual representation or associated description of the

--- a/Quotient/jobs/basejob.cpp
+++ b/Quotient/jobs/basejob.cpp
@@ -174,14 +174,11 @@ inline bool isHex(QChar c)
 
 QByteArray BaseJob::encodeIfParam(const QString& paramPart)
 {
-    const auto percentIndex = paramPart.indexOf(u'%');
-    if (percentIndex != -1 && paramPart.size() > percentIndex + 2
-        && isHex(paramPart[percentIndex + 1])
-        && isHex(paramPart[percentIndex + 2])) {
-        qCWarning(JOBS)
-            << "Developers, upfront percent-encoding of job parameters is "
-               "deprecated since libQuotient 0.7; the string involved is"
-            << paramPart;
+    if (const auto percentIt = std::ranges::find(paramPart, u'%');
+        percentIt <= paramPart.end() - 3 && isHex(*(percentIt + 1)) && isHex((*(percentIt + 2)))) {
+        qCWarning(JOBS) << "Developers, upfront percent-encoding of job paramParteters is "
+                           "deprecated since libQuotient 0.7; the string involved is"
+                        << paramPart;
         return QUrl(paramPart, QUrl::TolerantMode).toEncoded();
     }
     return QUrl::toPercentEncoding(paramPart);

--- a/Quotient/jobs/basejob.cpp
+++ b/Quotient/jobs/basejob.cpp
@@ -567,12 +567,13 @@ BaseJob::Status BaseJob::prepareError(Status currentStatus)
     return currentStatus; // The error payload is not recognised
 }
 
-QJsonValue BaseJob::takeValueFromJson(const QString& key)
+QJsonValue BaseJob::takeValueFromJson(QAnyStringView key)
 {
     if (!d->jsonResponse.isObject())
         return QJsonValue::Undefined;
     auto o = d->jsonResponse.object();
-    auto v = o.take(key);
+    auto v = key.visit(Overloads{ [&o](QUtf8StringView k) { return o.take(k.utf8()); },
+                                  [&o](auto k) { return o.take(k); } });
     d->jsonResponse.setObject(o);
     return v;
 }

--- a/Quotient/jobs/basejob.cpp
+++ b/Quotient/jobs/basejob.cpp
@@ -158,8 +158,8 @@ public:
 
     [[nodiscard]] QString dumpRequest() const
     {
-        static const std::array verbs { "GET"_ls, "PUT"_ls, "POST"_ls,
-                                        "DELETE"_ls };
+        static const std::array verbs { "GET"_L1, "PUT"_L1, "POST"_L1,
+                                        "DELETE"_L1 };
         const auto verbWord = verbs.at(size_t(verb));
         return verbWord % u' '
                % (reply ? reply->url().toString(QUrl::RemoveQuery)
@@ -295,7 +295,7 @@ QNetworkRequest BaseJob::Private::prepareRequest() const
 {
     QNetworkRequest req{ makeRequestUrl(connection->homeserverData(), apiEndpoint, requestQuery) };
     if (!requestHeaders.contains("Content-Type"))
-        req.setHeader(QNetworkRequest::ContentTypeHeader, "application/json"_ls);
+        req.setHeader(QNetworkRequest::ContentTypeHeader, "application/json"_L1);
     if (needsToken)
         req.setRawHeader("Authorization",
                          QByteArray("Bearer ") + connection->accessToken());
@@ -350,7 +350,7 @@ void BaseJob::initiate(ConnectionData* connData, bool inBackground)
         else if ((d->verb == HttpVerb::Post || d->verb == HttpVerb::Put)
             && d->requestData.source()
             && !d->requestData.source()->isReadable()) {
-            setStatus(FileError, "Request data not ready"_ls);
+            setStatus(FileError, "Request data not ready"_L1);
         }
         Q_ASSERT(status().code != Pending); // doPrepare() must NOT set this
         if (Q_LIKELY(status().code == Unprepared)) {
@@ -498,7 +498,7 @@ BaseJob::Status BaseJob::checkReply(const QNetworkReply* reply) const
         if (!checkContentType(reply->rawHeader("Content-Type"),
                               d->expectedContentTypes))
             return { UnexpectedResponseTypeWarning,
-                     "Unexpected content type of the response"_ls };
+                     "Unexpected content type of the response"_L1 };
         return NoError;
     }
     if (reply->isFinished())
@@ -526,10 +526,10 @@ BaseJob::Status BaseJob::prepareError(Status currentStatus)
     // a valid JSON object - or an empty object otherwise (in which case most
     // of if's below will fall through retaining the current status)
     const auto& errorJson = jsonData();
-    const auto errCode = errorJson.value("errcode"_ls).toString();
-    if (error() == TooManyRequests || errCode == "M_LIMIT_EXCEEDED"_ls) {
+    const auto errCode = errorJson.value("errcode"_L1).toString();
+    if (error() == TooManyRequests || errCode == "M_LIMIT_EXCEEDED"_L1) {
         QString msg = tr("Too many requests");
-        int64_t retryAfterMs = errorJson.value("retry_after_ms"_ls).toInt(-1);
+        int64_t retryAfterMs = errorJson.value("retry_after_ms"_L1).toInt(-1);
         if (retryAfterMs >= 0)
             msg += tr(", next retry advised after %1 ms").arg(retryAfterMs);
         else // We still have to figure some reasonable interval
@@ -540,26 +540,26 @@ BaseJob::Status BaseJob::prepareError(Status currentStatus)
         return { TooManyRequests, msg };
     }
 
-    if (errCode == "M_CONSENT_NOT_GIVEN"_ls) {
-        d->errorUrl = QUrl(errorJson.value("consent_uri"_ls).toString());
+    if (errCode == "M_CONSENT_NOT_GIVEN"_L1) {
+        d->errorUrl = QUrl(errorJson.value("consent_uri"_L1).toString());
         return { UserConsentRequired };
     }
-    if (errCode == "M_UNSUPPORTED_ROOM_VERSION"_ls
-        || errCode == "M_INCOMPATIBLE_ROOM_VERSION"_ls)
+    if (errCode == "M_UNSUPPORTED_ROOM_VERSION"_L1
+        || errCode == "M_INCOMPATIBLE_ROOM_VERSION"_L1)
         return { UnsupportedRoomVersion,
-                 errorJson.contains("room_version"_ls)
+                 errorJson.contains("room_version"_L1)
                      ? tr("Requested room version: %1")
-                           .arg(errorJson.value("room_version"_ls).toString())
-                     : errorJson.value("error"_ls).toString() };
-    if (errCode == "M_CANNOT_LEAVE_SERVER_NOTICE_ROOM"_ls)
+                           .arg(errorJson.value("room_version"_L1).toString())
+                     : errorJson.value("error"_L1).toString() };
+    if (errCode == "M_CANNOT_LEAVE_SERVER_NOTICE_ROOM"_L1)
         return { CannotLeaveRoom,
                  tr("It's not allowed to leave a server notices room") };
-    if (errCode == "M_USER_DEACTIVATED"_ls)
+    if (errCode == "M_USER_DEACTIVATED"_L1)
         return { UserDeactivated };
 
     // Not localisable on the client side
-    if (errorJson.contains("error"_ls)) // Keep the code, update the message
-        return { currentStatus.code, errorJson.value("error"_ls).toString() };
+    if (errorJson.contains("error"_L1)) // Keep the code, update the message
+        return { currentStatus.code, errorJson.value("error"_L1).toString() };
 
     return currentStatus; // The error payload is not recognised
 }
@@ -612,7 +612,7 @@ void BaseJob::finishJob()
             qCWarning(d->logCat).nospace()
                 << this << ": retry #" << d->retriesTaken << " in "
                 << retryIn.count() << " s";
-            setStatus(Pending, "Pending retry"_ls);
+            setStatus(Pending, "Pending retry"_L1);
             d->retryTimer.start(retryIn);
             emit retryScheduled(d->retriesTaken, milliseconds(retryIn).count());
             return;
@@ -777,7 +777,7 @@ void BaseJob::setStatus(Status s)
 
     if (!s.message.isEmpty() && d->connection
         && !d->connection->accessToken().isEmpty())
-        s.message.replace(QString::fromUtf8(d->connection->accessToken()), "(REDACTED)"_ls);
+        s.message.replace(QString::fromUtf8(d->connection->accessToken()), "(REDACTED)"_L1);
     if (!s.good())
         qCWarning(d->logCat) << this << "status" << s;
     d->status = std::move(s);
@@ -813,7 +813,7 @@ void BaseJob::abandon()
 
 void BaseJob::timeout()
 {
-    setStatus(Timeout, "The job has timed out"_ls);
+    setStatus(Timeout, "The job has timed out"_L1);
     finishJob();
 }
 

--- a/Quotient/jobs/basejob.cpp
+++ b/Quotient/jobs/basejob.cpp
@@ -175,7 +175,7 @@ inline bool isHex(QChar c)
 QByteArray BaseJob::encodeIfParam(const QString& paramPart)
 {
     if (const auto percentIt = std::ranges::find(paramPart, u'%');
-        percentIt <= paramPart.end() - 3 && isHex(*(percentIt + 1)) && isHex((*(percentIt + 2)))) {
+        percentIt <= paramPart.end() - 3 && isHex(*(percentIt + 1)) && isHex(*(percentIt + 2))) {
         qCWarning(JOBS) << "Developers, upfront percent-encoding of job paramParteters is "
                            "deprecated since libQuotient 0.7; the string involved is"
                         << paramPart;

--- a/Quotient/jobs/basejob.h
+++ b/Quotient/jobs/basejob.h
@@ -31,9 +31,9 @@ class QUOTIENT_API BaseJob : public QObject {
 
     static QByteArray encodeIfParam(const QString& paramPart);
     template <int N>
-    static auto encodeIfParam(const char (&constPart)[N])
+    static auto encodeIfParam(const char (&literalPart)[N])
     {
-        return constPart;
+        return literalPart;
     }
 
 public:
@@ -74,9 +74,9 @@ public:
     Q_ENUM(StatusCode)
 
     template <typename... StrTs>
-    static QByteArray makePath(StrTs&&... parts)
+    static QByteArray makePath(QByteArrayView base, StrTs&&... parts)
     {
-        return (QByteArray() % ... % encodeIfParam(parts));
+        return (base % ... % encodeIfParam(std::forward<StrTs>(parts)));
     }
 
     //! \brief The status of a job

--- a/Quotient/jobs/basejob.h
+++ b/Quotient/jobs/basejob.h
@@ -431,7 +431,6 @@ private:
     template <class JobT>
     friend class JobHandle;
 
-private:
     void stop();
     void finishJob();
     QFuture<void> future();

--- a/Quotient/jobs/basejob.h
+++ b/Quotient/jobs/basejob.h
@@ -173,12 +173,11 @@ public:
     //!
     //! If there's no top-level JSON object in the response or if there's
     //! no node with the key \p keyName, \p defaultValue is returned.
-    template <typename T, typename StrT>
-    T loadFromJson(const StrT& keyName, T&& defaultValue = {}) const
+    template <typename T>
+    T loadFromJson(auto keyName, T&& defaultValue = {}) const
     {
         const auto& jv = jsonData().value(keyName);
-        return jv.isUndefined() ? std::forward<T>(defaultValue)
-                                : fromJson<T>(jv);
+        return jv.isUndefined() ? std::forward<T>(defaultValue) : fromJson<T>(jv);
     }
 
     //! \brief Load the property from the JSON response and delete it from JSON
@@ -186,7 +185,7 @@ public:
     //! If there's no top-level JSON object in the response or if there's
     //! no node with the key \p keyName, \p defaultValue is returned.
     template <typename T>
-    T takeFromJson(const QString& key, T&& defaultValue = {})
+    T takeFromJson(auto key, T&& defaultValue = {})
     {
         if (const auto& jv = takeValueFromJson(key); !jv.isUndefined())
             return fromJson<T>(jv);
@@ -399,7 +398,7 @@ protected:
     //!         have \p key; the value for \p key otherwise.
     //!
     //! \sa takeFromJson
-    QJsonValue takeValueFromJson(const QString& key);
+    QJsonValue takeValueFromJson(QAnyStringView key);
 
     void setStatus(Status s);
     void setStatus(int code, QString message);
@@ -432,6 +431,7 @@ private:
     template <class JobT>
     friend class JobHandle;
 
+private:
     void stop();
     void finishJob();
     QFuture<void> future();

--- a/Quotient/jobs/downloadfilejob.cpp
+++ b/Quotient/jobs/downloadfilejob.cpp
@@ -51,7 +51,7 @@ QUrl DownloadFileJob::makeRequestUrl(const HomeserverData& hsData, const QString
 }
 
 DownloadFileJob::DownloadFileJob(QString serverName, QString mediaId, const QString& localFilename)
-    : BaseJob(HttpVerb::Get, QStringLiteral("DownloadFileJob"), {})
+    : BaseJob(HttpVerb::Get, u"DownloadFileJob"_s, {})
     , d(makeImpl<Private>(std::move(serverName), std::move(mediaId), localFilename))
 {}
 

--- a/Quotient/jobs/downloadfilejob.cpp
+++ b/Quotient/jobs/downloadfilejob.cpp
@@ -24,7 +24,7 @@ public:
         : serverName(std::move(serverName))
         , mediaId(std::move(mediaId))
         , targetFile(!localFilename.isEmpty() ? new QFile(localFilename) : nullptr)
-        , tempFile(!localFilename.isEmpty() ? new QFile(targetFile->fileName() + ".qtntdownload"_ls)
+        , tempFile(!localFilename.isEmpty() ? new QFile(targetFile->fileName() + ".qtntdownload"_L1)
                                             : new QTemporaryFile())
     {}
 
@@ -77,13 +77,13 @@ void DownloadFileJob::doPrepare(const ConnectionData* connectionData)
         && !d->targetFile->open(QIODevice::WriteOnly)) {
         qCWarning(JOBS) << "Couldn't open the file" << d->targetFile->fileName()
                         << "for writing";
-        setStatus(FileError, "Could not open the target file for writing"_ls);
+        setStatus(FileError, "Could not open the target file for writing"_L1);
         return;
     }
     if (!d->tempFile->isReadable() && !d->tempFile->open(QIODevice::ReadWrite)) {
         qCWarning(JOBS) << "Couldn't open the temporary file"
                         << d->tempFile->fileName() << "for writing";
-        setStatus(FileError, "Could not open the temporary download file"_ls);
+        setStatus(FileError, "Could not open the temporary download file"_L1);
         return;
     }
     qCDebug(JOBS) << "Downloading to" << d->tempFile->fileName();
@@ -102,7 +102,7 @@ void DownloadFileJob::onSentRequest(QNetworkReply* reply)
                     qCWarning(JOBS) << "Failed to allocate" << targetSize
                                     << "bytes for" << d->tempFile->fileName();
                     setStatus(FileError,
-                              "Could not reserve disk space for download"_ls);
+                              "Could not reserve disk space for download"_L1);
                 }
         }
     });
@@ -144,12 +144,12 @@ BaseJob::Status DownloadFileJob::prepareResult()
             d->targetFile->close();
             if (!d->targetFile->remove()) {
                 qWarning(JOBS) << "Failed to remove the target file placeholder";
-                return { FileError, "Couldn't finalise the download"_ls };
+                return { FileError, "Couldn't finalise the download"_L1 };
             }
             if (!d->tempFile->rename(d->targetFile->fileName())) {
                 qWarning(JOBS) << "Failed to rename" << d->tempFile->fileName()
                                 << "to" << d->targetFile->fileName();
-                return { FileError, "Couldn't finalise the download"_ls };
+                return { FileError, "Couldn't finalise the download"_L1 };
             }
         }
     } else {
@@ -160,12 +160,12 @@ BaseJob::Status DownloadFileJob::prepareResult()
             if (!d->tempFile->remove()) {
                 qWarning(JOBS)
                     << "Failed to remove the decrypted file placeholder";
-                return { FileError, "Couldn't finalise the download"_ls };
+                return { FileError, "Couldn't finalise the download"_L1 };
             }
             if (!tempTempFile.rename(d->tempFile->fileName())) {
                 qWarning(JOBS) << "Failed to rename" << tempTempFile.fileName()
                                 << "to" << d->tempFile->fileName();
-                return { FileError, "Couldn't finalise the download"_ls };
+                return { FileError, "Couldn't finalise the download"_L1 };
             }
         } else {
             d->tempFile->close();

--- a/Quotient/jobs/mediathumbnailjob.cpp
+++ b/Quotient/jobs/mediathumbnailjob.cpp
@@ -35,7 +35,7 @@ QUrl MediaThumbnailJob::makeRequestUrl(const HomeserverData& hsData, const QStri
 
 MediaThumbnailJob::MediaThumbnailJob(QString serverName, QString mediaId, QSize requestedSize,
                                      std::optional<bool> animated)
-    : BaseJob(HttpVerb::Get, QStringLiteral("MediaThumbnailJob"), {})
+    : BaseJob(HttpVerb::Get, u"MediaThumbnailJob"_s, {})
     , serverName(std::move(serverName))
     , mediaId(std::move(mediaId))
     , requestedSize(std::move(requestedSize))
@@ -70,5 +70,5 @@ BaseJob::Status MediaThumbnailJob::prepareResult()
     if (_thumbnail.loadFromData(reply()->readAll()))
         return Success;
 
-    return { IncorrectResponse, QStringLiteral("Could not read image data") };
+    return { IncorrectResponse, u"Could not read image data"_s };
 }

--- a/Quotient/jobs/mediathumbnailjob.cpp
+++ b/Quotient/jobs/mediathumbnailjob.cpp
@@ -26,10 +26,10 @@ QUrl MediaThumbnailJob::makeRequestUrl(const HomeserverData& hsData, const QStri
                    ? GetContentThumbnailAuthedJob::makeRequestUrl(hsData, serverName, mediaId,
                                                                   requestedSize.width(),
                                                                   requestedSize.height(),
-                                                                  "scale"_ls, 20'000, animated)
+                                                                  "scale"_L1, 20'000, animated)
                    : GetContentThumbnailJob::makeRequestUrl(hsData, serverName, mediaId,
                                                             requestedSize.width(),
-                                                            requestedSize.height(), "scale"_ls,
+                                                            requestedSize.height(), "scale"_L1,
                                                             true, 20'000, false, animated);)
 }
 

--- a/Quotient/jobs/syncjob.cpp
+++ b/Quotient/jobs/syncjob.cpp
@@ -9,18 +9,16 @@ using namespace Quotient;
 
 static size_t jobId = 0;
 
-SyncJob::SyncJob(const QString& since, const QString& filter, int timeout,
-                 const QString& presence)
-    : BaseJob(HttpVerb::Get, QStringLiteral("SyncJob-%1").arg(++jobId),
-              "_matrix/client/r0/sync")
+SyncJob::SyncJob(const QString& since, const QString& filter, int timeout, const QString& presence)
+    : BaseJob(HttpVerb::Get, "SyncJob-"_L1 + QString::number(++jobId), "_matrix/client/r0/sync")
 {
     setLoggingCategory(SYNCJOB);
     QUrlQuery query;
-    addParam<IfNotEmpty>(query, QStringLiteral("filter"), filter);
-    addParam<IfNotEmpty>(query, QStringLiteral("set_presence"), presence);
+    addParam<IfNotEmpty>(query, u"filter"_s, filter);
+    addParam<IfNotEmpty>(query, u"set_presence"_s, presence);
     if (timeout >= 0)
-        query.addQueryItem(QStringLiteral("timeout"), QString::number(timeout));
-    addParam<IfNotEmpty>(query, QStringLiteral("since"), since);
+        query.addQueryItem(u"timeout"_s, QString::number(timeout));
+    addParam<IfNotEmpty>(query, u"since"_s, since);
     setRequestQuery(query);
 
     setMaxRetries(std::numeric_limits<int>::max());

--- a/Quotient/keyimport.cpp
+++ b/Quotient/keyimport.cpp
@@ -28,8 +28,8 @@ const auto HeaderLength = VersionLength + AesBlockSize + AesBlockSize + RoundsLe
 
 Expected<QJsonArray, KeyImport::Error> KeyImport::decrypt(QString data, const QString& passphrase)
 {
-    data.remove("-----BEGIN MEGOLM SESSION DATA-----"_ls);
-    data.remove("-----END MEGOLM SESSION DATA-----"_ls);
+    data.remove("-----BEGIN MEGOLM SESSION DATA-----"_L1);
+    data.remove("-----END MEGOLM SESSION DATA-----"_L1);
     data.remove(u'\n');
     auto decoded = QByteArray::fromBase64(data.toLatin1());
     if (decoded[0] != 1) {
@@ -88,10 +88,10 @@ KeyImport::Error KeyImport::importKeys(QString data, const QString& passphrase, 
         }
         // We don't know the session index for these sessions here. We just pretend it's 0, it's not terribly important.
         room->addMegolmSessionFromBackup(
-            keyObject["session_id"_ls].toString().toLatin1(),
-            keyObject["session_key"_ls].toString().toLatin1(), 0,
+            keyObject["session_id"_L1].toString().toLatin1(),
+            keyObject["session_key"_L1].toString().toLatin1(), 0,
             keyObject[SenderKeyKey].toVariant().toByteArray(),
-            keyObject["sender_claimed_keys"_ls]["ed25519"_ls].toString().toLatin1()
+            keyObject["sender_claimed_keys"_L1]["ed25519"_L1].toString().toLatin1()
         );
     }
     return Success;

--- a/Quotient/keyverificationsession.cpp
+++ b/Quotient/keyverificationsession.cpp
@@ -695,7 +695,7 @@ void KeyVerificationSession::sendEvent(const QString &userId, const QString &dev
         json.remove("transaction_id"_L1);
         if (event.metaType().matrixId == KeyVerificationRequestEvent::TypeId) {
             json["msgtype"_L1] = event.matrixType();
-            json["body"_L1] = "%1 sent a verification request"_L1.arg(m_connection->userId());
+            json["body"_L1] = m_connection->userId() + " sent a verification request"_L1;
             json["to"_L1] = m_remoteUserId;
             m_room->postJson("m.room.message"_L1, json);
         } else {

--- a/Quotient/keyverificationsession.cpp
+++ b/Quotient/keyverificationsession.cpp
@@ -290,12 +290,12 @@ QString KeyVerificationSession::calculateMac(const QString& input,
     const auto inputBytes = input.toLatin1();
     const auto macLength = olm_sas_mac_length(olmData);
     auto macChars = byteArrayForOlm(macLength);
-    const auto macInfo =
-        (verifying ? "MATRIX_KEY_VERIFICATION_MAC%3%4%1%2%5%6"_L1
-                   : "MATRIX_KEY_VERIFICATION_MAC%1%2%3%4%5%6"_L1)
-            .arg(m_connection->userId(), m_connection->deviceId(),
-                 m_remoteUserId, m_remoteDeviceId, m_room ? m_requestEventId : m_transactionId, input.contains(u',') ? QStringLiteral("KEY_IDS") : keyId)
-            .toLatin1();
+    const auto macInfo = (verifying ? "MATRIX_KEY_VERIFICATION_MAC%3%4%1%2%5%6"_L1
+                                    : "MATRIX_KEY_VERIFICATION_MAC%1%2%3%4%5%6"_L1)
+                             .arg(m_connection->userId(), m_connection->deviceId(), m_remoteUserId,
+                                  m_remoteDeviceId, m_room ? m_requestEventId : m_transactionId,
+                                  input.contains(u',') ? u"KEY_IDS"_s : keyId)
+                             .toLatin1();
     if (m_commonMacCodes.contains(HmacSha256V2Code))
         olm_sas_calculate_mac_fixed_base64(olmData, inputBytes.data(),
                                            unsignedSize(inputBytes),
@@ -695,7 +695,7 @@ void KeyVerificationSession::sendEvent(const QString &userId, const QString &dev
         json.remove("transaction_id"_L1);
         if (event.metaType().matrixId == KeyVerificationRequestEvent::TypeId) {
             json["msgtype"_L1] = event.matrixType();
-            json["body"_L1] = QStringLiteral("%1 sent a verification request").arg(m_connection->userId());
+            json["body"_L1] = "%1 sent a verification request"_L1.arg(m_connection->userId());
             json["to"_L1] = m_remoteUserId;
             m_room->postJson("m.room.message"_L1, json);
         } else {

--- a/Quotient/keyverificationsession.cpp
+++ b/Quotient/keyverificationsession.cpp
@@ -57,8 +57,8 @@ KeyVerificationSession::KeyVerificationSession(QString remoteUserId,
 
 KeyVerificationSession::KeyVerificationSession(const RoomMessageEvent* event, Room* room)
     : KeyVerificationSession(event->senderId(), room->connection(),
-                             event->contentPart<QString>("from_device"_ls), room->usesEncryption(),
-                             event->contentPart<QStringList>("methods"_ls),
+                             event->contentPart<QString>("from_device"_L1), room->usesEncryption(),
+                             event->contentPart<QStringList>("methods"_L1),
                              event->originTimestamp(), {}, room, event->id())
 {}
 
@@ -189,10 +189,10 @@ struct EmojiStoreEntry : EmojiEntry {
     QHash<QString, QString> translatedDescriptions;
 
     explicit EmojiStoreEntry(const QJsonObject& json)
-        : EmojiEntry{ fromJson<QString>(json["emoji"_ls]),
-                      fromJson<QString>(json["description"_ls]) }
+        : EmojiEntry{ fromJson<QString>(json["emoji"_L1]),
+                      fromJson<QString>(json["description"_L1]) }
         , translatedDescriptions{ fromJson<QHash<QString, QString>>(
-              json["translated_descriptions"_ls]) }
+              json["translated_descriptions"_L1]) }
     {}
 };
 
@@ -201,7 +201,7 @@ using EmojiStore = QVector<EmojiStoreEntry>;
 EmojiStore loadEmojiStore()
 {
     Q_INIT_RESOURCE(libquotientemojis);
-    QFile dataFile(":/sas-emoji.json"_ls);
+    QFile dataFile(":/sas-emoji.json"_L1);
     dataFile.open(QFile::ReadOnly);
     auto data = dataFile.readAll();
     Q_CLEANUP_RESOURCE(libquotientemojis);
@@ -248,8 +248,8 @@ void KeyVerificationSession::handleKey(const KeyVerificationKeyEvent& event)
 
     std::array<std::byte, 6> output{};
     const auto infoTemplate =
-        startSentByUs ? "MATRIX_KEY_VERIFICATION_SAS|%1|%2|%3|%4|%5|%6|%7"_ls
-                      : "MATRIX_KEY_VERIFICATION_SAS|%4|%5|%6|%1|%2|%3|%7"_ls;
+        startSentByUs ? "MATRIX_KEY_VERIFICATION_SAS|%1|%2|%3|%4|%5|%6|%7"_L1
+                      : "MATRIX_KEY_VERIFICATION_SAS|%4|%5|%6|%1|%2|%3|%7"_L1;
 
     const auto info = infoTemplate
                           .arg(m_connection->userId(), m_connection->deviceId(),
@@ -291,8 +291,8 @@ QString KeyVerificationSession::calculateMac(const QString& input,
     const auto macLength = olm_sas_mac_length(olmData);
     auto macChars = byteArrayForOlm(macLength);
     const auto macInfo =
-        (verifying ? "MATRIX_KEY_VERIFICATION_MAC%3%4%1%2%5%6"_ls
-                   : "MATRIX_KEY_VERIFICATION_MAC%1%2%3%4%5%6"_ls)
+        (verifying ? "MATRIX_KEY_VERIFICATION_MAC%3%4%1%2%5%6"_L1
+                   : "MATRIX_KEY_VERIFICATION_MAC%1%2%3%4%5%6"_L1)
             .arg(m_connection->userId(), m_connection->deviceId(),
                  m_remoteUserId, m_remoteDeviceId, m_room ? m_requestEventId : m_transactionId, input.contains(u',') ? QStringLiteral("KEY_IDS") : keyId)
             .toLatin1();
@@ -310,13 +310,13 @@ QString KeyVerificationSession::calculateMac(const QString& input,
 
 void KeyVerificationSession::sendMac()
 {
-    QString keyId{ "ed25519:"_ls % m_connection->deviceId() };
+    QString keyId{ "ed25519:"_L1 % m_connection->deviceId() };
 
     const auto &masterKey = m_connection->isUserVerified(m_connection->userId()) ? m_connection->masterKeyForUser(m_connection->userId()) : QString();
 
     QStringList keyList{keyId};
     if (!masterKey.isEmpty()) {
-        keyList += "ed25519:"_ls + masterKey;
+        keyList += "ed25519:"_L1 + masterKey;
     }
     keyList.sort();
 
@@ -326,7 +326,7 @@ void KeyVerificationSession::sendMac()
     auto key = m_connection->olmAccount()->deviceKeys().keys.value(keyId);
     mac[keyId] = calculateMac(key, false, keyId);
     if (!masterKey.isEmpty()) {
-        mac["ed25519:"_ls + masterKey] = calculateMac(masterKey, false, "ed25519:"_ls + masterKey);
+        mac["ed25519:"_L1 + masterKey] = calculateMac(masterKey, false, "ed25519:"_L1 + masterKey);
     }
 
     sendEvent(m_remoteUserId, m_remoteDeviceId,
@@ -396,10 +396,10 @@ void KeyVerificationSession::sendStartSas()
     KeyVerificationStartEvent event(m_transactionId, m_connection->deviceId());
     auto fixedJson = event.contentJson();
     if (m_room) {
-        fixedJson.remove("transaction_id"_ls);
-        fixedJson["m.relates_to"_ls] = QJsonObject {
-            {"event_id"_ls, m_requestEventId},
-            {"rel_type"_ls, "m.reference"_ls},
+        fixedJson.remove("transaction_id"_L1);
+        fixedJson["m.relates_to"_L1] = QJsonObject {
+            {"event_id"_L1, m_requestEventId},
+            {"rel_type"_L1, "m.reference"_L1},
         };
     }
     m_startEvent = QString::fromUtf8(
@@ -464,8 +464,8 @@ void KeyVerificationSession::handleMac(const KeyVerificationMacEvent& event)
 {
     QStringList keys = event.mac().keys();
     keys.sort();
-    const auto& key = keys.join(","_ls);
-    const QString edKeyId = "ed25519:"_ls % m_remoteDeviceId;
+    const auto& key = keys.join(","_L1);
+    const QString edKeyId = "ed25519:"_L1 % m_remoteDeviceId;
 
     if (calculateMac(m_connection->edKeyForUserDevice(m_remoteUserId,
                                                       m_remoteDeviceId),
@@ -476,9 +476,9 @@ void KeyVerificationSession::handleMac(const KeyVerificationMacEvent& event)
     }
 
     auto masterKey = m_connection->masterKeyForUser(m_remoteUserId);
-    if (event.mac().contains("ed25519:"_ls % masterKey)
-        && calculateMac(masterKey, true, "ed25519:"_ls % masterKey)
-               != event.mac().value("ed25519:"_ls % masterKey)) {
+    if (event.mac().contains("ed25519:"_L1 % masterKey)
+        && calculateMac(masterKey, true, "ed25519:"_L1 % masterKey)
+               != event.mac().value("ed25519:"_L1 % masterKey)) {
         cancelVerification(KEY_MISMATCH);
         return;
     }
@@ -506,22 +506,22 @@ void KeyVerificationSession::trustKeys()
 
     if (!m_pendingMasterKey.isEmpty()) {
         if (m_remoteUserId == m_connection->userId()) {
-            const auto selfSigningKey = m_connection->database()->loadEncrypted("m.cross_signing.self_signing"_ls);
+            const auto selfSigningKey = m_connection->database()->loadEncrypted("m.cross_signing.self_signing"_L1);
             if (!selfSigningKey.isEmpty()) {
                 QHash<QString, QHash<QString, QJsonObject>> signatures;
                 auto json = QJsonObject {
-                    {"keys"_ls, QJsonObject {
-                        {"ed25519:"_ls + m_remoteDeviceId, m_connection->edKeyForUserDevice(m_remoteUserId, m_remoteDeviceId)},
-                        {"curve25519:"_ls + m_remoteDeviceId, m_connection->curveKeyForUserDevice(m_remoteUserId, m_remoteDeviceId)},
+                    {"keys"_L1, QJsonObject {
+                        {"ed25519:"_L1 + m_remoteDeviceId, m_connection->edKeyForUserDevice(m_remoteUserId, m_remoteDeviceId)},
+                        {"curve25519:"_L1 + m_remoteDeviceId, m_connection->curveKeyForUserDevice(m_remoteUserId, m_remoteDeviceId)},
                     }},
-                    {"algorithms"_ls, QJsonArray {"m.olm.v1.curve25519-aes-sha2"_ls, "m.megolm.v1.aes-sha2"_ls}},
-                    {"device_id"_ls, m_remoteDeviceId},
-                    {"user_id"_ls, m_remoteUserId},
+                    {"algorithms"_L1, QJsonArray {"m.olm.v1.curve25519-aes-sha2"_L1, "m.megolm.v1.aes-sha2"_L1}},
+                    {"device_id"_L1, m_remoteDeviceId},
+                    {"user_id"_L1, m_remoteUserId},
                 };
                 auto signature = sign(selfSigningKey, QJsonDocument(json).toJson(QJsonDocument::Compact));
-                json["signatures"_ls] = QJsonObject {
+                json["signatures"_L1] = QJsonObject {
                     {m_connection->userId(), QJsonObject {
-                        {"ed25519:"_ls + m_connection->database()->selfSigningPublicKey(), QString::fromLatin1(signature)},
+                        {"ed25519:"_L1 + m_connection->database()->selfSigningPublicKey(), QString::fromLatin1(signature)},
                     }},
                 };
                 signatures[m_remoteUserId][m_remoteDeviceId] = json;
@@ -539,20 +539,20 @@ void KeyVerificationSession::trustKeys()
                 connect(handler, &SSSSHandler::finished, handler, &QObject::deleteLater);
             }
         } else {
-            const auto userSigningKey = m_connection->database()->loadEncrypted("m.cross_signing.user_signing"_ls);
+            const auto userSigningKey = m_connection->database()->loadEncrypted("m.cross_signing.user_signing"_L1);
             if (!userSigningKey.isEmpty()) {
                 QHash<QString, QHash<QString, QJsonObject>> signatures;
                 auto json = QJsonObject {
-                    {"keys"_ls, QJsonObject {
-                        {"ed25519:"_ls + m_pendingMasterKey, m_pendingMasterKey},
+                    {"keys"_L1, QJsonObject {
+                        {"ed25519:"_L1 + m_pendingMasterKey, m_pendingMasterKey},
                     }},
-                    {"usage"_ls, QJsonArray {"master"_ls}},
-                    {"user_id"_ls, m_remoteUserId},
+                    {"usage"_L1, QJsonArray {"master"_L1}},
+                    {"user_id"_L1, m_remoteUserId},
                 };
                 auto signature = sign(userSigningKey, QJsonDocument(json).toJson(QJsonDocument::Compact));
-                json["signatures"_ls] = QJsonObject {
+                json["signatures"_L1] = QJsonObject {
                     {m_connection->userId(), QJsonObject {
-                        {"ed25519:"_ls + m_connection->database()->userSigningPublicKey(), QString::fromLatin1(signature)},
+                        {"ed25519:"_L1 + m_connection->database()->userSigningPublicKey(), QString::fromLatin1(signature)},
                     }},
                 };
                 signatures[m_remoteUserId][m_pendingMasterKey] = json;
@@ -621,59 +621,59 @@ QString KeyVerificationSession::errorToString(Error error)
 {
     switch(error) {
         case NONE:
-            return "none"_ls;
+            return "none"_L1;
         case TIMEOUT:
-            return "m.timeout"_ls;
+            return "m.timeout"_L1;
         case USER:
-            return "m.user"_ls;
+            return "m.user"_L1;
         case UNEXPECTED_MESSAGE:
-            return "m.unexpected_message"_ls;
+            return "m.unexpected_message"_L1;
         case UNKNOWN_TRANSACTION:
-            return "m.unknown_transaction"_ls;
+            return "m.unknown_transaction"_L1;
         case UNKNOWN_METHOD:
-            return "m.unknown_method"_ls;
+            return "m.unknown_method"_L1;
         case KEY_MISMATCH:
-            return "m.key_mismatch"_ls;
+            return "m.key_mismatch"_L1;
         case USER_MISMATCH:
-            return "m.user_mismatch"_ls;
+            return "m.user_mismatch"_L1;
         case INVALID_MESSAGE:
-            return "m.invalid_message"_ls;
+            return "m.invalid_message"_L1;
         case SESSION_ACCEPTED:
-            return "m.accepted"_ls;
+            return "m.accepted"_L1;
         case MISMATCHED_COMMITMENT:
-            return "m.mismatched_commitment"_ls;
+            return "m.mismatched_commitment"_L1;
         case MISMATCHED_SAS:
-            return "m.mismatched_sas"_ls;
+            return "m.mismatched_sas"_L1;
         default:
-            return "m.user"_ls;
+            return "m.user"_L1;
     }
 }
 
 KeyVerificationSession::Error KeyVerificationSession::stringToError(const QString& error)
 {
-    if (error == "m.timeout"_ls)
+    if (error == "m.timeout"_L1)
         return REMOTE_TIMEOUT;
-    if (error == "m.user"_ls)
+    if (error == "m.user"_L1)
         return REMOTE_USER;
-    if (error == "m.unexpected_message"_ls)
+    if (error == "m.unexpected_message"_L1)
         return REMOTE_UNEXPECTED_MESSAGE;
-    if (error == "m.unknown_message"_ls)
+    if (error == "m.unknown_message"_L1)
         return REMOTE_UNEXPECTED_MESSAGE;
-    if (error == "m.unknown_transaction"_ls)
+    if (error == "m.unknown_transaction"_L1)
         return REMOTE_UNKNOWN_TRANSACTION;
-    if (error == "m.unknown_method"_ls)
+    if (error == "m.unknown_method"_L1)
         return REMOTE_UNKNOWN_METHOD;
-    if (error == "m.key_mismatch"_ls)
+    if (error == "m.key_mismatch"_L1)
         return REMOTE_KEY_MISMATCH;
-    if (error == "m.user_mismatch"_ls)
+    if (error == "m.user_mismatch"_L1)
         return REMOTE_USER_MISMATCH;
-    if (error == "m.invalid_message"_ls)
+    if (error == "m.invalid_message"_L1)
         return REMOTE_INVALID_MESSAGE;
-    if (error == "m.accepted"_ls)
+    if (error == "m.accepted"_L1)
         return REMOTE_SESSION_ACCEPTED;
-    if (error == "m.mismatched_commitment"_ls)
+    if (error == "m.mismatched_commitment"_L1)
         return REMOTE_MISMATCHED_COMMITMENT;
-    if (error == "m.mismatched_sas"_ls)
+    if (error == "m.mismatched_sas"_L1)
         return REMOTE_MISMATCHED_SAS;
     return NONE;
 }
@@ -692,16 +692,16 @@ void KeyVerificationSession::sendEvent(const QString &userId, const QString &dev
 {
     if (m_room) {
         auto json = event.contentJson();
-        json.remove("transaction_id"_ls);
+        json.remove("transaction_id"_L1);
         if (event.metaType().matrixId == KeyVerificationRequestEvent::TypeId) {
-            json["msgtype"_ls] = event.matrixType();
-            json["body"_ls] = QStringLiteral("%1 sent a verification request").arg(m_connection->userId());
-            json["to"_ls] = m_remoteUserId;
-            m_room->postJson("m.room.message"_ls, json);
+            json["msgtype"_L1] = event.matrixType();
+            json["body"_L1] = QStringLiteral("%1 sent a verification request").arg(m_connection->userId());
+            json["to"_L1] = m_remoteUserId;
+            m_room->postJson("m.room.message"_L1, json);
         } else {
-            json["m.relates_to"_ls] = QJsonObject {
-                {"event_id"_ls, m_requestEventId},
-                {"rel_type"_ls, "m.reference"_ls}
+            json["m.relates_to"_L1] = QJsonObject {
+                {"event_id"_L1, m_requestEventId},
+                {"rel_type"_L1, "m.reference"_L1}
             };
             m_room->postJson(event.matrixType(), json);
         }

--- a/Quotient/keyverificationsession.h
+++ b/Quotient/keyverificationsession.h
@@ -178,8 +178,8 @@ private:
     void trustKeys();
     void sendEvent(const QString &userId, const QString &deviceId, const KeyVerificationEvent &event, bool encrypted);
 
-    QByteArray macInfo(bool verifying, const QString& key = "KEY_IDS"_ls);
-    QString calculateMac(const QString& input, bool verifying, const QString& keyId= "KEY_IDS"_ls);
+    QByteArray macInfo(bool verifying, const QString& key = "KEY_IDS"_L1);
+    QString calculateMac(const QString& input, bool verifying, const QString& keyId= "KEY_IDS"_L1);
 };
 
 } // namespace Quotient

--- a/Quotient/networkaccessmanager.cpp
+++ b/Quotient/networkaccessmanager.cpp
@@ -151,7 +151,7 @@ QNetworkReply* NetworkAccessManager::createRequest(
         return reply;
     }
     const QUrlQuery query{ url.query() };
-    const auto accountId = query.queryItemValue(QStringLiteral("user_id"));
+    const auto accountId = query.queryItemValue(u"user_id"_s);
     if (accountId.isEmpty()) {
         // Using QSettings here because Quotient::NetworkSettings
         // doesn't provide multi-threading guarantees
@@ -179,20 +179,18 @@ QNetworkReply* NetworkAccessManager::createRequest(
     // Convert mxc:// URL into normal http(s) for the given homeserver
     QNetworkRequest rewrittenRequest(request);
     rewrittenRequest.setUrl(DownloadFileJob::makeRequestUrl(hsData, url));
-    rewrittenRequest.setRawHeader("Authorization", QByteArrayLiteral("Bearer ") + hsData.accessToken);
+    rewrittenRequest.setRawHeader("Authorization", "Bearer "_ba + hsData.accessToken);
 
     auto* implReply = QNetworkAccessManager::createRequest(op, rewrittenRequest);
     implReply->ignoreSslErrors(d.getIgnoredSslErrors());
-    const auto& fileMetadata = FileMetadataMap::lookup(
-        query.queryItemValue(QStringLiteral("room_id")),
-        query.queryItemValue(QStringLiteral("event_id")));
+    const auto& fileMetadata = FileMetadataMap::lookup(query.queryItemValue(u"room_id"_s),
+                                                       query.queryItemValue(u"event_id"_s));
     return new MxcReply(implReply, fileMetadata);
 }
 
 QStringList NetworkAccessManager::supportedSchemesImplementation() const
 {
-    return QNetworkAccessManager::supportedSchemesImplementation()
-           << QStringLiteral("mxc");
+    return QNetworkAccessManager::supportedSchemesImplementation() << u"mxc"_s;
 }
 
 void NetworkAccessManager::setAccessToken(const QString& userId, const QByteArray& token)

--- a/Quotient/networkaccessmanager.cpp
+++ b/Quotient/networkaccessmanager.cpp
@@ -144,7 +144,7 @@ QNetworkReply* NetworkAccessManager::createRequest(
     Operation op, const QNetworkRequest& request, QIODevice* outgoingData)
 {
     const auto url = request.url();
-    if (url.scheme() != "mxc"_ls) {
+    if (url.scheme() != "mxc"_L1) {
         auto reply =
             QNetworkAccessManager::createRequest(op, request, outgoingData);
         reply->ignoreSslErrors(d.getIgnoredSslErrors());
@@ -156,7 +156,7 @@ QNetworkReply* NetworkAccessManager::createRequest(
         // Using QSettings here because Quotient::NetworkSettings
         // doesn't provide multi-threading guarantees
         if (static thread_local const QSettings s;
-            s.value("Network/allow_direct_media_requests"_ls).toBool()) //
+            s.value("Network/allow_direct_media_requests"_L1).toBool()) //
         {
             // TODO: Make the best effort with a direct unauthenticated request
             // to the media server

--- a/Quotient/networksettings.h
+++ b/Quotient/networksettings.h
@@ -17,10 +17,7 @@ class QUOTIENT_API NetworkSettings : public SettingsGroup {
     QUO_DECLARE_SETTING(quint16, proxyPort, setProxyPort)
     Q_PROPERTY(QString proxyHost READ proxyHostName WRITE setProxyHostName)
 public:
-    template <typename... ArgTs>
-    explicit NetworkSettings(ArgTs... qsettingsArgs)
-        : SettingsGroup(QStringLiteral("Network"), qsettingsArgs...)
-    {}
+    explicit NetworkSettings() : SettingsGroup(u"Network"_s) {}
 
     Q_INVOKABLE void setupApplicationProxy() const;
 };

--- a/Quotient/quotient_common.h
+++ b/Quotient/quotient_common.h
@@ -67,7 +67,7 @@ QUO_DECLARE_FLAGS_NS(MembershipMask, Membership)
 
 constexpr std::array MembershipStrings {
     // The order MUST be the same as the order in the Membership enum
-    "join"_ls, "leave"_ls, "invite"_ls, "knock"_ls, "ban"_ls
+    "join"_L1, "leave"_L1, "invite"_L1, "knock"_L1, "ban"_L1
 };
 
 //! \brief Local user join-state names
@@ -114,7 +114,7 @@ enum class RoomType : uint8_t {
 };
 Q_ENUM_NS(RoomType)
 
-[[maybe_unused]] constexpr std::array RoomTypeStrings { "m.space"_ls };
+[[maybe_unused]] constexpr std::array RoomTypeStrings { "m.space"_L1 };
 
 enum class EncryptionType : uint8_t {
     MegolmV1AesSha2 = 0,

--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -373,7 +373,7 @@ public:
             return {};
         }
         auto& senderSession = groupSessionIt->second;
-        if (senderSession.senderId() != "BACKUP"_ls && senderSession.senderId() != senderId) {
+        if (senderSession.senderId() != "BACKUP"_L1 && senderSession.senderId() != senderId) {
             qCWarning(E2EE) << "Sender from event does not match sender from session";
             return {};
         }
@@ -1021,7 +1021,7 @@ bool Room::canSwitchVersions() const
         const auto currentUserLevel =
             plEvt->powerLevelForUser(localMember().id());
         const auto tombstonePowerLevel =
-            plEvt->powerLevelForState("m.room.tombstone"_ls);
+            plEvt->powerLevelForState("m.room.tombstone"_L1);
         return currentUserLevel >= tombstonePowerLevel;
     }
     return true;
@@ -1133,7 +1133,7 @@ void Room::Private::getAllMembers()
         return;
 
     allMembersJob = connection->callApi<GetMembersByRoomJob>(
-        id, connection->nextBatchToken(), "join"_ls);
+        id, connection->nextBatchToken(), "join"_L1);
     auto nextIndex = timeline.empty() ? 0 : timeline.back().index() + 1;
     connect(allMembersJob, &BaseJob::success, q, [this, nextIndex] {
         Q_ASSERT(timeline.empty() || nextIndex <= q->maxTimelineIndex() + 1);
@@ -1298,7 +1298,7 @@ std::pair<bool, QString> validatedTag(QString name)
 
     qCWarning(MAIN) << "The tag" << name
                     << "doesn't follow the CS API conventions";
-    name.prepend("u."_ls);
+    name.prepend("u."_L1);
     qCWarning(MAIN) << "Using " << name << "instead";
 
     return { true, name };
@@ -1329,8 +1329,8 @@ void Room::removeTag(const QString& name)
         d->tags.remove(name);
         emit tagsChanged();
         connection()->callApi<DeleteRoomTagJob>(localMember().id(), id(), name);
-    } else if (!name.startsWith("u."_ls))
-        removeTag("u."_ls + name);
+    } else if (!name.startsWith("u."_L1))
+        removeTag("u."_L1 + name);
     else
         qCWarning(MAIN) << "Tag" << name << "on room" << objectName()
                        << "not found, nothing to remove";
@@ -1404,9 +1404,9 @@ QUrl Room::makeMediaUrl(const QString& eventId, const QUrl& mxcUrl) const
 {
     auto url = connection()->makeMediaUrl(mxcUrl);
     QUrlQuery q(url.query());
-    Q_ASSERT(q.hasQueryItem("user_id"_ls));
-    q.addQueryItem("room_id"_ls, id());
-    q.addQueryItem("event_id"_ls, eventId);
+    Q_ASSERT(q.hasQueryItem("user_id"_L1));
+    q.addQueryItem("room_id"_L1, id());
+    q.addQueryItem("event_id"_L1, eventId);
     url.setQuery(q);
     return url;
 }
@@ -2016,7 +2016,7 @@ void Room::Private::onEventSendingFailure(PendingEvents::iterator eventItemIter,
     if (eventItemIter == unsyncedEvents.end()) // ¯\_(ツ)_/¯
         return;
 
-    eventItemIter->setSendingFailed(call ? call->statusCaption() % ": "_ls % call->errorString()
+    eventItemIter->setSendingFailed(call ? call->statusCaption() % ": "_L1 % call->errorString()
                                          : tr("The call could not be started"));
     emit q->pendingEventChanged(int(eventItemIter - unsyncedEvents.begin()));
 }
@@ -2317,7 +2317,7 @@ JobHandle<GetRoomEventsJob> Room::Private::getPreviousContent(int limit, const Q
 
     lastRequestedHistorySize = limit;
     eventsHistoryJob =
-        connection->callApi<GetRoomEventsJob>(id, "b"_ls, *prevBatch, QString(), limit, filter);
+        connection->callApi<GetRoomEventsJob>(id, "b"_L1, *prevBatch, QString(), limit, filter);
     emit q->eventsHistoryJobChanged();
     connect(eventsHistoryJob, &BaseJob::success, q, [this] {
         if (const auto newPrevBatch = eventsHistoryJob->end();
@@ -2446,7 +2446,7 @@ void Room::downloadFile(const QString& eventId, const QUrl& localFilename)
         filePath = fileInfo->url().path().mid(1) % u'_' % event->fileNameToDownload();
 
         if (filePath.size() > 200) // If too long, elide in the middle
-            filePath.replace(128, filePath.size() - 192, "---"_ls);
+            filePath.replace(128, filePath.size() - 192, "---"_L1);
 
         filePath = QDir::tempPath() % u'/' % filePath;
         qDebug(MAIN) << "File path:" << filePath;
@@ -2561,8 +2561,8 @@ RoomEventPtr makeRedacted(const RoomEvent& target,
     // the preserved keys being only relevant for homeservers. Just in case.
     static const QStringList TopLevelKeysToKeep{
         EventIdKey,  TypeKey,          RoomIdKey,        SenderKey,
-        StateKeyKey, ContentKey,       "hashes"_ls,      "signatures"_ls,
-        "depth"_ls,  "prev_events"_ls, "auth_events"_ls, "origin_server_ts"_ls
+        StateKeyKey, ContentKey,       "hashes"_L1,      "signatures"_L1,
+        "depth"_L1,  "prev_events"_L1, "auth_events"_L1, "origin_server_ts"_L1
     };
 
     auto originalJson = target.fullJson();
@@ -2574,16 +2574,16 @@ RoomEventPtr makeRedacted(const RoomEvent& target,
     }
     if (!target.is<RoomCreateEvent>()) { // See MSC2176 on create events
         static const QHash<QString, QStringList> ContentKeysToKeepPerType{
-            { RedactionEvent::TypeId, { "redacts"_ls } },
+            { RedactionEvent::TypeId, { "redacts"_L1 } },
             { RoomMemberEvent::TypeId,
-              { "membership"_ls, "join_authorised_via_users_server"_ls } },
+              { "membership"_L1, "join_authorised_via_users_server"_L1 } },
             { RoomPowerLevelsEvent::TypeId,
-              { "ban"_ls, "events"_ls, "events_default"_ls, "invite"_ls,
-                "kick"_ls, "redact"_ls, "state_default"_ls, "users"_ls,
-                "users_default"_ls } },
+              { "ban"_L1, "events"_L1, "events_default"_L1, "invite"_L1,
+                "kick"_L1, "redact"_L1, "state_default"_L1, "users"_L1,
+                "users_default"_L1 } },
             // TODO: Replace with RoomJoinRules::TypeId etc. once available
-            { "m.room.join_rules"_ls, { "join_rule"_ls, "allow"_ls } },
-            { "m.room.history_visibility"_ls, { "history_visibility"_ls } }
+            { "m.room.join_rules"_L1, { "join_rule"_L1, "allow"_L1 } },
+            { "m.room.history_visibility"_L1, { "history_visibility"_L1 } }
         };
 
         if (const auto contentKeysToKeep = ContentKeysToKeepPerType.value(target.matrixType());
@@ -2670,12 +2670,12 @@ bool Room::Private::processRedaction(const RedactionEvent& redaction)
 RoomEventPtr makeReplaced(const RoomEvent& target,
                           const RoomMessageEvent& replacement)
 {
-    auto newContent = replacement.contentPart<QJsonObject>("m.new_content"_ls);
+    auto newContent = replacement.contentPart<QJsonObject>("m.new_content"_L1);
     addParam<IfNotEmpty>(newContent, RelatesToKey, target.contentPart<QJsonObject>(RelatesToKey));
     auto originalJson = target.fullJson();
     originalJson[ContentKey] = newContent;
     editSubobject(originalJson, UnsignedKey, [&replacement](QJsonObject& unsignedData) {
-        replaceSubvalue(unsignedData, "m.relations"_ls, "m.replace"_ls, replacement.id());
+        replaceSubvalue(unsignedData, "m.relations"_L1, "m.replace"_L1, replacement.id());
     });
 
     return loadEvent<RoomEvent>(originalJson);
@@ -2875,7 +2875,7 @@ Room::Changes Room::Private::addNewMessageEvents(RoomEvents&& events)
     for (auto it = from; it != syncEdge(); ++it) {
         if (it->event()->senderId() == connection->userId()) {
             if (const auto* evt = it->viewAs<RoomMessageEvent>()) {
-                if (evt->rawMsgtype() == "m.key.verification.request"_ls && pendingKeyVerificationSession && evt->senderId() == q->localMember().id()) {
+                if (evt->rawMsgtype() == "m.key.verification.request"_L1 && pendingKeyVerificationSession && evt->senderId() == q->localMember().id()) {
                     keyVerificationSessions[evt->id()] = pendingKeyVerificationSession;
                     connect(pendingKeyVerificationSession.get(), &QObject::destroyed, q, [this, evt] {
                         keyVerificationSessions.remove(evt->id());
@@ -2887,7 +2887,7 @@ Room::Changes Room::Private::addNewMessageEvents(RoomEvents&& events)
             continue;
         }
         if (const auto* evt = it->viewAs<RoomMessageEvent>()) {
-            if (evt->rawMsgtype() == "m.key.verification.request"_ls) {
+            if (evt->rawMsgtype() == "m.key.verification.request"_L1) {
                 if (evt->originTimestamp() > QDateTime::currentDateTime().addSecs(-60)) {
                     auto session = new KeyVerificationSession(evt, q);
                     emit connection->newKeyVerificationSession(session);
@@ -2899,8 +2899,8 @@ Room::Changes Room::Private::addNewMessageEvents(RoomEvents&& events)
             }
         }
         if (auto event = it->viewAs<KeyVerificationEvent>()) {
-            const auto &baseEvent = event->contentJson()["m.relates_to"_ls]["event_id"_ls].toString();
-            if (event->matrixType() == "m.key.verification.done"_ls) {
+            const auto &baseEvent = event->contentJson()["m.relates_to"_L1]["event_id"_L1].toString();
+            if (event->matrixType() == "m.key.verification.done"_L1) {
                 continue;
             }
             if (keyVerificationSessions.contains(baseEvent)) {
@@ -3206,12 +3206,12 @@ Room::Changes Room::processEphemeralEvent(EventPtr&& event)
                         << "Event" << evtId
                         << "is not found; saving read receipt(s) anyway";
                 const auto reads =
-                    eventIt.value().toObject().value("m.read"_ls).toObject();
+                    eventIt.value().toObject().value("m.read"_L1).toObject();
                 for (auto userIt = reads.begin(); userIt != reads.end();
                      ++userIt) {
                     ReadReceipt rr{ evtId,
                                     fromJson<QDateTime>(
-                                        userIt->toObject().value("ts"_ls)) };
+                                        userIt->toObject().value("ts"_L1)) };
                     const auto userId = userIt.key();
                     if (userId == connection()->userId()) {
                         // Local user is special, and will get a signal about
@@ -3473,7 +3473,7 @@ void Room::addMegolmSessionFromBackup(const QByteArray& sessionId, const QByteAr
     session.setOlmSessionId(d->connection->isVerifiedSession(sessionId)
                                 ? QByteArrayLiteral("BACKUP_VERIFIED")
                                 : QByteArrayLiteral("BACKUP"));
-    session.setSenderId("BACKUP"_ls);
+    session.setSenderId("BACKUP"_L1);
     d->connection->saveMegolmSession(this, session, senderKey, senderEdKey);
 }
 
@@ -3499,13 +3499,13 @@ QJsonArray Room::exportMegolmSessions()
         const auto senderClaimedKey = connection()->database()->edKeyForMegolmSession(QString::fromLatin1(value.sessionId()));
         const auto senderKey = connection()->database()->senderKeyForMegolmSession(QString::fromLatin1(value.sessionId()));
         const auto json = QJsonObject {
-            {"algorithm"_ls, "m.megolm.v1.aes-sha2"_ls},
-            {"forwarding_curve25519_key_chain"_ls, QJsonArray()},
-            {"room_id"_ls, id()},
-            {"sender_claimed_keys"_ls, QJsonObject{ {"ed25519"_ls, senderClaimedKey} }},
-            {"sender_key"_ls, senderKey},
-            {"session_id"_ls, QString::fromLatin1(value.sessionId())},
-            {"session_key"_ls, QString::fromLatin1(session.value())},
+            {"algorithm"_L1, "m.megolm.v1.aes-sha2"_L1},
+            {"forwarding_curve25519_key_chain"_L1, QJsonArray()},
+            {"room_id"_L1, id()},
+            {"sender_claimed_keys"_L1, QJsonObject{ {"ed25519"_L1, senderClaimedKey} }},
+            {"sender_key"_L1, senderKey},
+            {"session_id"_L1, QString::fromLatin1(value.sessionId())},
+            {"session_key"_L1, QString::fromLatin1(session.value())},
         };
         if (senderClaimedKey.isEmpty() || senderKey.isEmpty()) {
             // These are edge-cases for some sessions that were added before libquotient started storing these fields.

--- a/Quotient/roommember.cpp
+++ b/Quotient/roommember.cpp
@@ -105,7 +105,7 @@ QString RoomMember::avatarMediaId() const
     } else if (_member->prevContent() && _member->prevContent()->avatarUrl) {
         baseUrl = *_member->prevContent()->avatarUrl;
     }
-    if (baseUrl.isEmpty() || baseUrl.scheme() != "mxc"_ls) {
+    if (baseUrl.isEmpty() || baseUrl.scheme() != "mxc"_L1) {
         return {};
     }
     return baseUrl.toString();
@@ -122,12 +122,12 @@ QUrl RoomMember::avatarUrl() const {
     } else if (_member->prevContent() && _member->prevContent()->avatarUrl) {
         baseUrl = *_member->prevContent()->avatarUrl;
     }
-    if (baseUrl.isEmpty() || baseUrl.scheme() != "mxc"_ls) {
+    if (baseUrl.isEmpty() || baseUrl.scheme() != "mxc"_L1) {
         return {};
     }
 
     const auto mediaUrl = _room->connection()->makeMediaUrl(baseUrl);
-    if (mediaUrl.isValid() && mediaUrl.scheme() == "mxc"_ls) {
+    if (mediaUrl.isValid() && mediaUrl.scheme() == "mxc"_L1) {
         return mediaUrl;
     }
     return {};

--- a/Quotient/settings.cpp
+++ b/Quotient/settings.cpp
@@ -107,8 +107,8 @@ QUO_DEFINE_SETTING(AccountSettings, bool, keepLoggedIn, "keep_logged_in", false,
                    setKeepLoggedIn)
 
 namespace {
-constexpr auto HomeserverKey = "homeserver"_ls;
-constexpr auto EncryptionAccountPickleKey = "encryption_account_pickle"_ls;
+constexpr auto HomeserverKey = "homeserver"_L1;
+constexpr auto EncryptionAccountPickleKey = "encryption_account_pickle"_L1;
 }
 
 QUrl AccountSettings::homeserver() const
@@ -125,13 +125,13 @@ QString AccountSettings::userId() const { return group().section(u'/', -1); }
 
 QByteArray AccountSettings::encryptionAccountPickle()
 {
-    return value("encryption_account_pickle"_ls, QString()).toByteArray();
+    return value("encryption_account_pickle"_L1, QString()).toByteArray();
 }
 
 void AccountSettings::setEncryptionAccountPickle(
     const QByteArray& encryptionAccountPickle)
 {
-    setValue("encryption_account_pickle"_ls, encryptionAccountPickle);
+    setValue("encryption_account_pickle"_L1, encryptionAccountPickle);
 }
 
 void AccountSettings::clearEncryptionAccountPickle()

--- a/Quotient/settings.cpp
+++ b/Quotient/settings.cpp
@@ -3,9 +3,6 @@
 
 #include "settings.h"
 
-#include "logging_categories_p.h"
-#include "util.h"
-
 #include <QtCore/QUrl>
 
 using namespace Quotient;
@@ -23,21 +20,21 @@ void Settings::setLegacyNames(const QString& organizationName,
 Settings::Settings(QObject* parent) : QSettings(parent)
 {}
 
-void Settings::setValue(const QString& key, const QVariant& value)
+void Settings::setValue(QAnyStringView key, const QVariant& value)
 {
     QSettings::setValue(key, value);
     if (legacySettings.contains(key))
         legacySettings.remove(key);
 }
 
-void Settings::remove(const QString& key)
+void Settings::remove(QAnyStringView key)
 {
     QSettings::remove(key);
     if (legacySettings.contains(key))
         legacySettings.remove(key);
 }
 
-QVariant Settings::value(const QString& key, const QVariant& defaultValue) const
+QVariant Settings::value(QAnyStringView key, const QVariant& defaultValue) const
 {
     auto value = QSettings::value(key, legacySettings.value(key, defaultValue));
     // QML's Qt.labs.Settings stores boolean values as strings, which, if loaded
@@ -45,10 +42,10 @@ QVariant Settings::value(const QString& key, const QVariant& defaultValue) const
     // (QVariant("false") == true in JavaScript). Since we have a mixed
     // environment where both QSettings and Qt.labs.Settings may potentially
     // work with same settings, better ensure compatibility.
-    return value.toString() == QStringLiteral("false") ? QVariant(false) : value;
+    return value.toString() == "false"_L1 ? QVariant(false) : value;
 }
 
-bool Settings::contains(const QString& key) const
+bool Settings::contains(QAnyStringView key) const
 {
     return QSettings::contains(key) || legacySettings.contains(key);
 }
@@ -63,20 +60,16 @@ QStringList Settings::childGroups() const
     return groups;
 }
 
-void SettingsGroup::setValue(const QString& key, const QVariant& value)
+void SettingsGroup::setValue(QAnyStringView key, const QVariant& value)
 {
-    Settings::setValue(groupPath + u'/' + key, value);
+    Settings::setValue(fullPath(key), value);
 }
 
-bool SettingsGroup::contains(const QString& key) const
-{
-    return Settings::contains(groupPath + u'/' + key);
-}
+bool SettingsGroup::contains(QAnyStringView key) const { return Settings::contains(fullPath(key)); }
 
-QVariant SettingsGroup::value(const QString& key,
-                              const QVariant& defaultValue) const
+QVariant SettingsGroup::value(QAnyStringView key, const QVariant& defaultValue) const
 {
-    return Settings::value(groupPath + u'/' + key, defaultValue);
+    return Settings::value(fullPath(key), defaultValue);
 }
 
 QString SettingsGroup::group() const { return groupPath; }

--- a/Quotient/settings.h
+++ b/Quotient/settings.h
@@ -137,7 +137,7 @@ class QUOTIENT_API AccountSettings : public SettingsGroup {
                    WRITE setEncryptionAccountPickle)
 public:
     explicit AccountSettings(const QString& accountId, QObject* parent = nullptr)
-        : SettingsGroup("Accounts/"_ls + accountId, parent)
+        : SettingsGroup("Accounts/"_L1 + accountId, parent)
     {}
 
     QString userId() const;

--- a/Quotient/settings.h
+++ b/Quotient/settings.h
@@ -3,12 +3,11 @@
 
 #pragma once
 
-#include "quotient_export.h"
 #include "util.h"
 
 #include <QtCore/QSettings>
 #include <QtCore/QUrl>
-#include <QtCore/QVector>
+#include <QtCore/QStringBuilder>
 
 class QVariant;
 
@@ -32,10 +31,10 @@ public:
 
     /// Set the value for a given key
     /*! If the key exists in the legacy location, it is removed. */
-    Q_INVOKABLE void setValue(const QString& key, const QVariant& value);
+    Q_INVOKABLE void setValue(QAnyStringView key, const QVariant& value);
 
     /// Remove the value from both the primary and legacy locations
-    Q_INVOKABLE void remove(const QString& key);
+    Q_INVOKABLE void remove(QAnyStringView key);
 
     /// Obtain a value for a given key
     /*!
@@ -48,8 +47,7 @@ public:
      *
      * \sa setLegacyNames, get
      */
-    Q_INVOKABLE QVariant value(const QString& key,
-                               const QVariant& defaultValue = {}) const;
+    Q_INVOKABLE QVariant value(QAnyStringView key, const QVariant& defaultValue = {}) const;
 
     /// Obtain a value for a given key, coerced to the given type
     /*!
@@ -68,7 +66,7 @@ public:
         return qv.isValid() && qv.canConvert<T>() ? qv.value<T>() : defaultValue;
     }
 
-    Q_INVOKABLE bool contains(const QString& key) const;
+    Q_INVOKABLE bool contains(QAnyStringView key) const;
     Q_INVOKABLE QStringList childGroups() const;
 
 private:
@@ -86,24 +84,25 @@ public:
         , groupPath(std::move(path))
     {}
 
-    Q_INVOKABLE bool contains(const QString& key) const;
-    Q_INVOKABLE QVariant value(const QString& key,
-                               const QVariant& defaultValue = {}) const;
+    Q_INVOKABLE bool contains(QAnyStringView key) const;
+    Q_INVOKABLE QVariant value(QAnyStringView key, const QVariant& defaultValue = {}) const;
 
     template <typename T>
-    T get(const QString& key, const T& defaultValue = {}) const
+    T get(auto key, const T& defaultValue = {}) const
     {
         const auto qv = value(key, QVariant());
-        return qv.isValid() && qv.canConvert<T>() ? qv.value<T>() : defaultValue;
+        return qv.isValid() && qv.template canConvert<T>() ? qv.template value<T>() : defaultValue;
     }
 
     Q_INVOKABLE QString group() const;
     Q_INVOKABLE QStringList childGroups() const;
-    Q_INVOKABLE void setValue(const QString& key, const QVariant& value);
+    Q_INVOKABLE void setValue(QAnyStringView key, const QVariant& value);
 
     Q_INVOKABLE void remove(const QString& key);
 
 private:
+    QString fullPath(QAnyStringView key) const { return groupPath % u'/' % key.toString(); }
+
     QString groupPath;
 };
 
@@ -115,17 +114,9 @@ public:                                                  \
                                                          \
 private:
 
-#define QUO_DEFINE_SETTING(classname, type, propname, qsettingname,   \
-                           defaultValue, setter)                      \
-    type classname::propname() const                                  \
-    {                                                                 \
-        return get<type>(QStringLiteral(qsettingname), defaultValue); \
-    }                                                                 \
-                                                                      \
-    void classname::setter(type newValue)                             \
-    {                                                                 \
-        setValue(QStringLiteral(qsettingname), std::move(newValue));  \
-    }
+#define QUO_DEFINE_SETTING(classname, type, propname, qsettingname, defaultValue, setter)   \
+    type classname::propname() const { return get<type>(qsettingname##_L1, defaultValue); } \
+    void classname::setter(type newValue) { setValue(qsettingname##_L1, std::move(newValue)); }
 
 class QUOTIENT_API AccountSettings : public SettingsGroup {
     Q_OBJECT

--- a/Quotient/ssosession.cpp
+++ b/Quotient/ssosession.cpp
@@ -33,7 +33,7 @@ public:
                 << "Could not open the port, SSO callback won't work:" << server->errorString();
         // The "/returnToApplication" part is just a hint for the end-user,
         // the callback will work without it equally well.
-        callbackUrl = "http://localhost:%1/returnToApplication"_L1.arg(server->serverPort());
+        callbackUrl = u"http://localhost:%1/returnToApplication"_s.arg(server->serverPort());
         ssoUrl = connection->getUrlForApi<RedirectToSSOJob>(callbackUrl);
 
         QObject::connect(server, &QTcpServer::newConnection, q, [this, q, server] {

--- a/Quotient/ssosession.cpp
+++ b/Quotient/ssosession.cpp
@@ -33,8 +33,7 @@ public:
                 << "Could not open the port, SSO callback won't work:" << server->errorString();
         // The "/returnToApplication" part is just a hint for the end-user,
         // the callback will work without it equally well.
-        callbackUrl = QStringLiteral("http://localhost:%1/returnToApplication")
-                          .arg(server->serverPort());
+        callbackUrl = "http://localhost:%1/returnToApplication"_L1.arg(server->serverPort());
         ssoUrl = connection->getUrlForApi<RedirectToSSOJob>(callbackUrl);
 
         QObject::connect(server, &QTcpServer::newConnection, q, [this, q, server] {
@@ -92,7 +91,7 @@ void SsoSession::Private::processCallback()
         onError("400 Bad Request", tr("Malformed single sign-on callback"));
         return;
     }
-    const auto& QueryItemName = QStringLiteral("loginToken");
+    const auto QueryItemName = u"loginToken"_s;
     QUrlQuery query { QUrl(QString::fromUtf8(requestParts[1])).query() };
     if (!query.hasQueryItem(QueryItemName)) {
         onError("400 Bad Request", tr("No login token in SSO callback"));

--- a/Quotient/syncdata.cpp
+++ b/Quotient/syncdata.cpp
@@ -44,36 +44,36 @@ void JsonObjectConverter<RoomSummary>::dumpTo(QJsonObject& jo,
 void JsonObjectConverter<RoomSummary>::fillFrom(const QJsonObject& jo,
                                                 RoomSummary& rs)
 {
-    fromJson(jo["m.joined_member_count"_ls], rs.joinedMemberCount);
-    fromJson(jo["m.invited_member_count"_ls], rs.invitedMemberCount);
-    fromJson(jo["m.heroes"_ls], rs.heroes);
+    fromJson(jo["m.joined_member_count"_L1], rs.joinedMemberCount);
+    fromJson(jo["m.invited_member_count"_L1], rs.invitedMemberCount);
+    fromJson(jo["m.heroes"_L1], rs.heroes);
 }
 
 template <typename EventsArrayT, typename StrT>
 inline EventsArrayT load(const QJsonObject& batches, StrT keyName)
 {
-    return fromJson<EventsArrayT>(batches[keyName].toObject().value("events"_ls));
+    return fromJson<EventsArrayT>(batches[keyName].toObject().value("events"_L1));
 }
 
 SyncRoomData::SyncRoomData(QString roomId_, JoinState joinState,
                            const QJsonObject& roomJson)
     : roomId(std::move(roomId_))
     , joinState(joinState)
-    , summary(fromJson<RoomSummary>(roomJson["summary"_ls]))
+    , summary(fromJson<RoomSummary>(roomJson["summary"_L1]))
     , state(load<StateEvents>(roomJson, joinState == JoinState::Invite
-                                         ? "invite_state"_ls
-                                         : "state"_ls))
+                                         ? "invite_state"_L1
+                                         : "state"_L1))
 {
     switch (joinState) {
     case JoinState::Join:
-        ephemeral = load<Events>(roomJson, "ephemeral"_ls);
+        ephemeral = load<Events>(roomJson, "ephemeral"_L1);
         [[fallthrough]];
     case JoinState::Leave: {
-        accountData = load<Events>(roomJson, "account_data"_ls);
-        timeline = load<RoomEvents>(roomJson, "timeline"_ls);
-        const auto timelineJson = roomJson.value("timeline"_ls).toObject();
-        timelineLimited = timelineJson.value("limited"_ls).toBool();
-        timelinePrevBatch = timelineJson.value("prev_batch"_ls).toString();
+        accountData = load<Events>(roomJson, "account_data"_L1);
+        timeline = load<RoomEvents>(roomJson, "timeline"_L1);
+        const auto timelineJson = roomJson.value("timeline"_L1).toObject();
+        timelineLimited = timelineJson.value("limited"_L1).toBool();
+        timelinePrevBatch = timelineJson.value("prev_batch"_L1).toString();
 
         break;
     }
@@ -84,12 +84,12 @@ SyncRoomData::SyncRoomData(QString roomId_, JoinState joinState,
 
     fromJson(unreadJson.value(PartiallyReadCountKey), partiallyReadCount);
     if (!partiallyReadCount.has_value())
-        fromJson(unreadJson.value("x-quotient.unread_count"_ls),
+        fromJson(unreadJson.value("x-quotient.unread_count"_L1),
                  partiallyReadCount);
 
     fromJson(roomJson.value(NewUnreadCountKey), unreadCount);
     if (!unreadCount.has_value())
-        fromJson(unreadJson.value("notification_count"_ls), unreadCount);
+        fromJson(unreadJson.value("notification_count"_L1), unreadCount);
     fromJson(unreadJson.value(HighlightCountKey), highlightCount);
 }
 
@@ -98,9 +98,9 @@ QDebug Quotient::operator<<(QDebug dbg, const DevicesList& devicesList)
     QDebugStateSaver _(dbg);
     QStringList sl;
     if (!devicesList.changed.isEmpty())
-        sl << QStringLiteral("changed: %1").arg(devicesList.changed.join(", "_ls));
+        sl << QStringLiteral("changed: %1").arg(devicesList.changed.join(", "_L1));
     if (!devicesList.left.isEmpty())
-        sl << QStringLiteral("left %1").arg(devicesList.left.join(", "_ls));
+        sl << QStringLiteral("left %1").arg(devicesList.left.join(", "_L1));
     dbg.nospace().noquote() << sl.join(QStringLiteral("; "));
     return dbg;
 }
@@ -117,8 +117,8 @@ void JsonObjectConverter<DevicesList>::dumpTo(QJsonObject& jo,
 void JsonObjectConverter<DevicesList>::fillFrom(const QJsonObject& jo,
                                                 DevicesList& rs)
 {
-    fromJson(jo["changed"_ls], rs.changed);
-    fromJson(jo["left"_ls], rs.left);
+    fromJson(jo["changed"_L1], rs.changed);
+    fromJson(jo["left"_L1], rs.left);
 }
 
 namespace {
@@ -152,7 +152,7 @@ SyncData::SyncData(const QString& cacheFileName)
     auto json = loadJson(cacheFileName);
     auto requiredVersion = MajorCacheVersion;
     auto actualVersion =
-        json.value("cache_version"_ls).toObject().value("major"_ls).toInt();
+        json.value("cache_version"_L1).toObject().value("major"_L1).toInt();
     if (actualVersion == requiredVersion)
         parseJson(json, QFileInfo(cacheFileName).absolutePath() + u'/');
     else
@@ -166,7 +166,7 @@ SyncDataList SyncData::takeRoomData() { return std::move(roomData); }
 QString SyncData::fileNameForRoom(QString roomId)
 {
     roomId.replace(u':', u'_');
-    return roomId + ".json"_ls;
+    return roomId + ".json"_L1;
 }
 
 Events SyncData::takePresenceData() { return std::move(presenceData); }
@@ -188,19 +188,19 @@ void SyncData::parseJson(const QJsonObject& json, const QString& baseDir)
     QElapsedTimer et;
     et.start();
 
-    nextBatch_ = json.value("next_batch"_ls).toString();
-    presenceData = load<Events>(json, "presence"_ls);
-    accountData = load<Events>(json, "account_data"_ls);
-    toDeviceEvents = load<Events>(json, "to_device"_ls);
+    nextBatch_ = json.value("next_batch"_L1).toString();
+    presenceData = load<Events>(json, "presence"_L1);
+    accountData = load<Events>(json, "account_data"_L1);
+    toDeviceEvents = load<Events>(json, "to_device"_L1);
 
-    fromJson(json.value("device_one_time_keys_count"_ls),
+    fromJson(json.value("device_one_time_keys_count"_L1),
              deviceOneTimeKeysCount_);
 
-    if(json.contains("device_lists"_ls)) {
-        fromJson(json.value("device_lists"_ls), devicesList);
+    if(json.contains("device_lists"_L1)) {
+        fromJson(json.value("device_lists"_L1), devicesList);
     }
 
-    auto rooms = json.value("rooms"_ls).toObject();
+    auto rooms = json.value("rooms"_L1).toObject();
     qsizetype totalRooms = 0;
     size_t totalEvents = 0;
     for (size_t i = 0; i < JoinStateStrings.size(); ++i) {
@@ -218,7 +218,7 @@ void SyncData::parseJson(const QJsonObject& json, const QString& baseDir)
                 roomJson = loadJson(
                     baseDir
                     + (roomIt->isObject() // lib 0.8.1.2 onwards = cache 11.3 onwards
-                           ? roomIt->toObject().value("$ref"_ls).toString()
+                           ? roomIt->toObject().value("$ref"_L1).toString()
                            : fileNameForRoom(roomIt.key()))); // lib pre-0.8.1.2 = cache pre-11.3
                 if (roomJson.isEmpty()) {
                     unresolvedRoomIds.push_back(roomIt.key());

--- a/Quotient/syncdata.h
+++ b/Quotient/syncdata.h
@@ -9,10 +9,10 @@
 
 namespace Quotient {
 
-constexpr inline auto UnreadNotificationsKey = "unread_notifications"_ls;
-constexpr inline auto PartiallyReadCountKey = "x-quotient.since_fully_read_count"_ls;
-constexpr inline auto NewUnreadCountKey = "org.matrix.msc2654.unread_count"_ls;
-constexpr inline auto HighlightCountKey = "highlight_count"_ls;
+constexpr inline auto UnreadNotificationsKey = "unread_notifications"_L1;
+constexpr inline auto PartiallyReadCountKey = "x-quotient.since_fully_read_count"_L1;
+constexpr inline auto NewUnreadCountKey = "org.matrix.msc2654.unread_count"_L1;
+constexpr inline auto HighlightCountKey = "highlight_count"_L1;
 
 //! \brief Room summary, as defined in MSC688
 //!

--- a/Quotient/uri.cpp
+++ b/Quotient/uri.cpp
@@ -18,15 +18,15 @@ struct ReplacePair { QLatin1String uriString; char sigil; };
 /// When there are two prefixes for the same sigil, the first matching
 /// entry for a given sigil is used.
 const ReplacePair replacePairs[] = {
-    { "u/"_ls, '@' },
-    { "user/"_ls, '@' },
-    { "roomid/"_ls, '!' },
-    { "r/"_ls, '#' },
-    { "room/"_ls, '#' },
+    { "u/"_L1, '@' },
+    { "user/"_L1, '@' },
+    { "roomid/"_L1, '!' },
+    { "r/"_L1, '#' },
+    { "room/"_L1, '#' },
     // The notation for bare event ids is not proposed in MSC2312 but there's
     // https://github.com/matrix-org/matrix-doc/pull/2644
-    { "e/"_ls, '$' },
-    { "event/"_ls, '$' }
+    { "e/"_L1, '$' },
+    { "event/"_L1, '$' }
 };
 
 }
@@ -36,7 +36,7 @@ Uri::Uri(QByteArray primaryId, QByteArray secondaryId, QString query)
     if (primaryId.isEmpty())
         primaryType_ = Empty;
     else {
-        setScheme("matrix"_ls);
+        setScheme("matrix"_L1);
         QString pathToBe;
         primaryType_ = Invalid;
         if (primaryId.size() < 2) // There should be something after sigil
@@ -56,7 +56,7 @@ Uri::Uri(QByteArray primaryId, QByteArray secondaryId, QString query)
             }
             auto safeSecondaryId = secondaryId.mid(1);
             safeSecondaryId.replace('/', "%2F");
-            pathToBe += "/event/"_ls + QString::fromUtf8(safeSecondaryId);
+            pathToBe += "/event/"_L1 + QString::fromUtf8(safeSecondaryId);
         }
         setPath(pathToBe, QUrl::TolerantMode);
     }
@@ -84,7 +84,7 @@ static inline auto matrixToUrlRegexInit()
 {
     // See https://matrix.org/docs/spec/appendices#matrix-to-navigation
     const QRegularExpression MatrixToUrlRE {
-        "^/(?<main>[^:]+(:|%3A|%3a)[^/?]+)(/(?<sec>(\\$|%24)[^?]+))?(\\?(?<query>.+))?$"_ls
+        "^/(?<main>[^:]+(:|%3A|%3a)[^/?]+)(/(?<sec>(\\$|%24)[^?]+))?(\\?(?<query>.+))?$"_L1
     };
     Q_ASSERT(MatrixToUrlRE.isValid());
     return MatrixToUrlRE;
@@ -100,7 +100,7 @@ Uri::Uri(QUrl url) : QUrl(std::move(url))
     if (!QUrl::isValid()) // MatrixUri::isValid() checks primaryType_
         return;
 
-    if (scheme() == "matrix"_ls) {
+    if (scheme() == "matrix"_L1) {
         // Check sanity as per https://github.com/matrix-org/matrix-doc/pull/2312
         const auto& urlPath = encodedPath(*this);
         const auto& splitPath = urlPath.split(u'/');
@@ -108,7 +108,7 @@ Uri::Uri(QUrl url) : QUrl(std::move(url))
         case 2:
             break;
         case 4:
-            if (splitPath[2] == "event"_ls || splitPath[2] == "e"_ls)
+            if (splitPath[2] == "event"_L1 || splitPath[2] == "e"_L1)
                 break;
             [[fallthrough]];
         default:
@@ -126,7 +126,7 @@ Uri::Uri(QUrl url) : QUrl(std::move(url))
     }
 
     primaryType_ = NonMatrix; // Default, unless overridden by the code below
-    if (scheme() == "https"_ls && authority() == "matrix.to"_ls) {
+    if (scheme() == "https"_L1 && authority() == "matrix.to"_L1) {
         static const auto MatrixToUrlRE = matrixToUrlRegexInit();
         // matrix.to accepts both literal sigils (as well as & and ? used in
         // its "query" substitute) and their %-encoded forms;
@@ -162,7 +162,7 @@ Uri::Type Uri::type() const { return primaryType_; }
 Uri::SecondaryType Uri::secondaryType() const
 {
     const auto& type2 = pathSegment(*this, 2);
-    return type2 == "event"_ls || type2 == "e"_ls ? EventId : NoSecondaryId;
+    return type2 == "event"_L1 || type2 == "e"_L1 ? EventId : NoSecondaryId;
 }
 
 QUrl Uri::toUrl(UriForm form) const
@@ -174,9 +174,9 @@ QUrl Uri::toUrl(UriForm form) const
         return SLICE(*this, QUrl);
 
     QUrl url;
-    url.setScheme("https"_ls);
-    url.setHost("matrix.to"_ls);
-    url.setPath("/"_ls);
+    url.setScheme("https"_L1);
+    url.setHost("matrix.to"_L1);
+    url.setPath("/"_L1);
     auto fragment = u'/' + primaryId();
     if (const auto& secId = secondaryId(); !secId.isEmpty())
         fragment += u'/' + secId;

--- a/Quotient/uri.cpp
+++ b/Quotient/uri.cpp
@@ -151,7 +151,7 @@ Uri Uri::fromUserInput(const QString& uriOrId)
     // spec but there's a movement towards making them navigable (see, e.g.,
     // https://github.com/matrix-org/matrix-doc/pull/2644) - so treat them
     // as valid
-    if (QStringLiteral("!@#+$").contains(uriOrId[0]))
+    if ("!@#+$"_L1.contains(uriOrId[0]))
         return Uri { uriOrId.toUtf8() };
 
     return Uri { QUrl::fromUserInput(uriOrId) };
@@ -205,13 +205,14 @@ QString Uri::secondaryId() const
     return idStem;
 }
 
-static const auto ActionKey = QStringLiteral("action");
+namespace {
+inline constexpr auto ActionKey = "action"_L1;
+}
 
 QString Uri::action() const
 {
-    return type() == NonMatrix || !isValid()
-               ? QString()
-               : QUrlQuery { query() }.queryItemValue(ActionKey);
+    return type() == NonMatrix || !isValid() ? QString()
+                                             : QUrlQuery{ query() }.queryItemValue(ActionKey);
 }
 
 void Uri::setAction(const QString& newAction)
@@ -228,8 +229,7 @@ void Uri::setAction(const QString& newAction)
 
 QStringList Uri::viaServers() const
 {
-    return QUrlQuery { query() }.allQueryItemValues(QStringLiteral("via"),
-                                                    QUrl::EncodeReserved);
+    return QUrlQuery{ query() }.allQueryItemValues(u"via"_s, QUrl::EncodeReserved);
 }
 
 bool Uri::isValid() const

--- a/Quotient/uriresolver.cpp
+++ b/Quotient/uriresolver.cpp
@@ -27,7 +27,7 @@ UriResolveResult UriResolverBase::visitResource(Connection* account,
 
     switch (uri.type()) {
     case Uri::UserId: {
-        if (uri.action() == "join"_ls)
+        if (uri.action() == "join"_L1)
             return IncorrectAction;
         auto* user = account->user(uri.primaryId());
         Q_ASSERT(user != nullptr);
@@ -42,7 +42,7 @@ UriResolveResult UriResolverBase::visitResource(Connection* account,
             visitRoom(room, uri.secondaryId());
             return UriResolved;
         }
-        if (uri.action() == "join"_ls) {
+        if (uri.action() == "join"_L1) {
             joinRoom(account, uri.primaryId(), uri.viaServers());
             return UriResolved;
         }

--- a/Quotient/user.cpp
+++ b/Quotient/user.cpp
@@ -63,7 +63,7 @@ QString User::displayname() const
 
 QString User::fullName() const
 {
-    return displayname().isEmpty() ? id() : (displayname() % " ("_ls % id() % u')');
+    return displayname().isEmpty() ? id() : (displayname() % " ("_L1 % id() % u')');
 }
 
 bool User::isGuest() const

--- a/Quotient/util.cpp
+++ b/Quotient/util.cpp
@@ -47,10 +47,10 @@ void Quotient::linkifyUrls(QString& htmlEscapedText)
     // NOTE: htmlEscapedText is already HTML-escaped! No literal <,>,&,"
 
     htmlEscapedText.replace(EmailAddressRegExp,
-                            R"(\1<a href='mailto:\3'>\2\3</a>)"_ls);
-    htmlEscapedText.replace(FullUrlRegExp, R"(<a href='\1'>\1</a>)"_ls);
+                            R"(\1<a href='mailto:\3'>\2\3</a>)"_L1);
+    htmlEscapedText.replace(FullUrlRegExp, R"(<a href='\1'>\1</a>)"_L1);
     htmlEscapedText.replace(MxIdRegExp,
-                            R"(\1<a href='https://matrix.to/#/\2'>\2</a>)"_ls);
+                            R"(\1<a href='https://matrix.to/#/\2'>\2</a>)"_L1);
 }
 
 QString Quotient::sanitized(const QString& plainText)
@@ -77,7 +77,7 @@ QString Quotient::cacheLocation(const QString& dirName)
         QStandardPaths::writableLocation(QStandardPaths::CacheLocation) % u'/'
         % dirName % u'/';
     if (const QDir dir(cachePath); !dir.exists())
-        dir.mkpath("."_ls);
+        dir.mkpath("."_L1);
     return cachePath;
 }
 
@@ -102,8 +102,8 @@ static const auto ServerPartRegEx = QStringLiteral(
 
 QString Quotient::serverPart(const QString& mxId)
 {
-    static const QString re("^[@!#$+].*?:("_ls // Localpart and colon
-                            % ServerPartRegEx % ")$"_ls);
+    static const QString re("^[@!#$+].*?:("_L1 // Localpart and colon
+                            % ServerPartRegEx % ")$"_L1);
     static const QRegularExpression parser(
         re,
         QRegularExpression::UseUnicodePropertiesOption); // Because Asian digits

--- a/Quotient/util.cpp
+++ b/Quotient/util.cpp
@@ -29,28 +29,23 @@ void Quotient::linkifyUrls(QString& htmlEscapedText)
     // <, >, ' or ", and ends before whitespaces, <, >, ', ", ], !, ), :,
     // comma or dot
     static const QRegularExpression FullUrlRegExp(
-        QStringLiteral(
-            R"(\b((www\.(?!\.)(?!(\w|\.|-)+@)|(https?|ftp):(//)?\w|(magnet|matrix):)(&(?![lg]t;)|[^&\s<>'"])+(&(?![lg]t;)|[^&!,.\s<>'"\]):])))"),
+        uR"(\b((www\.(?!\.)(?!(\w|\.|-)+@)|(https?|ftp):(//)?\w|(magnet|matrix):)(&(?![lg]t;)|[^&\s<>'"])+(&(?![lg]t;)|[^&!,.\s<>'"\]):])))"_s,
         RegExpOptions);
     static const QRegularExpression EmailAddressRegExp(
-        QStringLiteral(R"((^|[][[:space:](){}`'";<>])(mailto:)?((\w|[!#$%&'*+=^_‘{|}~.-])+@(\w|\.|-)+\.\w+\b))"),
+        uR"((^|[][[:space:](){}`'";<>])(mailto:)?((\w|[!#$%&'*+=^_‘{|}~.-])+@(\w|\.|-)+\.\w+\b))"_s,
         RegExpOptions);
     // An interim liberal implementation of
     // https://matrix.org/docs/spec/appendices.html#identifier-grammar
     static const QRegularExpression MxIdRegExp(
-        QStringLiteral(
-            R"((^|[][[:space:](){}`'";])([!#@][-a-z0-9_=#/.]{1,252}:\w(?:\w|\.|-)*\.\w+(?::\d{1,5})?))"),
+        uR"((^|[][[:space:](){}`'";])([!#@][-a-z0-9_=#/.]{1,252}:\w(?:\w|\.|-)*\.\w+(?::\d{1,5})?))"_s,
         RegExpOptions);
-    Q_ASSERT(FullUrlRegExp.isValid() && EmailAddressRegExp.isValid()
-             && MxIdRegExp.isValid());
+    Q_ASSERT(FullUrlRegExp.isValid() && EmailAddressRegExp.isValid() && MxIdRegExp.isValid());
 
     // NOTE: htmlEscapedText is already HTML-escaped! No literal <,>,&,"
 
-    htmlEscapedText.replace(EmailAddressRegExp,
-                            R"(\1<a href='mailto:\3'>\2\3</a>)"_L1);
-    htmlEscapedText.replace(FullUrlRegExp, R"(<a href='\1'>\1</a>)"_L1);
-    htmlEscapedText.replace(MxIdRegExp,
-                            R"(\1<a href='https://matrix.to/#/\2'>\2</a>)"_L1);
+    htmlEscapedText.replace(EmailAddressRegExp, uR"(\1<a href='mailto:\3'>\2\3</a>)"_s);
+    htmlEscapedText.replace(FullUrlRegExp, uR"(<a href='\1'>\1</a>)"_s);
+    htmlEscapedText.replace(MxIdRegExp, uR"(\1<a href='https://matrix.to/#/\2'>\2</a>)"_s);
 }
 
 QString Quotient::sanitized(const QString& plainText)
@@ -66,12 +61,11 @@ QString Quotient::prettyPrint(const QString& plainText)
 {
     auto pt = plainText.toHtmlEscaped();
     linkifyUrls(pt);
-    pt.replace(u'\n', QStringLiteral("<br/>"));
-    return QStringLiteral("<span style='white-space:pre-wrap'>") + pt
-           + QStringLiteral("</span>");
+    pt.replace(u'\n', "<br/>"_L1);
+    return "<span style='white-space:pre-wrap'>"_L1 % pt % "</span>"_L1;
 }
 
-QString Quotient::cacheLocation(const QString& dirName)
+QString Quotient::cacheLocation(QStringView dirName)
 {
     const QString cachePath =
         QStandardPaths::writableLocation(QStandardPaths::CacheLocation) % u'/'
@@ -95,10 +89,11 @@ qreal Quotient::stringToHueF(const QString& s)
     return hueF;
 }
 
-static const auto ServerPartRegEx = QStringLiteral(
-    "(\\[[^][:space:]]+]|[-[:alnum:].]+)" // IPv6 address or hostname/IPv4 address
-    "(?::(\\d{1,5}))?" // Optional port
-);
+namespace {
+inline constexpr auto ServerPartRegEx =
+    QLatin1StringView("(\\[[^][:space:]]+]|[-[:alnum:].]+)" // IPv6 address or hostname/IPv4 address
+                      "(?::(\\d{1,5}))?"); // Optional port
+}
 
 QString Quotient::serverPart(const QString& mxId)
 {
@@ -130,7 +125,7 @@ int Quotient::patchVersion() { return Quotient_VERSION_PATCH; }
 
 bool Quotient::isGuestUserId(const UserId& uId)
 {
-    static const QRegularExpression guestMxIdRe{ QStringLiteral("^@\\d+:") };
+    static const QRegularExpression guestMxIdRe{ u"^@\\d+:"_s };
     return guestMxIdRe.match(uId).hasMatch();
 }
 

--- a/Quotient/util.h
+++ b/Quotient/util.h
@@ -103,7 +103,9 @@ using UnorderedMap
 
 inline namespace Literals { using namespace Qt::Literals; }
 
-// [[deprecated("Use operators from Qt::Literals (aka Quotient::Literals) instead")]]
+#if Quotient_VERSION_MAJOR == 0 && Quotient_VERSION_MINOR > 9
+[[deprecated("Use operators from Qt::Literals (aka Quotient::Literals) instead")]]
+#endif
 constexpr auto operator""_ls(const char* s, std::size_t size)
 {
     return operator""_L1(s, size);

--- a/Quotient/util.h
+++ b/Quotient/util.h
@@ -101,9 +101,12 @@ template <typename KeyT, typename ValT>
 using UnorderedMap
     [[deprecated("Use std::unordered_map directly")]] = std::unordered_map<KeyT, ValT, HashQ<KeyT>>;
 
-constexpr auto operator"" _ls(const char* s, std::size_t size)
+inline namespace Literals { using namespace Qt::Literals; }
+
+// [[deprecated("Use operators from Qt::Literals (aka Quotient::Literals) instead")]]
+constexpr auto operator""_ls(const char* s, std::size_t size)
 {
-    return QLatin1String(s, int(size));
+    return operator""_L1(s, size);
 }
 
 template <typename ArrayT>

--- a/Quotient/util.h
+++ b/Quotient/util.h
@@ -325,7 +325,7 @@ QUOTIENT_API QString prettyPrint(const QString& plainText);
  * The returned path has a trailing slash, clients don't need to append it.
  * \param dirName path to cache directory relative to the standard cache path
  */
-QUOTIENT_API QString cacheLocation(const QString& dirName);
+QUOTIENT_API QString cacheLocation(QStringView dirName);
 
 /** Hue color component of based of the hash of the string.
  *

--- a/autotests/callcandidateseventtest.cpp
+++ b/autotests/callcandidateseventtest.cpp
@@ -50,9 +50,9 @@ void TestCallCandidatesEvent::fromJson()
     QCOMPARE(callCandidatesEvent->candidates().size(), 1);
 
     const auto& candidate = callCandidatesEvent->candidates().at(0).toObject();
-    QCOMPARE(candidate.value("sdpMid"_ls).toString(), QStringLiteral("audio"));
-    QCOMPARE(candidate.value("sdpMLineIndex"_ls).toInt(), 0);
-    QCOMPARE(candidate.value("candidate"_ls).toString(),
+    QCOMPARE(candidate.value("sdpMid"_L1).toString(), QStringLiteral("audio"));
+    QCOMPARE(candidate.value("sdpMLineIndex"_L1).toInt(), 0);
+    QCOMPARE(candidate.value("candidate"_L1).toString(),
              QStringLiteral("candidate:863018703 1 udp 2122260223 10.9.64.156 43670 typ host generation 0"));
 }
 

--- a/autotests/callcandidateseventtest.cpp
+++ b/autotests/callcandidateseventtest.cpp
@@ -16,7 +16,7 @@ private Q_SLOTS:
 
 void TestCallCandidatesEvent::fromJson()
 {
-    auto document = QJsonDocument::fromJson(R"({
+    auto document = QJsonDocument::fromJson(QByteArrayLiteral(R"({
         "age": 242352,
         "content": {
             "call_id": "12345",
@@ -34,7 +34,7 @@ void TestCallCandidatesEvent::fromJson()
         "room_id": "!Cuyf34gef24t:localhost",
         "sender": "@example:localhost",
         "type": "m.call.candidates"
-    })");
+    })"));
 
     QVERIFY(document.isObject());
 
@@ -46,14 +46,14 @@ void TestCallCandidatesEvent::fromJson()
     QVERIFY(callCandidatesEvent->is<CallCandidatesEvent>());
 
     QCOMPARE(callCandidatesEvent->version(), 0);
-    QCOMPARE(callCandidatesEvent->callId(), QStringLiteral("12345"));
+    QCOMPARE(callCandidatesEvent->callId(), u"12345");
     QCOMPARE(callCandidatesEvent->candidates().size(), 1);
 
     const auto& candidate = callCandidatesEvent->candidates().at(0).toObject();
-    QCOMPARE(candidate.value("sdpMid"_L1).toString(), QStringLiteral("audio"));
+    QCOMPARE(candidate.value("sdpMid"_L1).toString(), u"audio");
     QCOMPARE(candidate.value("sdpMLineIndex"_L1).toInt(), 0);
     QCOMPARE(candidate.value("candidate"_L1).toString(),
-             QStringLiteral("candidate:863018703 1 udp 2122260223 10.9.64.156 43670 typ host generation 0"));
+             u"candidate:863018703 1 udp 2122260223 10.9.64.156 43670 typ host generation 0");
 }
 
 QTEST_APPLESS_MAIN(TestCallCandidatesEvent)

--- a/autotests/testcrosssigning.cpp
+++ b/autotests/testcrosssigning.cpp
@@ -27,25 +27,25 @@ private Q_SLOTS:
         jobMock.setResult(QJsonDocument::fromJson(data));
         auto mockKeys = collectResponse(&jobMock);
 
-        auto connection = Connection::makeMockConnection("@tobiasfella:kde.org"_ls, true);
+        auto connection = Connection::makeMockConnection("@tobiasfella:kde.org"_L1, true);
         connection->d->encryptionData->handleQueryKeys(mockKeys);
 
-        QVERIFY(!connection->isUserVerified("@tobiasfella:kde.org"_ls));
-        QVERIFY(!connection->isUserVerified("@carl:kde.org"_ls));
-        QVERIFY(!connection->isUserVerified("@eve:foo.bar"_ls));
-        QVERIFY(!connection->isUserVerified("@aloy:kde.org"_ls));
-        QVERIFY(!connection->isVerifiedDevice("@tobiasfella:kde.org"_ls, "LTLVYDIVMO"_ls));
-        connection->database()->setMasterKeyVerified("iiNvK2+mJtBXj6t+FVnaPBZ4e/M/n84wPJBfUVN38OE"_ls);
-        QVERIFY(connection->isUserVerified("@tobiasfella:kde.org"_ls));
+        QVERIFY(!connection->isUserVerified("@tobiasfella:kde.org"_L1));
+        QVERIFY(!connection->isUserVerified("@carl:kde.org"_L1));
+        QVERIFY(!connection->isUserVerified("@eve:foo.bar"_L1));
+        QVERIFY(!connection->isUserVerified("@aloy:kde.org"_L1));
+        QVERIFY(!connection->isVerifiedDevice("@tobiasfella:kde.org"_L1, "LTLVYDIVMO"_L1));
+        connection->database()->setMasterKeyVerified("iiNvK2+mJtBXj6t+FVnaPBZ4e/M/n84wPJBfUVN38OE"_L1);
+        QVERIFY(connection->isUserVerified("@tobiasfella:kde.org"_L1));
         connection->d->encryptionData->handleQueryKeys(mockKeys);
 
-        QVERIFY(connection->isUserVerified("@tobiasfella:kde.org"_ls));
-        QVERIFY(connection->isUserVerified("@aloy:kde.org"_ls));
-        QVERIFY(!connection->isVerifiedDevice("@tobiasfella:kde.org"_ls, "IDEJTUJQAF"_ls));
-        QVERIFY(!connection->isVerifiedDevice("@tobiasfella:kde.org"_ls, "DEADBEEF"_ls));
-        QVERIFY(connection->isVerifiedDevice("@tobiasfella:kde.org"_ls, "LTLVYDIVMO"_ls));
-        QVERIFY(connection->isVerifiedDevice("@aloy:kde.org"_ls, "BUJGIJTVJB"_ls));
-        QVERIFY(!connection->isVerifiedDevice("@aloy:kde.org"_ls, "VJIBVDKIST"_ls));
+        QVERIFY(connection->isUserVerified("@tobiasfella:kde.org"_L1));
+        QVERIFY(connection->isUserVerified("@aloy:kde.org"_L1));
+        QVERIFY(!connection->isVerifiedDevice("@tobiasfella:kde.org"_L1, "IDEJTUJQAF"_L1));
+        QVERIFY(!connection->isVerifiedDevice("@tobiasfella:kde.org"_L1, "DEADBEEF"_L1));
+        QVERIFY(connection->isVerifiedDevice("@tobiasfella:kde.org"_L1, "LTLVYDIVMO"_L1));
+        QVERIFY(connection->isVerifiedDevice("@aloy:kde.org"_L1, "BUJGIJTVJB"_L1));
+        QVERIFY(!connection->isVerifiedDevice("@aloy:kde.org"_L1, "VJIBVDKIST"_L1));
     }
 };
 QTEST_GUILESS_MAIN(TestCrossSigning)

--- a/autotests/testcrosssigning.cpp
+++ b/autotests/testcrosssigning.cpp
@@ -18,7 +18,7 @@ private Q_SLOTS:
     {
         auto path = QString::fromUtf8(__FILE__);
         path = path.left(path.lastIndexOf(QDir::separator()));
-        path += QStringLiteral("/cross_signing_data.json");
+        path += "/cross_signing_data.json"_L1;
         QFile file(path);
         file.open(QIODevice::ReadOnly);
         auto data = file.readAll();

--- a/autotests/testcryptoutils.cpp
+++ b/autotests/testcryptoutils.cpp
@@ -102,9 +102,9 @@ void TestCryptoUtils::testEncrypted()
 {
     QByteArray key(32, '\0');
     auto text = QByteArrayLiteral("This is a message");
-    auto connection = Connection::makeMockConnection("@foo:bar.com"_ls, true);
-    connection->database()->storeEncrypted("testKey"_ls, text);
-    auto decrypted = connection->database()->loadEncrypted("testKey"_ls);
+    auto connection = Connection::makeMockConnection("@foo:bar.com"_L1, true);
+    connection->database()->storeEncrypted("testKey"_L1, text);
+    auto decrypted = connection->database()->loadEncrypted("testKey"_L1);
     QCOMPARE(text, decrypted);
 }
 

--- a/autotests/testkeyimport.cpp
+++ b/autotests/testkeyimport.cpp
@@ -40,26 +40,26 @@ void TestKeyImport::testExport()
 
     QJsonArray sessions;
     sessions += QJsonObject {
-        {"algorithm"_ls, "m.megolm.v1.aes-sha2"_ls},
-        {"forwarding_curve25519_key_chain"_ls, QJsonArray()},
-        {"room_id"_ls, "!asdf:foo.bar"_ls},
-        {"sender_claimed_keys"_ls, QJsonObject {
-            {"ed25519"_ls, "asdfkey"_ls}
+        {"algorithm"_L1, "m.megolm.v1.aes-sha2"_L1},
+        {"forwarding_curve25519_key_chain"_L1, QJsonArray()},
+        {"room_id"_L1, "!asdf:foo.bar"_L1},
+        {"sender_claimed_keys"_L1, QJsonObject {
+            {"ed25519"_L1, "asdfkey"_L1}
         }},
-        {"sender_key"_ls, "senderkey"_ls},
-        {"session_id"_ls, "sessionidasdf"_ls},
-        {"session_key"_ls, "sessionkeyfoo"_ls},
+        {"sender_key"_L1, "senderkey"_L1},
+        {"session_id"_L1, "sessionidasdf"_L1},
+        {"session_key"_L1, "sessionkeyfoo"_L1},
 
     };
     auto result = keyImport.encrypt(sessions, QStringLiteral("a passphrase"));
     QVERIFY(result.has_value());
     QVERIFY(result.value().size() > 0);
 
-    auto plain = keyImport.decrypt(QString::fromLatin1(result.value()), "a passphrase"_ls);
+    auto plain = keyImport.decrypt(QString::fromLatin1(result.value()), "a passphrase"_L1);
     QVERIFY(plain.has_value());
     auto value = plain.value();
     QCOMPARE(value.size(), 1);
-    QCOMPARE(value[0]["algorithm"_ls].toString(), "m.megolm.v1.aes-sha2"_ls);
+    QCOMPARE(value[0]["algorithm"_L1].toString(), "m.megolm.v1.aes-sha2"_L1);
 }
 
 QTEST_GUILESS_MAIN(TestKeyImport)

--- a/autotests/testkeyimport.cpp
+++ b/autotests/testkeyimport.cpp
@@ -23,12 +23,12 @@ void TestKeyImport::testImport()
 
     auto path = QString::fromUtf8(__FILE__);
     path = path.left(path.lastIndexOf(QDir::separator()));
-    path += QStringLiteral("/key-export.data");
+    path += "/key-export.data"_L1;
     QFile file(path);
     file.open(QIODevice::ReadOnly);
     auto data = file.readAll();
     QVERIFY(!data.isEmpty());
-    const auto result = keyImport.decrypt(QString::fromUtf8(data), QStringLiteral("123passphrase"));
+    const auto result = keyImport.decrypt(QString::fromUtf8(data), u"123passphrase"_s);
     QVERIFY(result.has_value());
     const auto &json = result.value();
     QCOMPARE(json.size(), 2);
@@ -39,23 +39,21 @@ void TestKeyImport::testExport()
     KeyImport keyImport;
 
     QJsonArray sessions;
-    sessions += QJsonObject {
-        {"algorithm"_L1, "m.megolm.v1.aes-sha2"_L1},
-        {"forwarding_curve25519_key_chain"_L1, QJsonArray()},
-        {"room_id"_L1, "!asdf:foo.bar"_L1},
-        {"sender_claimed_keys"_L1, QJsonObject {
-            {"ed25519"_L1, "asdfkey"_L1}
-        }},
-        {"sender_key"_L1, "senderkey"_L1},
-        {"session_id"_L1, "sessionidasdf"_L1},
-        {"session_key"_L1, "sessionkeyfoo"_L1},
+    sessions += QJsonObject{
+        { "algorithm"_L1, "m.megolm.v1.aes-sha2"_L1 },
+        { "forwarding_curve25519_key_chain"_L1, QJsonArray() },
+        { "room_id"_L1, "!asdf:foo.bar"_L1 },
+        { "sender_claimed_keys"_L1, QJsonObject{ { "ed25519"_L1, "asdfkey"_L1 } } },
+        { "sender_key"_L1, "senderkey"_L1 },
+        { "session_id"_L1, "sessionidasdf"_L1 },
+        { "session_key"_L1, "sessionkeyfoo"_L1 },
 
     };
-    auto result = keyImport.encrypt(sessions, QStringLiteral("a passphrase"));
+    auto result = keyImport.encrypt(sessions, u"a passphrase"_s);
     QVERIFY(result.has_value());
     QVERIFY(result.value().size() > 0);
 
-    auto plain = keyImport.decrypt(QString::fromLatin1(result.value()), "a passphrase"_L1);
+    auto plain = keyImport.decrypt(QString::fromLatin1(result.value()), u"a passphrase"_s);
     QVERIFY(plain.has_value());
     auto value = plain.value();
     QCOMPARE(value.size(), 1);

--- a/autotests/testkeyverification.cpp
+++ b/autotests/testkeyverification.cpp
@@ -21,14 +21,14 @@ private Q_SLOTS:
     {
         auto userId = QStringLiteral("@bob:localhost");
         auto deviceId = QStringLiteral("DEFABC");
-        auto connection = Connection::makeMockConnection("@carl:localhost"_ls);
-        const auto transactionId = "other_transaction_id"_ls;
-        auto session = connection->startKeyVerificationSession("@alice:localhost"_ls, "ABCDEF"_ls);
+        auto connection = Connection::makeMockConnection("@carl:localhost"_L1);
+        const auto transactionId = "other_transaction_id"_L1;
+        auto session = connection->startKeyVerificationSession("@alice:localhost"_L1, "ABCDEF"_L1);
         session->sendRequest();
         QVERIFY(session->state() == KeyVerificationSession::WAITINGFORREADY);
-        session->handleEvent(KeyVerificationReadyEvent(transactionId, "ABCDEF"_ls, {SasV1Method}));
+        session->handleEvent(KeyVerificationReadyEvent(transactionId, "ABCDEF"_L1, {SasV1Method}));
         QVERIFY(session->state() == KeyVerificationSession::WAITINGFORACCEPT);
-        session->handleEvent(KeyVerificationAcceptEvent(transactionId, "commitment_TODO"_ls));
+        session->handleEvent(KeyVerificationAcceptEvent(transactionId, "commitment_TODO"_L1));
         QVERIFY(session->state() == KeyVerificationSession::WAITINGFORKEY);
         // Since we can't get the events sent by the session, we're limited by what we can test. This means that continuing here would force us to test
         // the exact same path as the other test, which is useless.
@@ -39,8 +39,8 @@ private Q_SLOTS:
     {
         auto userId = QStringLiteral("@bob:localhost");
         auto deviceId = QStringLiteral("DEFABC");
-        const auto transactionId = "trans123action123id"_ls;
-        auto connection = Connection::makeMockConnection("@carl:localhost"_ls);
+        const auto transactionId = "trans123action123id"_L1;
+        auto connection = Connection::makeMockConnection("@carl:localhost"_L1);
         auto session = new KeyVerificationSession(userId, KeyVerificationRequestEvent(transactionId, deviceId, {SasV1Method}, QDateTime::currentDateTime()), connection, false);
         QVERIFY(session->state() == KeyVerificationSession::INCOMING);
         session->sendReady();

--- a/autotests/testkeyverification.cpp
+++ b/autotests/testkeyverification.cpp
@@ -19,8 +19,6 @@ class TestKeyVerificationSession : public QObject
 private Q_SLOTS:
     void testOutgoing1()
     {
-        auto userId = QStringLiteral("@bob:localhost");
-        auto deviceId = QStringLiteral("DEFABC");
         auto connection = Connection::makeMockConnection("@carl:localhost"_L1);
         const auto transactionId = "other_transaction_id"_L1;
         auto session = connection->startKeyVerificationSession("@alice:localhost"_L1, "ABCDEF"_L1);
@@ -37,8 +35,8 @@ private Q_SLOTS:
 
     void testIncoming1()
     {
-        auto userId = QStringLiteral("@bob:localhost");
-        auto deviceId = QStringLiteral("DEFABC");
+        auto userId = u"@bob:localhost"_s;
+        auto deviceId = u"DEFABC"_s;
         const auto transactionId = "trans123action123id"_L1;
         auto connection = Connection::makeMockConnection("@carl:localhost"_L1);
         auto session = new KeyVerificationSession(userId, KeyVerificationRequestEvent(transactionId, deviceId, {SasV1Method}, QDateTime::currentDateTime()), connection, false);

--- a/autotests/testolmaccount.cpp
+++ b/autotests/testolmaccount.cpp
@@ -358,8 +358,8 @@ void TestOlmAccount::claimKeys()
                                     bob->deviceId(), bob->userId()));
 
     // Retrieve the identity key for the current device to check after claiming
-    const auto& bobEd25519 = bobDevices.value(bob->deviceId())
-                                 .keys.value("ed25519:%1"_L1.arg(bob->deviceId()));
+    const auto& bobEd25519 =
+        bobDevices.value(bob->deviceId()).keys.value("ed25519:"_L1 + bob->deviceId());
 
     const QHash<QString, QHash<QString, QString>> oneTimeKeys{
         { bob->userId(), { { bob->deviceId(), SignedCurve25519Key } } }

--- a/autotests/testolmaccount.cpp
+++ b/autotests/testolmaccount.cpp
@@ -82,20 +82,20 @@ void TestOlmAccount::deviceKeys()
 {
     // copied from mtxclient
     DeviceKeys device1;
-    device1.userId = "@alice:example.com"_ls;
-    device1.deviceId = "JLAFKJWSCS"_ls;
-    device1.keys = {{"curve25519:JLAFKJWSCS"_ls, "3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIArzgyI"_ls},
-                    {"ed25519:JLAFKJWSCS"_ls, "lEuiRJBit0IG6nUf5pUzWTUEsRVVe/HJkoKuEww9ULI"_ls}};
+    device1.userId = "@alice:example.com"_L1;
+    device1.deviceId = "JLAFKJWSCS"_L1;
+    device1.keys = {{"curve25519:JLAFKJWSCS"_L1, "3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIArzgyI"_L1},
+                    {"ed25519:JLAFKJWSCS"_L1, "lEuiRJBit0IG6nUf5pUzWTUEsRVVe/HJkoKuEww9ULI"_L1}};
 
     // TODO that should be the default value
     device1.algorithms =
         QStringList { OlmV1Curve25519AesSha2AlgoKey, MegolmV1AesSha2AlgoKey };
 
     device1.signatures = {
-      {"@alice:example.com"_ls,
-       {{"ed25519:JLAFKJWSCS"_ls,
+      {"@alice:example.com"_L1,
+       {{"ed25519:JLAFKJWSCS"_L1,
          "dSO80A01XiigH3uBiDVx/EjzaoycHcjq9lfQX0uWsqxl2giMIiSPR8a4d291W1ihKJL/"
-         "a+myXS367WT6NAIcBA"_ls}}}};
+         "a+myXS367WT6NAIcBA"_L1}}}};
 
     QJsonObject j;
     JsonObjectConverter<DeviceKeys>::dumpTo(j, device1);
@@ -161,19 +161,19 @@ void TestOlmAccount::encryptedFile()
 
     const auto file = fromJson<EncryptedFileMetadata>(doc);
 
-    QCOMPARE(file.v, "v2"_ls);
-    QCOMPARE(file.iv, "w+sE15fzSc0AAAAAAAAAAA"_ls);
-    QCOMPARE(file.hashes["sha256"_ls], "fdSLu/YkRx3Wyh3KQabP3rd6+SFiKg5lsJZQHtkSAYA"_ls);
-    QCOMPARE(file.key.alg, "A256CTR"_ls);
+    QCOMPARE(file.v, "v2"_L1);
+    QCOMPARE(file.iv, "w+sE15fzSc0AAAAAAAAAAA"_L1);
+    QCOMPARE(file.hashes["sha256"_L1], "fdSLu/YkRx3Wyh3KQabP3rd6+SFiKg5lsJZQHtkSAYA"_L1);
+    QCOMPARE(file.key.alg, "A256CTR"_L1);
     QCOMPARE(file.key.ext, true);
-    QCOMPARE(file.key.k, "aWF6-32KGYaC3A_FEUCk1Bt0JA37zP0wrStgmdCaW-0"_ls);
+    QCOMPARE(file.key.k, "aWF6-32KGYaC3A_FEUCk1Bt0JA37zP0wrStgmdCaW-0"_L1);
     QCOMPARE(file.key.keyOps.size(), 2);
-    QCOMPARE(file.key.kty, "oct"_ls);
+    QCOMPARE(file.key.kty, "oct"_L1);
 }
 
 void TestOlmAccount::uploadIdentityKey()
 {
-    CREATE_CONNECTION(conn, "alice1"_ls, "secret"_ls, "AlicePhone"_ls)
+    CREATE_CONNECTION(conn, "alice1"_L1, "secret"_L1, "AlicePhone"_L1)
 
     auto olmAccount = conn->olmAccount();
     auto idKeys = olmAccount->identityKeys();
@@ -198,7 +198,7 @@ void TestOlmAccount::uploadIdentityKey()
 
 void TestOlmAccount::uploadOneTimeKeys()
 {
-    CREATE_CONNECTION(conn, "alice2"_ls, "secret"_ls, "AlicePhone"_ls)
+    CREATE_CONNECTION(conn, "alice2"_L1, "secret"_L1, "AlicePhone"_L1)
     auto olmAccount = conn->olmAccount();
 
     auto nKeys = olmAccount->generateOneTimeKeys(5);
@@ -208,7 +208,7 @@ void TestOlmAccount::uploadOneTimeKeys()
 
     OneTimeKeys oneTimeKeysHash;
     for (const auto& [keyId, key] : oneTimeKeys.curve25519().asKeyValueRange())
-        oneTimeKeysHash["curve25519:"_ls + keyId] = key;
+        oneTimeKeysHash["curve25519:"_L1 + keyId] = key;
 
     auto request = new UploadKeysJob({}, oneTimeKeysHash);
     connect(request, &BaseJob::result, this, [request] {
@@ -223,7 +223,7 @@ void TestOlmAccount::uploadOneTimeKeys()
 
 void TestOlmAccount::uploadSignedOneTimeKeys()
 {
-    CREATE_CONNECTION(conn, "alice3"_ls, "secret"_ls, "AlicePhone"_ls)
+    CREATE_CONNECTION(conn, "alice3"_L1, "secret"_L1, "AlicePhone"_L1)
     auto olmAccount = conn->olmAccount();
     auto nKeys = olmAccount->generateOneTimeKeys(5);
     QCOMPARE(nKeys, 5);
@@ -243,7 +243,7 @@ void TestOlmAccount::uploadSignedOneTimeKeys()
 
 void TestOlmAccount::uploadKeys()
 {
-    CREATE_CONNECTION(conn, "alice4"_ls, "secret"_ls, "AlicePhone"_ls)
+    CREATE_CONNECTION(conn, "alice4"_L1, "secret"_L1, "AlicePhone"_L1)
     auto olmAccount = conn->olmAccount();
     auto idks = olmAccount->identityKeys();
     olmAccount->generateOneTimeKeys(1);
@@ -261,8 +261,8 @@ void TestOlmAccount::uploadKeys()
 
 void TestOlmAccount::queryTest()
 {
-    CREATE_CONNECTION(alice, "alice5"_ls, "secret"_ls, "AlicePhone"_ls)
-    CREATE_CONNECTION(bob, "bob1"_ls, "secret"_ls, "BobPhone"_ls)
+    CREATE_CONNECTION(alice, "alice5"_L1, "secret"_L1, "AlicePhone"_L1)
+    CREATE_CONNECTION(bob, "bob1"_L1, "secret"_L1, "BobPhone"_L1)
 
     // Create and upload keys for both users.
     auto aliceOlm = alice->olmAccount();
@@ -329,8 +329,8 @@ void TestOlmAccount::queryTest()
 
 void TestOlmAccount::claimKeys()
 {
-    CREATE_CONNECTION(alice, "alice6"_ls, "secret"_ls, "AlicePhone"_ls)
-    CREATE_CONNECTION(bob, "bob2"_ls, "secret"_ls, "BobPhone"_ls)
+    CREATE_CONNECTION(alice, "alice6"_L1, "secret"_L1, "AlicePhone"_L1)
+    CREATE_CONNECTION(bob, "bob2"_L1, "secret"_L1, "BobPhone"_L1)
 
     // Bob uploads his keys.
     auto *bobOlm = bob->olmAccount();
@@ -359,7 +359,7 @@ void TestOlmAccount::claimKeys()
 
     // Retrieve the identity key for the current device to check after claiming
     const auto& bobEd25519 = bobDevices.value(bob->deviceId())
-                                 .keys.value("ed25519:%1"_ls.arg(bob->deviceId()));
+                                 .keys.value("ed25519:%1"_L1.arg(bob->deviceId()));
 
     const QHash<QString, QHash<QString, QString>> oneTimeKeys{
         { bob->userId(), { { bob->deviceId(), SignedCurve25519Key } } }
@@ -387,9 +387,9 @@ void TestOlmAccount::claimKeys()
 void TestOlmAccount::claimMultipleKeys()
 {
     // Login with alice multiple times
-    CREATE_CONNECTION(alice, "alice7"_ls, "secret"_ls, "AlicePhone"_ls)
-    CREATE_CONNECTION(alice1, "alice7"_ls, "secret"_ls, "AlicePhone"_ls)
-    CREATE_CONNECTION(alice2, "alice7"_ls, "secret"_ls, "AlicePhone"_ls)
+    CREATE_CONNECTION(alice, "alice7"_L1, "secret"_L1, "AlicePhone"_L1)
+    CREATE_CONNECTION(alice1, "alice7"_L1, "secret"_L1, "AlicePhone"_L1)
+    CREATE_CONNECTION(alice2, "alice7"_L1, "secret"_L1, "AlicePhone"_L1)
 
     auto olm = alice->olmAccount();
     olm->generateOneTimeKeys(10);
@@ -422,7 +422,7 @@ void TestOlmAccount::claimMultipleKeys()
     QVERIFY(spy2.wait(10000));
 
     // Bob will claim all keys from alice
-    CREATE_CONNECTION(bob, "bob3"_ls, "secret"_ls, "BobPhone"_ls)
+    CREATE_CONNECTION(bob, "bob3"_L1, "secret"_L1, "BobPhone"_L1)
 
     QStringList devices_;
     devices_ << alice->deviceId()
@@ -444,7 +444,7 @@ void TestOlmAccount::claimMultipleKeys()
 
 void TestOlmAccount::enableEncryption()
 {
-    CREATE_CONNECTION(alice, "alice9"_ls, "secret"_ls, "AlicePhone"_ls)
+    CREATE_CONNECTION(alice, "alice9"_L1, "secret"_L1, "AlicePhone"_L1)
 
     auto job = alice->createRoom(Connection::PublishRoom, {}, {}, {}, {});
     QSignalSpy createRoomSpy(job, &BaseJob::success);

--- a/autotests/testolmaccount.cpp
+++ b/autotests/testolmaccount.cpp
@@ -20,11 +20,11 @@ using namespace Quotient;
 
 void TestOlmAccount::pickleUnpickledTest()
 {
-    QOlmAccount olmAccount(QStringLiteral("@foo:bar.com"), QStringLiteral("QuotientTestDevice"));
+    QOlmAccount olmAccount(u"@foo:bar.com"_s, u"QuotientTestDevice"_s);
     olmAccount.setupNewAccount();
     auto identityKeys = olmAccount.identityKeys();
     auto pickled = olmAccount.pickle(PicklingKey::mock());
-    QOlmAccount olmAccount2(QStringLiteral("@foo:bar.com"), QStringLiteral("QuotientTestDevice"));
+    QOlmAccount olmAccount2(u"@foo:bar.com"_s, u"QuotientTestDevice"_s);
     auto unpickleResult = olmAccount2.unpickle(std::move(pickled),
                                                PicklingKey::mock());
     QCOMPARE(unpickleResult, 0);
@@ -35,7 +35,7 @@ void TestOlmAccount::pickleUnpickledTest()
 
 void TestOlmAccount::identityKeysValid()
 {
-    QOlmAccount olmAccount(QStringLiteral("@foo:bar.com"), QStringLiteral("QuotientTestDevice"));
+    QOlmAccount olmAccount(u"@foo:bar.com"_s, u"QuotientTestDevice"_s);
     olmAccount.setupNewAccount();
     const auto identityKeys = olmAccount.identityKeys();
     const auto curve25519 = identityKeys.curve25519;
@@ -51,7 +51,7 @@ void TestOlmAccount::identityKeysValid()
 
 void TestOlmAccount::signatureValid()
 {
-    QOlmAccount olmAccount(QStringLiteral("@foo:bar.com"), QStringLiteral("QuotientTestDevice"));
+    QOlmAccount olmAccount(u"@foo:bar.com"_s, u"QuotientTestDevice"_s);
     olmAccount.setupNewAccount();
     const auto message = "Hello world!";
     const auto signature = olmAccount.sign(message);
@@ -65,7 +65,7 @@ void TestOlmAccount::signatureValid()
 
 void TestOlmAccount::oneTimeKeysValid()
 {
-    QOlmAccount olmAccount(QStringLiteral("@foo:bar.com"), QStringLiteral("QuotientTestDevice"));
+    QOlmAccount olmAccount(u"@foo:bar.com"_s, u"QuotientTestDevice"_s);
     olmAccount.setupNewAccount();
     const auto maxNumberOfOneTimeKeys = olmAccount.maxNumberOfOneTimeKeys();
     QCOMPARE(100, maxNumberOfOneTimeKeys);

--- a/autotests/testolmsession.cpp
+++ b/autotests/testolmsession.cpp
@@ -12,23 +12,21 @@ std::pair<QOlmSession, QOlmSession> createSessionPair()
 {
     QByteArray pickledAccountA("eOBXIKivUT6YYowRH031BNv7zNmzqM5B7CpXdyeaPvala5mt7/OeqrG1qVA7vA1SYloFyvJPIy0QNkD3j1HiPl5vtZHN53rtfZ9exXDok03zjmssqn4IJsqcA7Fbo1FZeKafG0NFcWwCPTdmcV7REqxjqGm3I4K8MQFa45AdTGSUu2C12cWeOcbSMlcINiMral+Uyah1sgPmLJ18h1qcnskXUXQvpffZ5DiUw1Iz5zxnwOQF1GVyowPJD7Zdugvj75RQnDxAn6CzyvrY2k2CuedwqDC3fIXM2xdUNWttW4nC2g4InpBhCVvNwhZYxlUb5BUEjmPI2AB3dAL5ry6o9MFncmbN6x5x");
     QByteArray pickledAccountB("eModTvoFi9oOIkax4j4nuxw9Tcl/J8mOmUctUWI68Q89HSaaPTqR+tdlKQ85v2GOs5NlZCp7EuycypN9GQ4fFbHUCrS7nspa3GFBWsR8PnM8+wez5PWmfFZLg3drOvT0jbMjpDx0MjGYClHBqcrEpKx9oFaIRGBaX6HXzT4lRaWSJkXxuX92q8iGNrLn96PuAWFNcD+2JXpPcNFntslwLUNgqzpZ04aIFYwL80GmzyOgq3Bz1GO6u3TgCQEAmTIYN2QkO0MQeuSfe7UoMumhlAJ6R8GPcdSSPtmXNk4tdyzzlgpVq1hm7ZLKto+g8/5Aq3PvnvA8wCqno2+Pi1duK1pZFTIlActr");
-    auto accountA = QOlmAccount(u"accountA:foo.com", u"Device1UserA");
+    auto accountA = QOlmAccount(u"accountA:foo.com"_s, u"Device1UserA"_s);
     if (accountA.unpickle(std::move(pickledAccountA), PicklingKey::mock())
         != OLM_SUCCESS)
         qFatal("Failed to unpickle account A: %s", accountA.lastError());
 
-    auto accountB = QOlmAccount(u"accountB:foo.com", u"Device1UserB");
+    auto accountB = QOlmAccount(u"accountB:foo.com"_s, u"Device1UserB"_s);
     if (accountB.unpickle(std::move(pickledAccountB), PicklingKey::mock())
         != OLM_SUCCESS)
         qFatal("Failed to unpickle account B: %s", accountB.lastError());
 
-
-    const QByteArray identityKeyA("qIEr3TWcJQt4CP8QoKKJcCaukByIOpgh6erBkhLEa2o");
-    const QByteArray oneTimeKeyA("WzsbsjD85iB1R32iWxfJdwkgmdz29ClMbJSJziECYwk");
-    const QByteArray identityKeyB("q/YhJtog/5VHCAS9rM9uUf6AaFk1yPe4GYuyUOXyQCg");
-    const QByteArray oneTimeKeyB("oWvzryma+B2onYjo3hM6A3Mgo/Yepm8HvgSvwZMTnjQ");
-    auto outbound =
-        accountA.createOutboundSession(identityKeyB, oneTimeKeyB).value();
+    //const auto identityKeyA = "qIEr3TWcJQt4CP8QoKKJcCaukByIOpgh6erBkhLEa2o"_ba;
+    //const auto oneTimeKeyA = "WzsbsjD85iB1R32iWxfJdwkgmdz29ClMbJSJziECYwk"_ba;
+    const auto identityKeyB = "q/YhJtog/5VHCAS9rM9uUf6AaFk1yPe4GYuyUOXyQCg"_ba;
+    const auto oneTimeKeyB = "oWvzryma+B2onYjo3hM6A3Mgo/Yepm8HvgSvwZMTnjQ"_ba;
+    auto outbound = accountA.createOutboundSession(identityKeyB, oneTimeKeyB).value();
 
     const auto preKey = outbound.encrypt(""); // Payload does not matter for PreKey
 

--- a/autotests/testolmutility.cpp
+++ b/autotests/testolmutility.cpp
@@ -49,7 +49,7 @@ void TestOlmUtility::canonicalJSON()
 
 void TestOlmUtility::verifySignedOneTimeKey()
 {
-    QOlmAccount aliceOlm { u"@alice:matrix.org", u"aliceDevice" };
+    QOlmAccount aliceOlm(u"@alice:matrix.org"_s, u"aliceDevice"_s);
     aliceOlm.setupNewAccount();
     aliceOlm.generateOneTimeKeys(1);
     auto keys = aliceOlm.oneTimeKeys();
@@ -89,8 +89,8 @@ void TestOlmUtility::verifySignedOneTimeKey()
 
 void TestOlmUtility::validUploadKeysRequest()
 {
-    const auto userId = QStringLiteral("@alice:matrix.org");
-    const auto deviceId = QStringLiteral("FKALSOCCC");
+    const auto userId = u"@alice:matrix.org"_s;
+    const auto deviceId = u"FKALSOCCC"_s;
 
     QOlmAccount alice { userId, deviceId };
     alice.setupNewAccount();
@@ -102,14 +102,10 @@ void TestOlmUtility::validUploadKeysRequest()
         { "algorithms"_L1, toJson(SupportedAlgorithms) },
         { "user_id"_L1, userId },
         { "device_id"_L1, deviceId },
-        { "keys"_L1,
-          QJsonObject{
-              { "curve25519:"_L1 + deviceId, alice.identityKeys().curve25519 },
-              { "ed25519:"_L1 + deviceId, alice.identityKeys().ed25519 } } },
-        { "signatures"_L1,
-          QJsonObject{
-              { userId, QJsonObject{ { "ed25519:"_L1 + deviceId,
-                                       QString::fromLatin1(idSig) } } } } }
+        { "keys"_L1, QJsonObject{ { "curve25519:"_L1 + deviceId, alice.identityKeys().curve25519 },
+                                  { "ed25519:"_L1 + deviceId, alice.identityKeys().ed25519 } } },
+        { "signatures"_L1, QJsonObject{ { userId, QJsonObject{ { "ed25519:"_L1 + deviceId,
+                                                                 QString::fromLatin1(idSig) } } } } }
     };
 
     const auto deviceKeys = alice.deviceKeys();

--- a/autotests/testolmutility.cpp
+++ b/autotests/testolmutility.cpp
@@ -55,7 +55,7 @@ void TestOlmUtility::verifySignedOneTimeKey()
     auto keys = aliceOlm.oneTimeKeys();
 
     auto firstKey = *keys.curve25519().begin();
-    auto msgObj = QJsonObject({{"key"_ls, firstKey}});
+    auto msgObj = QJsonObject({{"key"_L1, firstKey}});
     auto sig = aliceOlm.sign(msgObj);
 
     auto msg = QJsonDocument(msgObj).toJson(QJsonDocument::Compact);
@@ -99,16 +99,16 @@ void TestOlmUtility::validUploadKeysRequest()
     auto idSig = alice.signIdentityKeys();
 
     const QJsonObject body{
-        { "algorithms"_ls, toJson(SupportedAlgorithms) },
-        { "user_id"_ls, userId },
-        { "device_id"_ls, deviceId },
-        { "keys"_ls,
+        { "algorithms"_L1, toJson(SupportedAlgorithms) },
+        { "user_id"_L1, userId },
+        { "device_id"_L1, deviceId },
+        { "keys"_L1,
           QJsonObject{
-              { "curve25519:"_ls + deviceId, alice.identityKeys().curve25519 },
-              { "ed25519:"_ls + deviceId, alice.identityKeys().ed25519 } } },
-        { "signatures"_ls,
+              { "curve25519:"_L1 + deviceId, alice.identityKeys().curve25519 },
+              { "ed25519:"_L1 + deviceId, alice.identityKeys().ed25519 } } },
+        { "signatures"_L1,
           QJsonObject{
-              { userId, QJsonObject{ { "ed25519:"_ls + deviceId,
+              { userId, QJsonObject{ { "ed25519:"_L1 + deviceId,
                                        QString::fromLatin1(idSig) } } } } }
     };
 

--- a/autotests/testutils.cpp
+++ b/autotests/testutils.cpp
@@ -17,11 +17,11 @@ bool waitForSignal(auto objPtr, auto signal)
     return QSignalSpy(std::to_address(objPtr), signal).wait(60000);
 }
 
-std::shared_ptr<Quotient::Connection> Quotient::createTestConnection(
-    const QString& localUserName, const QString& secret,
-    const QString& deviceName)
+std::shared_ptr<Quotient::Connection> Quotient::createTestConnection(QLatin1StringView localUserName,
+                                                                     QLatin1StringView secret,
+                                                                     QLatin1StringView deviceName)
 {
-    static constexpr auto homeserverAddr = "localhost:1234"_ls;
+    static constexpr auto homeserverAddr = "localhost:1234"_L1;
     auto* const nam = NetworkAccessManager::instance();
     QObject::connect(nam, &QNetworkAccessManager::sslErrors, nam,
                      [](QNetworkReply* reply) { reply->ignoreSslErrors(); });

--- a/autotests/testutils.h
+++ b/autotests/testutils.h
@@ -12,10 +12,9 @@ namespace Quotient {
 
 class Connection;
 
-std::shared_ptr<Connection> createTestConnection(const QString& localUserName,
-                                                 const QString& secret,
-                                                 const QString& deviceName);
-
+std::shared_ptr<Connection> createTestConnection(QLatin1StringView localUserName,
+                                                 QLatin1StringView secret,
+                                                 QLatin1StringView deviceName);
 }
 
 #define CREATE_CONNECTION(VAR, USERNAME, SECRET, DEVICE_NAME)             \

--- a/autotests/utiltests.cpp
+++ b/autotests/utiltests.cpp
@@ -91,10 +91,9 @@ void TestUtils::testQuoCStr()
     T(QUtf8StringView);
 #endif
 #undef T
-    QVERIFY("Test QStringBuilder<QString>"sv
-            == QUO_CSTR(QStringLiteral("Test ") % u"QStringBuilder<QString>"));
+    QVERIFY("Test QStringBuilder<QString>"sv == QUO_CSTR(u"Test "_s % u"QStringBuilder<QString>"));
     QVERIFY("Test QStringBuilder<QByteArray>"sv
-            == QUO_CSTR(QByteArrayLiteral("Test ") % "QStringBuilder<QByteArray>"));
+            == QUO_CSTR("Test "_ba % "QStringBuilder<QByteArray>"));
 }
 
 QTEST_APPLESS_MAIN(TestUtils)

--- a/autotests/utiltests.cpp
+++ b/autotests/utiltests.cpp
@@ -42,40 +42,40 @@ void TestUtils::testLinkifyUrl()
     // Pending rewrite once std::source_location() works everywhere
 #define T(Original, Expected) testLinkified(Original, Expected, __LINE__)
 
-    T("https://www.matrix.org"_ls,
-      "<a href='https://www.matrix.org'>https://www.matrix.org</a>"_ls);
-//    T("www.matrix.org"_ls, // Doesn't work yet
-//      "<a href='https://www.matrix.org'>www.matrix.org</a>"_ls);
-    T("smb://some/file"_ls, "smb://some/file"_ls); // Disallowed scheme
-    T("https:/something"_ls, "https:/something"_ls); // Malformed URL
-    T("https://matrix.to/#/!roomid:example.org"_ls,
-      "<a href='https://matrix.to/#/!roomid:example.org'>https://matrix.to/#/!roomid:example.org</a>"_ls);
-    T("https://matrix.to/#/@user_id:example.org"_ls,
-      "<a href='https://matrix.to/#/@user_id:example.org'>https://matrix.to/#/@user_id:example.org</a>"_ls);
-    T("https://matrix.to/#/#roomalias:example.org"_ls,
-      "<a href='https://matrix.to/#/#roomalias:example.org'>https://matrix.to/#/#roomalias:example.org</a>"_ls);
-    T("https://matrix.to/#/##ircroomalias:example.org"_ls,
-      "<a href='https://matrix.to/#/##ircroomalias:example.org'>https://matrix.to/#/##ircroomalias:example.org</a>"_ls);
-    T("me@example.org"_ls,
-      "<a href='mailto:me@example.org'>me@example.org</a>"_ls);
-    T("mailto:me@example.org"_ls,
-      "<a href='mailto:me@example.org'>mailto:me@example.org</a>"_ls);
-    T("www.example.com?email@example.com"_ls,
-      "<a href='www.example.com?email@example.com'>www.example.com?email@example.com</a>"_ls);
-    T("!room_id:example.org"_ls,
-      "<a href='https://matrix.to/#/!room_id:example.org'>!room_id:example.org</a>"_ls);
-    T("@user_id:example.org"_ls,
-      "<a href='https://matrix.to/#/@user_id:example.org'>@user_id:example.org</a>"_ls);
-    T("#room_alias:example.org"_ls,
-      "<a href='https://matrix.to/#/#room_alias:example.org'>#room_alias:example.org</a>"_ls);
+    T("https://www.matrix.org"_L1,
+      "<a href='https://www.matrix.org'>https://www.matrix.org</a>"_L1);
+//    T("www.matrix.org"_L1, // Doesn't work yet
+//      "<a href='https://www.matrix.org'>www.matrix.org</a>"_L1);
+    T("smb://some/file"_L1, "smb://some/file"_L1); // Disallowed scheme
+    T("https:/something"_L1, "https:/something"_L1); // Malformed URL
+    T("https://matrix.to/#/!roomid:example.org"_L1,
+      "<a href='https://matrix.to/#/!roomid:example.org'>https://matrix.to/#/!roomid:example.org</a>"_L1);
+    T("https://matrix.to/#/@user_id:example.org"_L1,
+      "<a href='https://matrix.to/#/@user_id:example.org'>https://matrix.to/#/@user_id:example.org</a>"_L1);
+    T("https://matrix.to/#/#roomalias:example.org"_L1,
+      "<a href='https://matrix.to/#/#roomalias:example.org'>https://matrix.to/#/#roomalias:example.org</a>"_L1);
+    T("https://matrix.to/#/##ircroomalias:example.org"_L1,
+      "<a href='https://matrix.to/#/##ircroomalias:example.org'>https://matrix.to/#/##ircroomalias:example.org</a>"_L1);
+    T("me@example.org"_L1,
+      "<a href='mailto:me@example.org'>me@example.org</a>"_L1);
+    T("mailto:me@example.org"_L1,
+      "<a href='mailto:me@example.org'>mailto:me@example.org</a>"_L1);
+    T("www.example.com?email@example.com"_L1,
+      "<a href='www.example.com?email@example.com'>www.example.com?email@example.com</a>"_L1);
+    T("!room_id:example.org"_L1,
+      "<a href='https://matrix.to/#/!room_id:example.org'>!room_id:example.org</a>"_L1);
+    T("@user_id:example.org"_L1,
+      "<a href='https://matrix.to/#/@user_id:example.org'>@user_id:example.org</a>"_L1);
+    T("#room_alias:example.org"_L1,
+      "<a href='https://matrix.to/#/#room_alias:example.org'>#room_alias:example.org</a>"_L1);
 
 #undef T
 }
 
 void TestUtils::testIsGuestUserId()
 {
-    QVERIFY(isGuestUserId("@123:example.org"_ls));
-    QVERIFY(!isGuestUserId("@normal:example.org"_ls));
+    QVERIFY(isGuestUserId("@123:example.org"_L1));
+    QVERIFY(!isGuestUserId("@normal:example.org"_L1));
 }
 
 void TestUtils::testQuoCStr()

--- a/gtad/define_models.mustache
+++ b/gtad/define_models.mustache
@@ -11,8 +11,8 @@ template <> struct JsonObjectConverter<{{name}}>
             {{/propertyMap}}{{#parents}}
         fillJson<{{name}}>(jo, pod);
             {{/parents}}{{#vars}}
-        addParam<{{^required?}}IfNotEmpty{{/required?}}>(jo,
-                QStringLiteral("{{baseName}}"), pod.{{nameCamelCase}});
+        addParam<{{^required?}}IfNotEmpty{{/required?}}>(jo, "{{baseName}}"_L1,
+                                                         pod.{{nameCamelCase}});
             {{/vars}}
         }
         {{/in?}}
@@ -21,7 +21,7 @@ template <> struct JsonObjectConverter<{{name}}>
     {       {{#parents}}
         fillFromJson<{{qualifiedName}}>(jo, pod);
             {{/parents}}{{#vars}}
-        fillFromJson(jo.{{>takeOrValue}}("{{baseName}}"_ls), pod.{{nameCamelCase}});
+        fillFromJson(jo.{{>takeOrValue}}("{{baseName}}"_L1), pod.{{nameCamelCase}});
             {{/vars}}{{#propertyMap}}
         fromJson(jo, pod.{{nameCamelCase}});
             {{/propertyMap}}

--- a/gtad/gtad.yaml
+++ b/gtad/gtad.yaml
@@ -236,7 +236,7 @@ mustache:
 
     passPathAndMaybeQuery: >-
       makePath("{{basePathWithoutHost}}"{{#pathParts}},
-      {{_}}{{/pathParts}}){{#queryParams?}},
+      {{#literal}}"{{literal}}"{{/literal}}{{variable}}{{/pathParts}}){{#queryParams?}},
       queryTo{{>titleCaseOperationId}}(
       {{#queryParams}}{{paramName}}{{>cjoin}}{{/queryParams}}){{/queryParams?}}
 

--- a/gtad/gtad.yaml
+++ b/gtad/gtad.yaml
@@ -83,20 +83,20 @@ analyzer:
       +on:
       - date:
           type: QDate
-          initializer: QDate::fromString("{{defaultValue}}")
+          initializer: QDate::fromString(u"{{defaultValue}}")
       - dateTime:
           type: QDateTime
-          initializer: QDateTime::fromString("{{defaultValue}}")
+          initializer: QDateTime::fromString(u"{{defaultValue}}")
       - uri: &Url
           type: QUrl
-          initializer: QUrl::fromEncoded("{{defaultValue}}")
+          initializer: QUrl::fromEncoded("{{defaultValue}}"_L1)
       - mx-mxc-uri: *Url
       - mx-user-id: UserId
       - mx-room-id: RoomId
       - mx-event-id: EventId
       - //: &QString
           type: QString
-          initializer: QStringLiteral("{{defaultValue}}")
+          initializer: u"{{defaultValue}}"_s
   - file: *ByteStream
   - +set: { avoidCopy: }
     +on:

--- a/gtad/operation.cpp.mustache
+++ b/gtad/operation.cpp.mustache
@@ -12,8 +12,8 @@ auto queryTo{{>titleCaseOperationId}}(
             {{#queryParams}}{{>joinedParamDef}}{{/queryParams}})
 {
     QUrlQuery _q;{{#queryParams}}
-    addParam<{{^required?}}IfNotEmpty{{/required?}}>(_q,
-            QStringLiteral("{{baseName}}"), {{paramName}});{{/queryParams}}
+    addParam<{{^required?}}IfNotEmpty{{/required?}}>(_q, u"{{baseName}}"_s,
+                                                     {{paramName}});{{/queryParams}}
     return _q;
 }
     {{/queryParams?}}
@@ -28,8 +28,7 @@ QUrl {{>titleCaseOperationId}}Job::makeRequestUrl(const HomeserverData& hsData{{
 {{>titleCaseOperationId}}Job::{{>titleCaseOperationId}}Job(
         {{#allParams}}{{>joinedParamDef}}{{/allParams}})
     : BaseJob(HttpVerb::{{#_titleCase}}{{httpMethod}}{{/_titleCase}},
-            {{!object name}}QStringLiteral("{{>titleCaseOperationId}}Job"),
-            {{>passPathAndMaybeQuery}}
+              {{!object name}}u"{{>titleCaseOperationId}}Job"_s, {{>passPathAndMaybeQuery}}
         {{#skipAuth}}{{#queryParams?}}, {}{{/queryParams?}}, false{{/skipAuth}} )
 {   {{#headerParams}}
     setRequestHeader("{{baseName}}", {{paramName}}.toLatin1());
@@ -44,8 +43,7 @@ QUrl {{>titleCaseOperationId}}Job::makeRequestUrl(const HomeserverData& hsData{{
         {{/propertyMap}}{{#inlineBody}}
     fillJson<{{>maybeOptionalType}}>(_dataJson, {{paramName}});
         {{/inlineBody}}{{#bodyParams}}
-    addParam<{{^required?}}IfNotEmpty{{/required?}}>(_dataJson,
-                    QStringLiteral("{{baseName}}"), {{paramName}});
+    addParam<{{^required?}}IfNotEmpty{{/required?}}>(_dataJson, "{{baseName}}"_L1, {{paramName}});
         {{/bodyParams}}
     setRequestData({ _dataJson });
     {{/bodyParams?}}{{/consumesNonJson?}}{{#producesNonJson?}}

--- a/gtad/operation.h.mustache
+++ b/gtad/operation.h.mustache
@@ -69,7 +69,7 @@ public:
 
     {{>nonInlineResponseSignature}}
     {
-        return {{>takeOrLoad}}FromJson<{{>maybeOptionalType}}>("{{baseName}}"_ls);
+        return {{>takeOrLoad}}FromJson<{{>maybeOptionalType}}>("{{baseName}}"_L1);
     }
         {{/properties}}{{^singleValue?}}{{#properties?}}
 
@@ -108,8 +108,8 @@ template <> struct QUOTIENT_API JsonObjectConverter<{{qualifiedName}}> {
             {{/propertyMap}}{{#parents}}
         fillJson<{{name}}>(jo, pod);
             {{/parents}}{{#vars}}
-        addParam<{{^required?}}IfNotEmpty{{/required?}}>(jo,
-                    QStringLiteral("{{baseName}}"), pod.{{nameCamelCase}});
+        addParam<{{^required?}}IfNotEmpty{{/required?}}>(jo, "{{baseName}}"_L1,
+                                                         pod.{{nameCamelCase}});
             {{/vars}}
     }
         {{/in?}}
@@ -118,8 +118,7 @@ template <> struct QUOTIENT_API JsonObjectConverter<{{qualifiedName}}> {
         {   {{#parents}}
         fillFromJson<{{name}}{{!of the parent!}}>(jo, result);
             {{/parents}}{{#vars}}
-        fillFromJson(jo.{{>takeOrValue}}("{{baseName}}"_ls),
-                 result.{{nameCamelCase}});
+        fillFromJson(jo.{{>takeOrValue}}("{{baseName}}"_L1), result.{{nameCamelCase}});
             {{/vars}}{{#propertyMap}}
         fromJson(jo, result.{{nameCamelCase}});
             {{/propertyMap}}

--- a/quotest/quotest.cpp
+++ b/quotest/quotest.cpp
@@ -369,7 +369,7 @@ TEST_IMPL(sendReaction)
         FAIL_TEST();
     }
 
-    const auto key = QStringLiteral("+1");
+    const auto key = u"+1"_s;
     const auto txnId = targetRoom->postReaction(targetEvtId, key);
     if (!validatePendingEvent<ReactionEvent>(txnId)) {
         clog << "Invalid pending event right after submitting" << endl;
@@ -633,7 +633,7 @@ TEST_IMPL(showLocalUsername)
 
 TEST_IMPL(addAndRemoveTag)
 {
-    static const auto TestTag = QStringLiteral("im.quotient.test");
+    static const auto TestTag = u"im.quotient.test"_s;
     // Pre-requisite
     if (targetRoom->tags().contains(TestTag))
         targetRoom->removeTag(TestTag);
@@ -762,14 +762,13 @@ TEST_IMPL(visitResources)
             clog << "Empty Matrix URI test failed" << endl;
             FAIL_TEST();
         }
-    if (Uri { QStringLiteral("#") }.isValid()) {
+    if (Uri { u"#"_s }.isValid()) {
         clog << "Bare sigil URI test failed" << endl;
         FAIL_TEST();
     }
     QUrl invalidUrl { "https://"_L1 };
     invalidUrl.setAuthority("---:@@@"_L1);
-    const Uri matrixUriFromInvalidUrl { invalidUrl },
-        invalidMatrixUri { QStringLiteral("matrix:&invalid@") };
+    const Uri matrixUriFromInvalidUrl{ invalidUrl }, invalidMatrixUri{ u"matrix:&invalid@"_s };
     if (matrixUriFromInvalidUrl.isEmpty() || matrixUriFromInvalidUrl.isValid()) {
         clog << "Invalid Matrix URI test failed" << endl;
         FAIL_TEST();
@@ -805,10 +804,9 @@ TEST_IMPL(visitResources)
         "https://matrix.to/#/"_L1 + roomId + u'/' + eventId
     };
     // Check that reserved characters are correctly processed.
-    static const auto& joinRoomAlias =
-        QStringLiteral("##/?.@\"unjoined:example.org");
+    static const auto joinRoomAlias = u"##/?.@\"unjoined:example.org"_s;
     static const auto& encodedRoomAliasNoSigil =
-        QString::fromLatin1(QUrl::toPercentEncoding(joinRoomAlias.mid(1), QByteArrayLiteral(":")));
+        QString::fromLatin1(QUrl::toPercentEncoding(joinRoomAlias.mid(1), ":"_ba));
     static const QString joinQuery { "?action=join"_L1 };
     // These URIs are not supposed to be actually joined (and even exist,
     // as yet) - only to be syntactically correct
@@ -819,7 +817,7 @@ TEST_IMPL(visitResources)
         "https://matrix.to/#/%23"_L1/*`#`*/ + encodedRoomAliasNoSigil + joinQuery,
         "https://matrix.to/#/%23"_L1 + joinRoomAlias.mid(1) /* unencoded */ + joinQuery
     };
-    static const auto& joinRoomId = QStringLiteral("!anyid:example.org");
+    static const auto joinRoomId = u"!anyid:example.org"_s;
     static const QStringList viaServers { "matrix.org"_L1, "example.org"_L1 };
     static const auto viaQuery =
         std::accumulate(viaServers.cbegin(), viaServers.cend(), joinQuery,

--- a/quotest/quotest.cpp
+++ b/quotest/quotest.cpp
@@ -169,13 +169,13 @@ void TestSuite::finishTest(const TestToken& token, bool condition,
     if (condition) {
         clog << item << " successful" << endl;
         if (targetRoom)
-            targetRoom->postMessage(origin % ": "_ls % QString::fromUtf8(item) % " successful"_ls,
+            targetRoom->postMessage(origin % ": "_L1 % QString::fromUtf8(item) % " successful"_L1,
                                     MessageEventType::Notice);
     } else {
         clog << item << " FAILED at " << file << ":" << line << endl;
         if (targetRoom)
-            targetRoom->postPlainText(origin % ": "_ls % QString::fromUtf8(item) % " FAILED at "_ls
-                                      % QString::fromUtf8(file) % ", line "_ls % QString::number(line));
+            targetRoom->postPlainText(origin % ": "_L1 % QString::fromUtf8(item) % " FAILED at "_L1
+                                      % QString::fromUtf8(file) % ", line "_L1 % QString::number(line));
     }
 
     emit finishedItem(item, condition);
@@ -337,7 +337,7 @@ TEST_IMPL(loadMembers)
 
 TEST_IMPL(sendMessage)
 {
-    auto txnId = targetRoom->postPlainText("Hello, "_ls % origin % " is here"_ls);
+    auto txnId = targetRoom->postPlainText("Hello, "_L1 % origin % " is here"_L1);
     if (!validatePendingEvent<RoomMessageEvent>(txnId)) {
         clog << "Invalid pending event right after submitting" << endl;
         FAIL_TEST();
@@ -411,7 +411,7 @@ TEST_IMPL(sendFile)
     const auto tfName = tfi.fileName();
     clog << "Sending file " << tfName.toStdString() << endl;
     const auto txnId = targetRoom->postFile(
-        "Test file"_ls, new EventContent::FileContent(tfi));
+        "Test file"_L1, new EventContent::FileContent(tfi));
     if (!validatePendingEvent<RoomMessageEvent>(txnId)) {
         clog << "Invalid pending event right after submitting" << endl;
         tf->deleteLater();
@@ -436,7 +436,7 @@ TEST_IMPL(sendFile)
             if (id != txnId)
                 return false;
 
-            targetRoom->postPlainText(origin % ": File upload failed: "_ls % error);
+            targetRoom->postPlainText(origin % ": File upload failed: "_L1 % error);
             tf->deleteLater();
             FAIL_TEST();
         });
@@ -628,7 +628,7 @@ TEST_IMPL(changeName)
 TEST_IMPL(showLocalUsername)
 {
     auto* const localUser = connection()->user();
-    FINISH_TEST(!localUser->name().contains("@"_ls));
+    FINISH_TEST(!localUser->name().contains("@"_L1));
 }
 
 TEST_IMPL(addAndRemoveTag)
@@ -716,7 +716,7 @@ TEST_IMPL(visitResources)
             clog << "Checking " << uriString.toStdString()
                  << " -> " << uri.toDisplayString().toStdString() << endl;
             if (auto matrixToUrl = uri.toUrl(Uri::MatrixToUri).toDisplayString();
-                !matrixToUrl.startsWith("https://matrix.to/#/"_ls)) {
+                !matrixToUrl.startsWith("https://matrix.to/#/"_L1)) {
                 clog << "Incorrect matrix.to representation:"
                      << matrixToUrl.toStdString() << endl;
             }
@@ -766,8 +766,8 @@ TEST_IMPL(visitResources)
         clog << "Bare sigil URI test failed" << endl;
         FAIL_TEST();
     }
-    QUrl invalidUrl { "https://"_ls };
-    invalidUrl.setAuthority("---:@@@"_ls);
+    QUrl invalidUrl { "https://"_L1 };
+    invalidUrl.setAuthority("---:@@@"_L1);
     const Uri matrixUriFromInvalidUrl { invalidUrl },
         invalidMatrixUri { QStringLiteral("matrix:&invalid@") };
     if (matrixUriFromInvalidUrl.isEmpty() || matrixUriFromInvalidUrl.isValid()) {
@@ -790,45 +790,45 @@ TEST_IMPL(visitResources)
     Q_ASSERT(!eventId.isEmpty());
 
     const QStringList roomUris {
-        roomId, "matrix:roomid/"_ls + roomId.mid(1),
-        "https://matrix.to/#/%21"_ls/*`!`*/ + roomId.mid(1),
-        roomAlias, "matrix:room/"_ls + roomAlias.mid(1),
-        "matrix:r/"_ls + roomAlias.mid(1),
-        "https://matrix.to/#/"_ls + roomAlias,
+        roomId, "matrix:roomid/"_L1 + roomId.mid(1),
+        "https://matrix.to/#/%21"_L1/*`!`*/ + roomId.mid(1),
+        roomAlias, "matrix:room/"_L1 + roomAlias.mid(1),
+        "matrix:r/"_L1 + roomAlias.mid(1),
+        "https://matrix.to/#/"_L1 + roomAlias,
     };
-    const QStringList userUris { userId, "matrix:user/"_ls + userId.mid(1),
-                                 "matrix:u/"_ls + userId.mid(1),
-                                 "https://matrix.to/#/"_ls + userId };
+    const QStringList userUris { userId, "matrix:user/"_L1 + userId.mid(1),
+                                 "matrix:u/"_L1 + userId.mid(1),
+                                 "https://matrix.to/#/"_L1 + userId };
     const QStringList eventUris {
-        "matrix:room/"_ls + roomAlias.mid(1) + "/event/"_ls + eventId.mid(1),
-        "matrix:r/"_ls + roomAlias.mid(1) + "/e/"_ls + eventId.mid(1),
-        "https://matrix.to/#/"_ls + roomId + u'/' + eventId
+        "matrix:room/"_L1 + roomAlias.mid(1) + "/event/"_L1 + eventId.mid(1),
+        "matrix:r/"_L1 + roomAlias.mid(1) + "/e/"_L1 + eventId.mid(1),
+        "https://matrix.to/#/"_L1 + roomId + u'/' + eventId
     };
     // Check that reserved characters are correctly processed.
     static const auto& joinRoomAlias =
         QStringLiteral("##/?.@\"unjoined:example.org");
     static const auto& encodedRoomAliasNoSigil =
         QString::fromLatin1(QUrl::toPercentEncoding(joinRoomAlias.mid(1), QByteArrayLiteral(":")));
-    static const QString joinQuery { "?action=join"_ls };
+    static const QString joinQuery { "?action=join"_L1 };
     // These URIs are not supposed to be actually joined (and even exist,
     // as yet) - only to be syntactically correct
     static const QStringList joinByAliasUris {
         Uri(joinRoomAlias.toUtf8(), {}, joinQuery.mid(1)).toDisplayString(),
-        "matrix:room/"_ls + encodedRoomAliasNoSigil + joinQuery,
-        "matrix:r/"_ls + encodedRoomAliasNoSigil + joinQuery,
-        "https://matrix.to/#/%23"_ls/*`#`*/ + encodedRoomAliasNoSigil + joinQuery,
-        "https://matrix.to/#/%23"_ls + joinRoomAlias.mid(1) /* unencoded */ + joinQuery
+        "matrix:room/"_L1 + encodedRoomAliasNoSigil + joinQuery,
+        "matrix:r/"_L1 + encodedRoomAliasNoSigil + joinQuery,
+        "https://matrix.to/#/%23"_L1/*`#`*/ + encodedRoomAliasNoSigil + joinQuery,
+        "https://matrix.to/#/%23"_L1 + joinRoomAlias.mid(1) /* unencoded */ + joinQuery
     };
     static const auto& joinRoomId = QStringLiteral("!anyid:example.org");
-    static const QStringList viaServers { "matrix.org"_ls, "example.org"_ls };
+    static const QStringList viaServers { "matrix.org"_L1, "example.org"_L1 };
     static const auto viaQuery =
         std::accumulate(viaServers.cbegin(), viaServers.cend(), joinQuery,
                         [](const QString& q, const QString& s) {
-                            return q + "&via="_ls + s;
+                            return q + "&via="_L1 + s;
                         });
     static const QStringList joinByIdUris {
-        "matrix:roomid/"_ls + joinRoomId.mid(1) + viaQuery,
-        "https://matrix.to/#/"_ls + joinRoomId + viaQuery
+        "matrix:roomid/"_L1 + joinRoomId.mid(1) + viaQuery,
+        "https://matrix.to/#/"_L1 + joinRoomId + viaQuery
     };
     // If any test breaks, the breaking call will return true, and further
     // execution will be cut by ||'s short-circuiting
@@ -869,27 +869,27 @@ void TestManager::conclude()
     room->setTopic({});
     c->user()->rename({});
 
-    const QString succeededRec{ QString::number(succeeded.size()) % " of "_ls
+    const QString succeededRec{ QString::number(succeeded.size()) % " of "_L1
                                 % QString::number(succeeded.size() + failed.size() + running.size())
-                                % " tests succeeded"_ls };
-    QString plainReport = origin % ": Testing complete, "_ls % succeededRec;
-    const QString color = failed.empty() && running.empty() ? "00AA00"_ls : "AA0000"_ls;
-    QString htmlReport = origin % ": <strong><font data-mx-color='#"_ls % color
-                         % "' color='#"_ls % color
-                         % "'>Testing complete</font></strong>, "_ls % succeededRec;
+                                % " tests succeeded"_L1 };
+    QString plainReport = origin % ": Testing complete, "_L1 % succeededRec;
+    const QString color = failed.empty() && running.empty() ? "00AA00"_L1 : "AA0000"_L1;
+    QString htmlReport = origin % ": <strong><font data-mx-color='#"_L1 % color
+                         % "' color='#"_L1 % color
+                         % "'>Testing complete</font></strong>, "_L1 % succeededRec;
     if (!failed.empty()) {
         QByteArray failedList;
         for (const auto& f : std::as_const(failed))
             failedList += ' ' + f;
-        plainReport += "\nFAILED:"_ls + QString::fromUtf8(failedList);
-        htmlReport += "<br><strong>Failed:</strong>"_ls + QString::fromUtf8(failedList);
+        plainReport += "\nFAILED:"_L1 + QString::fromUtf8(failedList);
+        htmlReport += "<br><strong>Failed:</strong>"_L1 + QString::fromUtf8(failedList);
     }
     if (!running.empty()) {
         QByteArray dnfList;
         for (const auto& r : std::as_const(running))
             dnfList += ' ' + r;
-        plainReport += "\nDID NOT FINISH:"_ls + QString::fromUtf8(dnfList);
-        htmlReport += "<br><strong>Did not finish:</strong>"_ls + QString::fromUtf8(dnfList);
+        plainReport += "\nDID NOT FINISH:"_L1 + QString::fromUtf8(dnfList);
+        htmlReport += "<br><strong>Did not finish:</strong>"_L1 + QString::fromUtf8(dnfList);
     }
 
     auto txnId = room->postHtmlText(plainReport, htmlReport);


### PR DESCRIPTION
The changeset is quite sweeping but meant to be behind the scenes and [mostly](https://en.wikipedia.org/wiki/Phrases_from_The_Hitchhiker%27s_Guide_to_the_Galaxy#Mostly_Harmless) ;) API-compatible. Most of it is search-replace of `""_ls` with `""_L1` and `QStringLiteral` with `u""_s` (or with `""_L1` where applicable). The payload is a tiny bit smaller (shaving up to 0.7%, depending on the mode), and runtime performance will most likely be the same.

(not rushing it for 0.9 beta, that window is closed already)