### PR TITLE
Fix a couple of blunders

### DIFF
--- a/Quotient/jobs/basejob.cpp
+++ b/Quotient/jobs/basejob.cpp
@@ -167,16 +167,10 @@ public:
     }
 };
 
-inline bool isHex(QChar c)
-{
-    return c.isDigit() || (c >= u'A' && c <= u'F') || (c >= u'a' && c <= u'f');
-}
-
 QByteArray BaseJob::encodeIfParam(const QString& paramPart)
 {
-    if (const auto percentIt = std::ranges::find(paramPart, u'%');
-        percentIt <= paramPart.end() - 3 && isHex(*(percentIt + 1)) && isHex(*(percentIt + 2))) {
-        qCWarning(JOBS) << "Developers, upfront percent-encoding of job paramParteters is "
+    if (static const QRegularExpression re{ "%[[:xdigit:]]{2}"_L1 }; paramPart.indexOf(re) != -1) {
+        qCWarning(JOBS) << "Developers, upfront percent-encoding of job parameters is "
                            "deprecated since libQuotient 0.7; the string involved is"
                         << paramPart;
         return QUrl(paramPart, QUrl::TolerantMode).toEncoded();

--- a/Quotient/settings.cpp
+++ b/Quotient/settings.cpp
@@ -20,21 +20,21 @@ void Settings::setLegacyNames(const QString& organizationName,
 Settings::Settings(QObject* parent) : QSettings(parent)
 {}
 
-void Settings::setValue(QAnyStringView key, const QVariant& value)
+void Settings::setValue(const QString& key, const QVariant& value)
 {
     QSettings::setValue(key, value);
     if (legacySettings.contains(key))
         legacySettings.remove(key);
 }
 
-void Settings::remove(QAnyStringView key)
+void Settings::remove(const QString& key)
 {
     QSettings::remove(key);
     if (legacySettings.contains(key))
         legacySettings.remove(key);
 }
 
-QVariant Settings::value(QAnyStringView key, const QVariant& defaultValue) const
+QVariant Settings::value(const QString& key, const QVariant& defaultValue) const
 {
     auto value = QSettings::value(key, legacySettings.value(key, defaultValue));
     // QML's Qt.labs.Settings stores boolean values as strings, which, if loaded
@@ -45,7 +45,7 @@ QVariant Settings::value(QAnyStringView key, const QVariant& defaultValue) const
     return value.toString() == "false"_L1 ? QVariant(false) : value;
 }
 
-bool Settings::contains(QAnyStringView key) const
+bool Settings::contains(const QString& key) const
 {
     return QSettings::contains(key) || legacySettings.contains(key);
 }
@@ -60,14 +60,14 @@ QStringList Settings::childGroups() const
     return groups;
 }
 
-void SettingsGroup::setValue(QAnyStringView key, const QVariant& value)
+void SettingsGroup::setValue(const QString& key, const QVariant& value)
 {
     Settings::setValue(fullPath(key), value);
 }
 
-bool SettingsGroup::contains(QAnyStringView key) const { return Settings::contains(fullPath(key)); }
+bool SettingsGroup::contains(const QString& key) const { return Settings::contains(fullPath(key)); }
 
-QVariant SettingsGroup::value(QAnyStringView key, const QVariant& defaultValue) const
+QVariant SettingsGroup::value(const QString& key, const QVariant& defaultValue) const
 {
     return Settings::value(fullPath(key), defaultValue);
 }

--- a/Quotient/settings.h
+++ b/Quotient/settings.h
@@ -31,10 +31,10 @@ public:
 
     /// Set the value for a given key
     /*! If the key exists in the legacy location, it is removed. */
-    Q_INVOKABLE void setValue(QAnyStringView key, const QVariant& value);
+    Q_INVOKABLE void setValue(const QString& key, const QVariant& value);
 
     /// Remove the value from both the primary and legacy locations
-    Q_INVOKABLE void remove(QAnyStringView key);
+    Q_INVOKABLE void remove(const QString& key);
 
     /// Obtain a value for a given key
     /*!
@@ -47,7 +47,7 @@ public:
      *
      * \sa setLegacyNames, get
      */
-    Q_INVOKABLE QVariant value(QAnyStringView key, const QVariant& defaultValue = {}) const;
+    Q_INVOKABLE QVariant value(const QString& key, const QVariant& defaultValue = {}) const;
 
     /// Obtain a value for a given key, coerced to the given type
     /*!
@@ -62,11 +62,11 @@ public:
     template <typename T>
     T get(const QString& key, const T& defaultValue = {}) const
     {
-        const auto qv = value(key, QVariant());
+        const auto qv = value(key);
         return qv.isValid() && qv.canConvert<T>() ? qv.value<T>() : defaultValue;
     }
 
-    Q_INVOKABLE bool contains(QAnyStringView key) const;
+    Q_INVOKABLE bool contains(const QString& key) const;
     Q_INVOKABLE QStringList childGroups() const;
 
 private:
@@ -84,19 +84,19 @@ public:
         , groupPath(std::move(path))
     {}
 
-    Q_INVOKABLE bool contains(QAnyStringView key) const;
-    Q_INVOKABLE QVariant value(QAnyStringView key, const QVariant& defaultValue = {}) const;
+    Q_INVOKABLE bool contains(const QString& key) const;
+    Q_INVOKABLE QVariant value(const QString& key, const QVariant& defaultValue = {}) const;
 
     template <typename T>
-    T get(auto key, const T& defaultValue = {}) const
+    T get(const QString& key, const T& defaultValue = {}) const
     {
-        const auto qv = value(key, QVariant());
-        return qv.isValid() && qv.template canConvert<T>() ? qv.template value<T>() : defaultValue;
+        const auto qv = value(key);
+        return qv.isValid() && qv.canConvert<T>() ? qv.value<T>() : defaultValue;
     }
 
     Q_INVOKABLE QString group() const;
     Q_INVOKABLE QStringList childGroups() const;
-    Q_INVOKABLE void setValue(QAnyStringView key, const QVariant& value);
+    Q_INVOKABLE void setValue(const QString& key, const QVariant& value);
 
     Q_INVOKABLE void remove(const QString& key);
 


### PR DESCRIPTION
The first commit is a fix for the problem identified in #793; the second one fixes inability to work with `Quotient::Settings` and its kin from QML.