### PR TITLE
RoomMessageEvent content save

### DIFF
--- a/Quotient/eventitem.cpp
+++ b/Quotient/eventitem.cpp
@@ -14,9 +14,9 @@ void PendingEventItem::setFileUploaded(const FileSourceInfo& uploadedFileData)
     // and unify the code below.
     if (auto* rme = getAs<RoomMessageEvent>()) {
         Q_ASSERT(rme->hasFileContent());
-        rme->editContent([&uploadedFileData](EventContent::TypedBase& ec) {
-            ec.fileInfo()->source = uploadedFileData;
-        });
+        auto fc = rme->fileContent();
+        fc->source = uploadedFileData;
+        rme->setContent(std::move(fc));
     }
     if (auto* rae = getAs<RoomAvatarEvent>()) {
         Q_ASSERT(rae->content().fileInfo());

--- a/Quotient/events/roommessageevent.cpp
+++ b/Quotient/events/roommessageevent.cpp
@@ -140,11 +140,10 @@ RoomMessageEvent::RoomMessageEvent(const QJsonObject& obj)
         return;
     }
 
-    if (auto it = std::ranges::find(msgTypes, content[MsgTypeKey].toString(), &MsgTypeDesc::matrixType); it != msgTypes.cend()) {
-        return;
+    if (auto it = std::ranges::find(msgTypes, content[MsgTypeKey].toString(), &MsgTypeDesc::matrixType); it == msgTypes.cend()) {
+        qCWarning(EVENTS) << "RoomMessageEvent: unknown msgtype, full content dump follows";
+        qCWarning(EVENTS) << formatJson << content;
     }
-    qCWarning(EVENTS) << "RoomMessageEvent: unknown msgtype, full content dump follows";
-    qCWarning(EVENTS) << formatJson << content;
 }
 
 RoomMessageEvent::MsgType RoomMessageEvent::msgtype() const
@@ -198,7 +197,7 @@ bool RoomMessageEvent::hasTextContent() const
                || msgtype() == MsgType::Notice);
 }
 
-std::unique_ptr<TextContent> RoomMessageEvent::textContent() const
+std::unique_ptr<TextContent> RoomMessageEvent::richTextContent() const
 {
     if (!hasTextContent() || !content()) {
         return {};
@@ -256,7 +255,8 @@ QString RoomMessageEvent::replacedEvent() const
     if (!content() || !hasTextContent())
         return {};
 
-    return isReplacement(relatesTo()) ? relatesTo()->eventId : QString();
+    const auto er = relatesTo();
+    return isReplacement(er) ? er->eventId : QString();
 }
 
 bool RoomMessageEvent::isReplaced() const

--- a/Quotient/events/roommessageevent.h
+++ b/Quotient/events/roommessageevent.h
@@ -55,11 +55,9 @@ public:
     //! \return an EventContent object if the event has content, nullptr otherwise.
     std::unique_ptr<EventContent::TypedBase> content() const;
 
-    void editContent(auto visitor)
-    {
-        visitor(*content());
-        editJson()[ContentKey] = assembleContentJson(plainBody(), rawMsgtype(), content().get(), relatesTo());
-    }
+    //! Update the message JSON with the given content.
+    void setContent(std::unique_ptr<EventContent::TypedBase> content);
+
     QMimeType mimeType() const;
 
     //! \brief Determine whether the message has text content
@@ -72,7 +70,7 @@ public:
     //! \brief Get the TextContent object for the event
     //!
     //! \return A TextContent object if the message has one; std::nullopt otherwise.
-    std::optional<EventContent::TextContent> textContent() const;
+    std::unique_ptr<EventContent::TextContent> textContent() const;
 
     //! \brief Determine whether the message has a file/attachment
     //!
@@ -83,7 +81,7 @@ public:
     //! \brief Get the FileContent object for the event
     //!
     //! \return A FileContent object if the message has one; std::nullopt otherwise.
-    std::optional<EventContent::FileContent> fileContent() const;
+    std::unique_ptr<EventContent::FileContent> fileContent() const;
 
     //! \brief Determine whether the message has a thumbnail
     //!
@@ -102,7 +100,7 @@ public:
     //! \brief Get the LocationContent object for the event
     //!
     //! \return A LocationContent object if the message has one; std::nullopt otherwise.
-    std::optional<EventContent::LocationContent> locationContent() const;
+    std::unique_ptr<EventContent::LocationContent> locationContent() const;
 
     //! \brief The EventRelation for this event.
     //!

--- a/Quotient/events/roommessageevent.h
+++ b/Quotient/events/roommessageevent.h
@@ -70,7 +70,7 @@ public:
     //! \brief Get the TextContent object for the event
     //!
     //! \return A TextContent object if the message has one; std::nullopt otherwise.
-    std::unique_ptr<EventContent::TextContent> textContent() const;
+    std::unique_ptr<EventContent::TextContent> richTextContent() const;
 
     //! \brief Determine whether the message has a file/attachment
     //!

--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -1743,7 +1743,7 @@ Room::Private::moveEventsToTimeline(RoomEventsRange events,
         eventsIndex.insert(eId, index);
         if (usesEncryption)
             if (auto* const rme = ti.viewAs<RoomMessageEvent>())
-                if (auto* const content = rme->content())
+                if (const auto content = rme->content())
                     if (auto* const fileInfo = content->fileInfo())
                         if (auto* const efm = std::get_if<EncryptedFileMetadata>(
                                 &fileInfo->source))

--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -1743,11 +1743,11 @@ Room::Private::moveEventsToTimeline(RoomEventsRange events,
         eventsIndex.insert(eId, index);
         if (usesEncryption)
             if (auto* const rme = ti.viewAs<RoomMessageEvent>())
-                if (const auto content = rme->content())
-                    if (auto* const fileInfo = content->fileInfo())
-                        if (auto* const efm = std::get_if<EncryptedFileMetadata>(
-                                &fileInfo->source))
-                            FileMetadataMap::add(id, eId, *efm);
+                if (const auto fileInfo = rme->fileContent()) {
+                    if (auto* const efm = std::get_if<EncryptedFileMetadata>(
+                            &fileInfo->source))
+                        FileMetadataMap::add(id, eId, *efm);
+                }
 
         if (auto n = q->checkForNotifications(ti); n.type != Notification::None)
             notifications.insert(eId, n);


### PR DESCRIPTION
Don't save the content or relates to structs in the RoomMessageEvent and just generate as required.

This also cleans up the code moving all content objefcts to EventContent and additional helpers to grab text, file or loaction content if you know it's what you need are added.