### PR TITLE
Better power level checking, part 1

### DIFF
--- a/Quotient/events/event.cpp
+++ b/Quotient/events/event.cpp
@@ -8,6 +8,10 @@
 
 #include <QtCore/QJsonDocument>
 
+#if Quotient_VERSION_MAJOR == 0 && Quotient_VERSION_MINOR <= 9
+#include "stateevent.h" // For deprecated isStateEvent(); remove, once Event::isStateEvent() is gone
+#endif
+
 using namespace Quotient;
 
 void AbstractEventMetaType::addDerived(const AbstractEventMetaType* newType)
@@ -53,7 +57,9 @@ const QJsonObject Event::unsignedJson() const
     return fullJson()[UnsignedKey].toObject();
 }
 
+#if Quotient_VERSION_MAJOR == 0 && Quotient_VERSION_MINOR <= 9
 bool Event::isStateEvent() const { return is<StateEvent>(); }
+#endif
 
 void Event::dumpTo(QDebug dbg) const
 {

--- a/Quotient/events/event.h
+++ b/Quotient/events/event.h
@@ -55,6 +55,7 @@ public:
     }
 
     void addDerived(const AbstractEventMetaType* newType);
+    const auto& derivedTypes() const { return _derivedTypes; }
 
     virtual ~AbstractEventMetaType() = default;
 
@@ -69,7 +70,7 @@ protected:
                             Event*& event) const = 0;
 
 private:
-    std::vector<const AbstractEventMetaType*> derivedTypes{};
+    std::vector<const AbstractEventMetaType*> _derivedTypes{};
     Q_DISABLE_COPY_MOVE(AbstractEventMetaType)
 };
 
