### PR TITLE
BaseJob: Check if null in encodeIfParam

### DIFF
--- a/Quotient/jobs/basejob.cpp
+++ b/Quotient/jobs/basejob.cpp
@@ -175,7 +175,8 @@ inline bool isHex(QChar c)
 QByteArray BaseJob::encodeIfParam(const QString& paramPart)
 {
     if (const auto percentIt = std::ranges::find(paramPart, u'%');
-        percentIt <= paramPart.end() - 3 && isHex(*(percentIt + 1)) && isHex(*(percentIt + 2))) {
+        percentIt != paramPart.end() && percentIt <= paramPart.end() - 3 && isHex(*(percentIt + 1))
+        && isHex(*(percentIt + 2))) {
         qCWarning(JOBS) << "Developers, upfront percent-encoding of job paramParteters is "
                            "deprecated since libQuotient 0.7; the string involved is"
                         << paramPart;


### PR DESCRIPTION
If % is not inside of paramPart - like if it's empty - then std::ranges::find will return a null iterator. The rest of this if check depends on it not being null, so it segfaults when it is.

Noticed this during some random usage in NeoChat.