### PR TITLE
Reply to All RoomMessageEvents

### DIFF
--- a/Quotient/events/eventrelation.cpp
+++ b/Quotient/events/eventrelation.cpp
@@ -17,7 +17,7 @@ void JsonObjectConverter<EventRelation>::dumpTo(QJsonObject& jo,
     }
 
     if (pod.type == EventRelation::ReplyType) {
-        jo.insert(EventRelation::ReplyType, {QJsonObject{{EventIdKey, pod.eventId}}});
+        jo.insert(EventRelation::ReplyType, QJsonObject{{EventIdKey, pod.eventId}});
         return;
     }
 
@@ -26,7 +26,7 @@ void JsonObjectConverter<EventRelation>::dumpTo(QJsonObject& jo,
     if (pod.type == EventRelation::AnnotationType)
         jo.insert("key"_L1, pod.key);
     if (pod.type == EventRelation::ThreadType) {
-        jo.insert(EventRelation::ReplyType, {QJsonObject{{EventIdKey, pod.inThreadReplyEventId}}});
+        jo.insert(EventRelation::ReplyType, QJsonObject{{EventIdKey, pod.inThreadReplyEventId}});
         jo.insert(IsFallingBackKey, pod.isFallingBack);
     }
 }

--- a/Quotient/events/eventrelation.cpp
+++ b/Quotient/events/eventrelation.cpp
@@ -17,7 +17,7 @@ void JsonObjectConverter<EventRelation>::dumpTo(QJsonObject& jo,
     }
 
     if (pod.type == EventRelation::ReplyType) {
-        jo.insert(EventRelation::ReplyType, {{EventIdKey, pod.eventId}});
+        jo.insert(EventRelation::ReplyType, {QJsonObject{{EventIdKey, pod.eventId}}});
         return;
     }
 
@@ -26,9 +26,9 @@ void JsonObjectConverter<EventRelation>::dumpTo(QJsonObject& jo,
     if (pod.type == EventRelation::AnnotationType)
         jo.insert("key"_L1, pod.key);
     if (pod.type == EventRelation::ThreadType) {
-        jo.insert(EventRelation::ReplyType, {{EventIdKey, pod.inThreadReplyEventId}});
+        jo.insert(EventRelation::ReplyType, {QJsonObject{{EventIdKey, pod.inThreadReplyEventId}}});
+        jo.insert(IsFallingBackKey, pod.isFallingBack);
     }
-    jo.insert(IsFallingBackKey, pod.isFallingBack);
 }
 
 void JsonObjectConverter<EventRelation>::fillFrom(const QJsonObject& jo,

--- a/Quotient/events/roommessageevent.cpp
+++ b/Quotient/events/roommessageevent.cpp
@@ -154,9 +154,7 @@ RoomMessageEvent::RoomMessageEvent(const QJsonObject& obj)
             return;
         }
 
-        if (content.contains(RelatesToKey)) {
-            _relatesTo = fromJson<std::optional<EventRelation>>(content[RelatesToKey]);
-        }
+        fromJson(content[RelatesToKey], _relatesTo);
     } else {
         qCWarning(EVENTS) << "No body or msgtype in room message event";
         qCWarning(EVENTS) << formatJson << obj;

--- a/Quotient/events/roommessageevent.cpp
+++ b/Quotient/events/roommessageevent.cpp
@@ -220,7 +220,7 @@ QString RoomMessageEvent::replacedEvent() const
 
 bool RoomMessageEvent::isReplaced() const
 {
-    return unsignedPart<QJsonObject>("m.relations"_L1).contains("m.replace"_L1);"format"_L1
+    return unsignedPart<QJsonObject>("m.relations"_L1).contains("m.replace"_L1);
 }
 
 QString RoomMessageEvent::replacedBy() const

--- a/Quotient/events/roommessageevent.h
+++ b/Quotient/events/roommessageevent.h
@@ -34,10 +34,12 @@ public:
     };
 
     RoomMessageEvent(const QString& plainBody, const QString& jsonMsgType,
-                     EventContent::TypedBase* content = nullptr);
+                     EventContent::TypedBase* content = nullptr,
+                     std::optional<EventRelation> relatesTo = std:: nullopt);
     explicit RoomMessageEvent(const QString& plainBody,
                               MsgType msgType = MsgType::Text,
-                              EventContent::TypedBase* content = nullptr);
+                              EventContent::TypedBase* content = nullptr,
+                              std::optional<EventRelation> relatesTo = std:: nullopt);
 
     explicit RoomMessageEvent(const QJsonObject& obj);
 
@@ -48,7 +50,7 @@ public:
     void editContent(auto visitor)
     {
         visitor(*_content);
-        editJson()[ContentKey] = assembleContentJson(plainBody(), rawMsgtype(), _content.get());
+        editJson()[ContentKey] = assembleContentJson(plainBody(), rawMsgtype(), _content.get(), _relatesTo);
     }
     QMimeType mimeType() const;
     //! \brief Determine whether the message has text content
@@ -141,11 +143,13 @@ public:
 
 private:
     std::unique_ptr<EventContent::TypedBase> _content;
+    std::optional<EventRelation> _relatesTo;
 
     // FIXME: should it really be static?
     static QJsonObject assembleContentJson(const QString& plainBody,
                                            const QString& jsonMsgType,
-                                           EventContent::TypedBase* content);
+                                           EventContent::TypedBase* content,
+                                           std::optional<EventRelation> relatesTo);
 
     Q_ENUM(MsgType)
 };
@@ -164,15 +168,13 @@ namespace EventContent {
      */
     class QUOTIENT_API TextContent : public TypedBase {
     public:
-        TextContent(QString text, const QString& contentType,
-                    std::optional<EventRelation> relatesTo = {});
+        TextContent(QString text, const QString& contentType);
         explicit TextContent(const QJsonObject& json);
 
         QMimeType type() const override { return mimeType; }
 
         QMimeType mimeType;
         QString body;
-        std::optional<EventRelation> relatesTo;
 
     protected:
         void fillJson(QJsonObject& json) const override;


### PR DESCRIPTION
As of v1.3 of the spec any RoomMessageEvent can be used to reply to another. This moves the EventRelation out of text content and  makes it a part of RoomMessageEvent itself.

This is part 1 which is just reworking the API in RoomMessageEvent, there will be further follow up to hook it up so that you can add an EventRelation to all the helpers for sending RoomMessageEvents in Room.

This also fixes a couple of cock ups in the dump to functions from my last commit.