@@ -146,7 +147,7 @@ private:
             if (EventT::TypeId != type)
                 return false;
         } else {
-            for (const auto& p : derivedTypes) {
+            for (const auto& p : _derivedTypes) {
                 p->doLoadFrom(fullJson, type, event);
                 if (event) {
                     Q_ASSERT(is<EventT>(*event));

--- a/Quotient/events/event.h
+++ b/Quotient/events/event.h
@@ -3,9 +3,12 @@
 
 #pragma once
 
+#include "single_key_value.h"
+
 #include <Quotient/converters.h>
 #include <Quotient/function_traits.h>
-#include "single_key_value.h"
+
+#include <span>
 
 namespace Quotient {
 // === event_ptr_tt<> and basic type casting facilities ===

--- a/Quotient/events/event.h
+++ b/Quotient/events/event.h
@@ -19,6 +19,7 @@ constexpr inline auto TypeKey = "type"_L1;
 constexpr inline auto BodyKey = "body"_L1;
 constexpr inline auto ContentKey = "content"_L1;
 constexpr inline auto SenderKey = "sender"_L1;
+constexpr inline auto UnsignedKey = "unsigned"_L1;
 
 using event_type_t = QLatin1String;
 
@@ -55,7 +56,7 @@ public:
     }
 
     void addDerived(const AbstractEventMetaType* newType);
-    const auto& derivedTypes() const { return _derivedTypes; }
+    auto derivedTypes() const { return std::span(_derivedTypes); }
 
     virtual ~AbstractEventMetaType() = default;
 
@@ -329,10 +330,9 @@ public:
         return dbg;
     }
 
-    // State events are quite special in Matrix; so isStateEvent() is here,
-    // as an exception. For other base events, Event::is<>() and
-    // Quotient::is<>() should be used; don't add is* methods here
-    bool isStateEvent() const;
+#if Quotient_VERSION_MAJOR == 0 && Quotient_VERSION_MINOR <= 9
+    [[deprecated("isStateEvent() has moved to RoomEvent")]] bool isStateEvent() const;
+#endif
 
 protected:
     friend class EventMetaType<Event>; // To access the below constructor

--- a/Quotient/events/roomevent.h
+++ b/Quotient/events/roomevent.h
@@ -14,7 +14,6 @@ constexpr inline auto RoomIdKey = "room_id"_L1;
 constexpr inline auto StateKeyKey = "state_key"_L1;
 constexpr inline auto RedactedCauseKey = "redacted_because"_L1;
 constexpr inline auto RelatesToKey = "m.relates_to"_L1;
-constexpr inline auto UnsignedKey = "unsigned"_L1;
 
 class RedactionEvent;
 class EncryptedEvent;
@@ -48,6 +47,12 @@ public:
 
     //! The transaction_id JSON value for the event.
     QString transactionId() const;
+
+    // State events are special in Matrix; so isStateEvent() and stateKey() are here,
+    // as an exception. For other event types (including base types), Event::is<>() and
+    // Quotient::is<>() should be used
+
+    bool isStateEvent() const;
 
     QString stateKey() const;
 
@@ -88,6 +93,9 @@ private:
 using RoomEventPtr = event_ptr_tt<RoomEvent>;
 using RoomEvents = EventsArray<RoomEvent>;
 using RoomEventsRange = std::ranges::subrange<RoomEvents::iterator>;
+
+//! \brief Determine whether a given event type is that of a state event
+QUOTIENT_API bool isStateEvent(const QString& eventTypeId);
 
 } // namespace Quotient
 Q_DECLARE_METATYPE(Quotient::RoomEvent*)

--- a/Quotient/events/roompowerlevelsevent.cpp
+++ b/Quotient/events/roompowerlevelsevent.cpp
@@ -5,33 +5,36 @@
 
 using namespace Quotient;
 
-// The default values used below are defined in
-// https://spec.matrix.org/v1.3/client-server-api/#mroompower_levels
-PowerLevelsEventContent::PowerLevelsEventContent(const QJsonObject& json) :
-    invite(json["invite"_L1].toInt(50)),
-    kick(json["kick"_L1].toInt(50)),
-    ban(json["ban"_L1].toInt(50)),
-    redact(json["redact"_L1].toInt(50)),
-    events(fromJson<QHash<QString, int>>(json["events"_L1])),
-    eventsDefault(json["events_default"_L1].toInt(0)),
-    stateDefault(json["state_default"_L1].toInt(50)),
-    users(fromJson<QHash<QString, int>>(json["users"_L1])),
-    usersDefault(json["users_default"_L1].toInt(0)),
-    notifications(Notifications{json["notifications"_L1].toObject()["room"_L1].toInt(50)})
-{}
-
-QJsonObject PowerLevelsEventContent::toJson() const
+PowerLevelsEventContent JsonConverter<PowerLevelsEventContent>::load(const QJsonValue& jv)
 {
-    return QJsonObject{ { u"invite"_s, invite },
-                        { u"kick"_s, kick },
-                        { u"ban"_s, ban },
-                        { u"redact"_s, redact },
-                        { u"events"_s, Quotient::toJson(events) },
-                        { u"events_default"_s, eventsDefault },
-                        { u"state_default"_s, stateDefault },
-                        { u"users"_s, Quotient::toJson(users) },
-                        { u"users_default"_s, usersDefault },
-                        { u"notifications"_s, QJsonObject{ { u"room"_s, notifications.room } } } };
+    const auto& jo = jv.toObject();
+    PowerLevelsEventContent c;
+#define FROM_JSON(member) fromJson(jo[toSnakeCase(#member##_L1)], c.member)
+    FROM_JSON(invite);
+    FROM_JSON(kick);
+    FROM_JSON(ban);
+    FROM_JSON(redact);
+    FROM_JSON(events);
+    FROM_JSON(eventsDefault);
+    FROM_JSON(stateDefault);
+    FROM_JSON(users);
+    FROM_JSON(usersDefault);
+    fromJson(jo["notifications"_L1]["room"_L1], c.notifications.room);
+#undef FROM_JSON
+    return c;
+}
+
+QJsonObject JsonConverter<PowerLevelsEventContent>::dump(const PowerLevelsEventContent& c) {
+    return QJsonObject{ { u"invite"_s, c.invite },
+                        { u"kick"_s, c.kick },
+                        { u"ban"_s, c.ban },
+                        { u"redact"_s, c.redact },
+                        { u"events"_s, Quotient::toJson(c.events) },
+                        { u"events_default"_s, c.eventsDefault },
+                        { u"state_default"_s, c.stateDefault },
+                        { u"users"_s, Quotient::toJson(c.users) },
+                        { u"users_default"_s, c.usersDefault },
+                        { u"notifications"_s, QJsonObject{ { u"room"_s, c.notifications.room } } } };
 }
 
 int RoomPowerLevelsEvent::powerLevelForEvent(const QString& eventTypeId) const

--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -3078,8 +3078,7 @@ Room::Changes Room::processStateEvent(const RoomEvent& e)
     Q_ASSERT(result != Change::None);
     // Whatever the outcome, the relevant piece of state should stay valid
     // (the absense of event is a valid state, too)
-    Q_ASSERT(currentState().queryOr(e.matrixType(), e.stateKey(),
-                                    &Event::isStateEvent, true));
+    Q_ASSERT(currentState().queryOr(e.matrixType(), e.stateKey(), &RoomEvent::isStateEvent, true));
     return result;
 }
 

--- a/Quotient/roomstateview.h
+++ b/Quotient/roomstateview.h
@@ -205,6 +205,7 @@ public:
     }
 
 private:
-    friend class Room;
+    friend class Room; // Factory class for RoomStateView
+    using QHash<StateEventKey, const StateEvent*>::QHash;
 };
 } // namespace Quotient


### PR DESCRIPTION
This PR is the first, API-breaking, part of additional facilities to simplify answering a question "am I allowed to do X?". While porting Quaternion to libQuotient 0.9, I thought that it would be great to have something like `Room::canRedact()` - turned out though that actually figuring out whether you can redact a certain event is not that easy to answer (and the spec doesn't seem to be very clear in that part). So I will propose `can*()` methods as an API/ABI-compatible addition after 0.9.0 is out (once I make them right) but here's some groundwork that needs to come in 0.9.0.