### PR TITLE
Can Set State

### DIFF
--- a/Quotient/events/roompowerlevelsevent.cpp
+++ b/Quotient/events/roompowerlevelsevent.cpp
@@ -48,3 +48,13 @@ int RoomPowerLevelsEvent::powerLevelForUser(const QString& userId) const
 {
     return users().value(userId, usersDefault());
 }
+
+bool RoomPowerLevelsEvent::canSendEvent(const QString& eventTypeId, const QString& memberId) const
+{
+    return powerLevelForUser(memberId) >= powerLevelForEvent(eventTypeId);
+}
+
+bool RoomPowerLevelsEvent::canSetState(const QString& eventTypeId, const QString& memberId) const
+{
+    return powerLevelForUser(memberId) >= powerLevelForState(eventTypeId);
+}

--- a/Quotient/events/roompowerlevelsevent.h
+++ b/Quotient/events/roompowerlevelsevent.h
@@ -55,5 +55,11 @@ public:
     int powerLevelForEvent(const QString& eventTypeId) const;
     int powerLevelForState(const QString& eventTypeId) const;
     int powerLevelForUser(const QString& userId) const;
+
+    //! Convenience function to check if the given member ID can set the given event type
+    bool canSendEvent(const QString& eventTypeId, const QString& memberId) const;
+
+    //! Convenience function to check if the given member ID can set the given state event type
+    bool canSetState(const QString& eventTypeId, const QString& memberId) const;
 };
 } // namespace Quotient

--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -2212,6 +2212,32 @@ QString Room::postJson(const QString& matrixType, const QJsonObject& eventConten
     return d->sendEvent(loadEvent<RoomEvent>(matrixType, eventContent))->transactionId();
 }
 
+bool Room::canSendEvent(const QString &eventTypeId, const QString& memberId) const
+{
+    int eventPowerLevel;
+    auto plEvent = currentState().get<RoomPowerLevelsEvent>();
+    if (plEvent == nullptr) {
+        eventPowerLevel = 0;
+    } else {
+        eventPowerLevel = plEvent->powerLevelForEvent(eventTypeId);
+    }
+
+    return memberEffectivePowerLevel(memberId) >= eventPowerLevel;
+}
+
+bool Room::canSetState(const QString &eventTypeId, const QString& memberId) const
+{
+    int statePowerLevel;
+    const auto plEvent = currentState().get<RoomPowerLevelsEvent>();
+    if (plEvent == nullptr) {
+        statePowerLevel = 50;
+    } else {
+        statePowerLevel = plEvent->powerLevelForState(eventTypeId);
+    }
+
+    return memberEffectivePowerLevel(memberId) >= statePowerLevel;
+}
+
 SetRoomStateWithKeyJob* Room::setState(const StateEvent& evt)
 {
     return setState(evt.matrixType(), evt.stateKey(), evt.contentJson());
@@ -2226,25 +2252,40 @@ SetRoomStateWithKeyJob* Room::setState(const QString& evtType,
 
 void Room::setName(const QString& newName)
 {
+    if (!canSetState(RoomNameEvent::TypeId)) {
+        qCWarning(EVENTS) << "You do not have permission to rename the room";
+    }
     setState<RoomNameEvent>(newName);
 }
 
 void Room::setCanonicalAlias(const QString& newAlias)
 {
+    if (!canSetState(RoomCanonicalAliasEvent::TypeId)) {
+        qCWarning(EVENTS) << "You do not have permission to set the room canonical alias";
+    }
     setState<RoomCanonicalAliasEvent>(newAlias, altAliases());
 }
 
 void Room::setPinnedEvents(const QStringList& events)
 {
+    if (canSetState(RoomPinnedEventsEvent::TypeId)) {
+        qCWarning(EVENTS) << "You do not have permission to pin an event in the room";
+    }
     setState<RoomPinnedEventsEvent>(events);
 }
 void Room::setLocalAliases(const QStringList& aliases)
 {
+    if (canSetState(RoomCanonicalAliasEvent::TypeId)) {
+        qCWarning(EVENTS) << "You do not have permission to set room local aliases";
+    }
     setState<RoomCanonicalAliasEvent>(canonicalAlias(), aliases);
 }
 
 void Room::setTopic(const QString& newTopic)
 {
+    if (canSetState(RoomTopicEvent::TypeId)) {
+        qCWarning(EVENTS) << "You do not have permission to set the room topic";
+    }
     setState<RoomTopicEvent>(newTopic);
 }
 
@@ -3455,6 +3496,10 @@ void Room::activateEncryption()
 {
     if(usesEncryption()) {
         qCWarning(E2EE) << "Room" << objectName() << "is already encrypted";
+        return;
+    }
+    if (!canSetState(EncryptionEvent::TypeId)) {
+        qCWarning(E2EE) << "You do not have permission to encrypt the room";
         return;
     }
     setState<EncryptionEvent>(EncryptionType::MegolmV1AesSha2);

--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -2234,7 +2234,7 @@ bool Room::canSetState(const QString &eventTypeId, const QString& memberId) cons
     } else {
         statePowerLevel = plEvent->powerLevelForState(eventTypeId);
     }
-
+    qWarning() <<statePowerLevel << memberEffectivePowerLevel(memberId);
     return memberEffectivePowerLevel(memberId) >= statePowerLevel;
 }
 

--- a/Quotient/room.h
+++ b/Quotient/room.h
@@ -702,6 +702,18 @@ public:
 
     PendingEventItem::future_type whenMessageMerged(QString txnId) const;
 
+    //! True if the given user can send the given event type
+    //!
+    //! \param eventTypedId the Matrix type for the event.
+    //! \param memberId the Matrix ID of the member to check. If blank the local member is used.
+    Q_INVOKABLE bool canSendEvent(const QString &eventTypeId, const QString& memberId = {}) const;
+
+    //! True if the given user can send the given state event type
+    //!
+    //! \param eventTypedId the Matrix type for the event.
+    //! \param memberId the Matrix ID of the member to check. If blank the local member is used.
+    Q_INVOKABLE bool canSetState(const QString &eventTypeId, const QString& memberId = {}) const;
+
     //! Send a request to update the room state with the given event
     SetRoomStateWithKeyJob* setState(const StateEvent& evt);
 

--- a/Quotient/user.cpp
+++ b/Quotient/user.cpp
@@ -99,6 +99,10 @@ void User::rename(const QString& newName, Room* r)
         rename(newName);
         return;
     }
+    if (!r->canSetState(RoomMemberEvent::TypeId, id())) {
+        qCWarning(MAIN) << "You do not have permission is rename" << id();
+        return;
+    }
     // #481: take the current state and update it with the new name
     if (const auto& maybeEvt = r->currentState().get<RoomMemberEvent>(id())) {
         auto content = maybeEvt->content();

--- a/autotests/testolmaccount.cpp
+++ b/autotests/testolmaccount.cpp
@@ -457,6 +457,7 @@ void TestOlmAccount::enableEncryption()
         QThread::sleep(100);
     }
     auto room = alice->rooms(JoinState::Join)[0];
+    qWarning() << room->memberEffectivePowerLevel(alice->userId());
     room->activateEncryption();
     QSignalSpy encryptionSpy(room, &Room::encryption);
     QVERIFY(encryptionSpy.wait(10000));


### PR DESCRIPTION
Upstream canSetState and canSendEvent from NeoChat and use to check before setting state to avoid pinging the server with no chance of success.