### PR TITLE
RoomMember::avatar()

### DIFF
--- a/Quotient/avatar.cpp
+++ b/Quotient/avatar.cpp
@@ -44,7 +44,7 @@ public:
     mutable std::vector<get_callback_t> callbacks{};
 };
 
-Avatar::Avatar(Connection* c, QUrl url) : d(makeImpl<Private>(c))
+Avatar::Avatar(Connection* parent, const QUrl& url) : d(makeImpl<Private>(parent))
 {
     if (!url.isEmpty())
         updateUrl(url);

--- a/Quotient/avatar.h
+++ b/Quotient/avatar.h
@@ -18,8 +18,14 @@ class QUOTIENT_API Avatar {
 public:
     explicit Avatar(Connection* parent, QUrl url = {});
 
+#ifdef __cpp_lib_move_only_function // AppleClang 15 doesn't have it
     using get_callback_t = std::move_only_function<void()>;
     using upload_callback_t = std::move_only_function<void(QUrl)>;
+#else
+    using get_callback_t = std::function<void()>;
+    using upload_callback_t = std::function<void(QUrl)>;
+#endif
+
 
     QImage get(int dimension, get_callback_t callback) const;
     QImage get(int w, int h, get_callback_t callback) const;

--- a/Quotient/avatar.h
+++ b/Quotient/avatar.h
@@ -16,26 +16,20 @@ class Connection;
 
 class QUOTIENT_API Avatar {
 public:
-    explicit Avatar();
-    explicit Avatar(QUrl url);
+    explicit Avatar(Connection* parent, QUrl url = {});
 
-    // TODO: use std::move_only_function once C++23 is here
-    using get_callback_t = std::function<void()>;
-    using upload_callback_t = std::function<void(QUrl)>;
+    using get_callback_t = std::move_only_function<void()>;
+    using upload_callback_t = std::move_only_function<void(QUrl)>;
 
-    QImage get(Connection* connection, int dimension,
-               get_callback_t callback) const;
-    QImage get(Connection* connection, int w, int h,
-               get_callback_t callback) const;
+    QImage get(int dimension, get_callback_t callback) const;
+    QImage get(int w, int h, get_callback_t callback) const;
 
     [[deprecated("Use the QFuture-returning overload instead")]]
-    bool upload(Connection* connection, const QString& fileName,
-                upload_callback_t callback) const;
+    bool upload(const QString& fileName, upload_callback_t callback) const;
     [[deprecated("Use the QFuture-returning overload instead")]]
-    bool upload(Connection* connection, QIODevice* source,
-                upload_callback_t callback) const;
-    QFuture<QUrl> upload(Connection* connection, const QString& fileName) const;
-    QFuture<QUrl> upload(Connection* connection, QIODevice* source) const;
+    bool upload(QIODevice* source, upload_callback_t callback) const;
+    QFuture<QUrl> upload(const QString& fileName) const;
+    QFuture<QUrl> upload(QIODevice* source) const;
 
     QString mediaId() const;
     QUrl url() const;

--- a/Quotient/avatar.h
+++ b/Quotient/avatar.h
@@ -16,7 +16,7 @@ class Connection;
 
 class QUOTIENT_API Avatar {
 public:
-    explicit Avatar(Connection* parent, QUrl url = {});
+    explicit Avatar(Connection* parent, const QUrl& url = {});
 
 #ifdef __cpp_lib_move_only_function // AppleClang 15 doesn't have it
     using get_callback_t = std::move_only_function<void()>;

--- a/Quotient/avatar.h
+++ b/Quotient/avatar.h
@@ -31,9 +31,12 @@ public:
     QFuture<QUrl> upload(const QString& fileName) const;
     QFuture<QUrl> upload(QIODevice* source) const;
 
+    bool isEmpty() const;
     QString mediaId() const;
     QUrl url() const;
     bool updateUrl(const QUrl& newUrl);
+
+    static bool isUrlValid(const QUrl& u);
 
 private:
     class Private;

--- a/Quotient/connection.cpp
+++ b/Quotient/connection.cpp
@@ -1082,7 +1082,7 @@ Avatar& Connection::userAvatar(const QString& avatarMediaId)
 Avatar& Connection::userAvatar(const QUrl& avatarUrl)
 {
     const auto mediaId = avatarUrl.authority() + avatarUrl.path();
-    return d->userAvatarMap.try_emplace(mediaId, avatarUrl).first->second;
+    return d->userAvatarMap.try_emplace(mediaId, this, avatarUrl).first->second;
 }
 
 QString Connection::deviceId() const { return d->data->deviceId(); }

--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -630,8 +630,8 @@ QImage Room::avatar(int width, int height)
     // Use the first (excluding self) user's avatar for direct chats
     for (const auto dcMembers = directChatMembers(); const auto& m : dcMembers)
         if (m != localMember())
-            return memberAvatar(m.id()).get(connection(), width, height,
-                                            [this] { emit avatarChanged(); });
+            return m.avatarObject().get(connection(), width, height,
+                                        [this] { emit avatarChanged(); });
 
     return {};
 }
@@ -1754,13 +1754,24 @@ Room::Private::moveEventsToTimeline(RoomEventsRange events,
     return Timeline::size_type(insertedSize);
 }
 
-const Avatar& Room::memberAvatar(const QString& memberId) const
+const Avatar& Room::memberAvatarObject(const QString& memberId) const
 {
     return connection()->userAvatar(member(memberId).avatarUrl());
 }
 
-Room::Changes Room::Private::updateStatsFromSyncData(const SyncRoomData& data,
-                                                     bool fromCache)
+QImage Room::memberAvatar(const QString& memberId, int width, int height)
+{
+    return member(memberId).avatar(width, height, [this, memberId] {
+        emit memberAvatarUpdated(member(memberId));
+    });
+}
+
+QImage Room::memberAvatar(const QString& memberId, int dimension)
+{
+    return memberAvatar(memberId, dimension, dimension);
+}
+
+Room::Changes Room::Private::updateStatsFromSyncData(const SyncRoomData& data, bool fromCache)
 {
     Changes changes {};
     if (fromCache) {

--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -85,6 +85,7 @@ public:
         : connection(c)
         , id(std::move(id_))
         , joinState(initialJoinState)
+        , avatar(c)
     {}
 
     Room* q = nullptr;
@@ -624,14 +625,12 @@ QImage Room::avatar(int dimension) { return avatar(dimension, dimension); }
 QImage Room::avatar(int width, int height)
 {
     if (!d->avatar.url().isEmpty())
-        return d->avatar.get(connection(), width, height,
-                             [this] { emit avatarChanged(); });
+        return d->avatar.get(width, height, [this] { emit avatarChanged(); });
 
     // Use the first (excluding self) user's avatar for direct chats
     for (const auto dcMembers = directChatMembers(); const auto& m : dcMembers)
         if (m != localMember())
-            return m.avatarObject().get(connection(), width, height,
-                                        [this] { emit avatarChanged(); });
+            return m.avatarObject().get(width, height, [this] { emit avatarChanged(); });
 
     return {};
 }

--- a/Quotient/room.h
+++ b/Quotient/room.h
@@ -332,7 +332,19 @@ public:
     //! Check whether a user with the given id is a member of the room
     Q_INVOKABLE bool isMember(const QString& userId) const;
 
-    const Avatar& memberAvatar(const QString& memberId) const;
+    const Avatar& memberAvatarObject(const QString& memberId) const;
+
+    //! \brief Get a avatar of the specified dimensions
+    //!
+    //! This always returns immediately; if there's no avatar cached yet, the call triggers
+    //! a network request, that will emit Room::memberAvatarUpdated() once completed.
+    //! \return a pixmap with the avatar or a placeholder if there's none available yet
+    Q_INVOKABLE QImage memberAvatar(const QString& memberId, int width, int height);
+
+    //! \brief Get a square avatar of the specified size
+    //!
+    //! This is an overload for the case when the needed width and height are equal.
+    Q_INVOKABLE QImage memberAvatar(const QString& memberId, int dimension);
 
     const Timeline& messageEvents() const;
     const PendingEvents& pendingEvents() const;

--- a/Quotient/roommember.cpp
+++ b/Quotient/roommember.cpp
@@ -133,12 +133,12 @@ int RoomMember::powerLevel() const
     return _room->memberEffectivePowerLevel(id());
 }
 
-QImage RoomMember::avatar(int width, int height, Avatar::get_callback_t callback)
+QImage RoomMember::avatar(int width, int height, Avatar::get_callback_t callback) const
 {
     return avatarObject().get(width, height, std::move(callback));
 }
 
-QImage RoomMember::avatar(int dimension, Avatar::get_callback_t callback)
+QImage RoomMember::avatar(int dimension, Avatar::get_callback_t callback) const
 {
     return avatar(dimension, dimension, std::move(callback));
 }

--- a/Quotient/roommember.cpp
+++ b/Quotient/roommember.cpp
@@ -135,12 +135,12 @@ int RoomMember::powerLevel() const
 
 QImage RoomMember::avatar(int width, int height, Avatar::get_callback_t callback)
 {
-    return avatarObject().get(_room->connection(), width, height, callback);
+    return avatarObject().get(width, height, std::move(callback));
 }
 
 QImage RoomMember::avatar(int dimension, Avatar::get_callback_t callback)
 {
-    return avatar(dimension, dimension, callback);
+    return avatar(dimension, dimension, std::move(callback));
 }
 
 namespace {

--- a/Quotient/roommember.cpp
+++ b/Quotient/roommember.cpp
@@ -108,7 +108,7 @@ QUrl getMediaId(const RoomMemberEvent* evt)
     else if (evt->prevContent() && evt->prevContent()->avatarUrl)
         baseUrl = *evt->prevContent()->avatarUrl;
 
-    return baseUrl.isEmpty() || baseUrl.scheme() != "mxc"_L1 ? QUrl() : baseUrl;
+    return Avatar::isUrlValid(baseUrl) ? baseUrl : QUrl();
 }
 }
 
@@ -121,8 +121,8 @@ QUrl RoomMember::avatarUrl() const {
     if (isEmpty())
         return {};
 
-    const auto mediaUrl = _room->connection()->makeMediaUrl(getMediaId(_member));
-    return mediaUrl.isValid() && mediaUrl.scheme() == "mxc"_L1 ? mediaUrl : QUrl();
+    const auto mediaId = getMediaId(_member);
+    return mediaId.isValid() ? _room->connection()->makeMediaUrl(mediaId) : QUrl();
 }
 
 int RoomMember::powerLevel() const

--- a/Quotient/roommember.cpp
+++ b/Quotient/roommember.cpp
@@ -93,6 +93,11 @@ QColor RoomMember::color() const
     return QColor::fromHslF(static_cast<float>(hueF()), 1.0f, -0.7f * lightness + 0.9f, 1.0f);
 }
 
+const Avatar& RoomMember::avatarObject() const
+{
+    return _room->connection()->userAvatar(avatarUrl());
+}
+
 namespace {
 QUrl getMediaId(const RoomMemberEvent* evt)
 {
@@ -126,6 +131,16 @@ int RoomMember::powerLevel() const
         return std::numeric_limits<int>::min();
     }
     return _room->memberEffectivePowerLevel(id());
+}
+
+QImage RoomMember::avatar(int width, int height, Avatar::get_callback_t callback)
+{
+    return avatarObject().get(_room->connection(), width, height, callback);
+}
+
+QImage RoomMember::avatar(int dimension, Avatar::get_callback_t callback)
+{
+    return avatar(dimension, dimension, callback);
 }
 
 namespace {

--- a/Quotient/roommember.h
+++ b/Quotient/roommember.h
@@ -199,9 +199,9 @@ public:
     //! This can be empty if none set.
     QUrl avatarUrl() const;
 
-    QImage avatar(int width, int height, Avatar::get_callback_t callback);
+    QImage avatar(int width, int height, Avatar::get_callback_t callback) const;
 
-    QImage avatar(int dimension, Avatar::get_callback_t callback);
+    QImage avatar(int dimension, Avatar::get_callback_t callback) const;
 
     //! \brief The power level of the member.
     //!

--- a/Quotient/roommember.h
+++ b/Quotient/roommember.h
@@ -5,6 +5,7 @@
 
 #include "quotient_common.h"
 #include "uri.h"
+#include "avatar.h"
 
 #include <QtCore/QObject>
 
@@ -186,6 +187,8 @@ public:
     //! for the methodology.
     QColor color() const;
 
+    const Avatar& avatarObject() const;
+
     //! \brief The mxc URL as a string for the user avatar in the room
     //!
     //! This can be empty if none set.
@@ -193,8 +196,12 @@ public:
 
     //! \brief The mxc URL for the user avatar in the room
     //!
-    //!This can be empty if none set.
+    //! This can be empty if none set.
     QUrl avatarUrl() const;
+
+    QImage avatar(int width, int height, Avatar::get_callback_t callback);
+
+    QImage avatar(int dimension, Avatar::get_callback_t callback);
 
     //! \brief The power level of the member.
     //!

--- a/Quotient/user.cpp
+++ b/Quotient/user.cpp
@@ -129,7 +129,7 @@ bool User::setAvatar(const QString& fileName)
 {
     auto ft = connection()
                   ->userAvatar(d->defaultAvatarUrl)
-                  .upload(connection(), fileName)
+                  .upload(fileName)
                   .then(std::bind_front(&User::doSetAvatar, this));
     // The return value only says whether the upload has started; the subsequent url setting job
     // will only start after the upload completes
@@ -140,7 +140,7 @@ bool User::setAvatar(QIODevice* source)
 {
     auto ft = connection()
                   ->userAvatar(d->defaultAvatarUrl)
-                  .upload(connection(), source)
+                  .upload(source)
                   .then(std::bind_front(&User::doSetAvatar, this));
     // The return value only says whether the upload has started; the subsequent url setting job
     // will only start after the upload completes

--- a/Quotient/user.cpp
+++ b/Quotient/user.cpp
@@ -113,11 +113,23 @@ void User::rename(const QString& newName, Room* r)
         << "Attempt to rename a non-member in a room context - ignored";
 }
 
+Avatar& User::avatarObject() { return connection()->userAvatar(avatarUrl()); }
+
+QImage User::avatar(int width, int height, Avatar::get_callback_t callback)
+{
+    return avatarObject().get(width, height, std::move(callback));
+}
+
+QImage User::avatar(int dimension, Avatar::get_callback_t callback)
+{
+    return avatar(dimension, dimension, std::move(callback));
+}
+
 void User::doSetAvatar(const QUrl& contentUri)
 {
     connection()->callApi<SetAvatarUrlJob>(id(), contentUri).then(this, [this, contentUri] {
         if (contentUri != d->defaultAvatarUrl) {
-            connection()->userAvatar(d->defaultAvatarUrl).updateUrl(contentUri);
+            avatarObject().updateUrl(contentUri);
             emit defaultAvatarChanged();
         } else
             qCWarning(MAIN) << "User" << id() << "already has avatar URL set to"
@@ -127,8 +139,7 @@ void User::doSetAvatar(const QUrl& contentUri)
 
 bool User::setAvatar(const QString& fileName)
 {
-    auto ft = connection()
-                  ->userAvatar(d->defaultAvatarUrl)
+    auto ft = avatarObject()
                   .upload(fileName)
                   .then(std::bind_front(&User::doSetAvatar, this));
     // The return value only says whether the upload has started; the subsequent url setting job
@@ -138,8 +149,7 @@ bool User::setAvatar(const QString& fileName)
 
 bool User::setAvatar(QIODevice* source)
 {
-    auto ft = connection()
-                  ->userAvatar(d->defaultAvatarUrl)
+    auto ft = avatarObject()
                   .upload(source)
                   .then(std::bind_front(&User::doSetAvatar, this));
     // The return value only says whether the upload has started; the subsequent url setting job

--- a/Quotient/user.h
+++ b/Quotient/user.h
@@ -85,6 +85,8 @@ public:
     //! may not work with non-Synapse servers.
     bool isGuest() const;
 
+    Avatar& avatarObject();
+
     //! \brief The default mxc URL as a string for the user avatar
     //!
     //! This can be empty if none set.
@@ -104,6 +106,10 @@ public:
     //!
     //! \sa RoomMember
     QUrl avatarUrl() const;
+
+    QImage avatar(int width, int height, Avatar::get_callback_t callback);
+
+    QImage avatar(int dimension, Avatar::get_callback_t callback);
 
     //! Upload the file and use it as an avatar
     Q_INVOKABLE bool setAvatar(const QString& fileName);


### PR DESCRIPTION
This was sorely missing while I ported Quaternion to libQuotient 0.9. Even though not really accessible from QML (for now at least), `Avatar` objects still do their job well in C++ code.