### PR TITLE
Rework enableEncryption test to be less timing dependent

### DIFF
--- a/autotests/testolmaccount.cpp
+++ b/autotests/testolmaccount.cpp
@@ -451,9 +451,6 @@ void TestOlmAccount::enableEncryption()
     auto job = alice->createRoom(Connection::PublishRoom, {}, {}, {}, {});
     QVERIFY(createRoomSpy.wait(10000));
 
-    while(alice->roomsCount(JoinState::Join) == 0) {
-        QThread::sleep(100);
-    }
     auto room = alice->rooms(JoinState::Join)[0];
     QSignalSpy encryptionSpy(room, &Room::encryption);
     room->activateEncryption();

--- a/autotests/testolmaccount.cpp
+++ b/autotests/testolmaccount.cpp
@@ -445,20 +445,18 @@ void TestOlmAccount::claimMultipleKeys()
 void TestOlmAccount::enableEncryption()
 {
     CREATE_CONNECTION(alice, "alice9"_L1, "secret"_L1, "AlicePhone"_L1)
+    alice->syncLoop();
 
+    QSignalSpy createRoomSpy(alice.get(), &Connection::loadedRoomState);
     auto job = alice->createRoom(Connection::PublishRoom, {}, {}, {}, {});
-    QSignalSpy createRoomSpy(job, &BaseJob::success);
     QVERIFY(createRoomSpy.wait(10000));
-    alice->sync();
-    connect(alice.get(), &Connection::syncDone, this, [alice](){
-        alice->sync();
-    });
+
     while(alice->roomsCount(JoinState::Join) == 0) {
         QThread::sleep(100);
     }
     auto room = alice->rooms(JoinState::Join)[0];
-    room->activateEncryption();
     QSignalSpy encryptionSpy(room, &Room::encryption);
+    room->activateEncryption();
     QVERIFY(encryptionSpy.wait(10000));
     QVERIFY(room->usesEncryption());
 }


### PR DESCRIPTION
So after failing the `enableEncryption` test in #800 I had a deeper look at the test. What was happening was that we were creating a room but were not waiting for the room state to be synced down. This meant that when we tried to check user power levels there were no state events available to get the user's power level and also no creation event so  it defaulted to 0.

In fact with the way the test was laid out it was pretty timing dependent. I.e. the manual syncs managed to happen after the encryption was activated.

This reworks a little so that the connection sync loop is activated then we just wait on first the room base state loading, then the encryption signal coming through.