### PR TITLE
Fixes before 0.9 RC2

### DIFF
--- a/Quotient/csapi/profile.cpp
+++ b/Quotient/csapi/profile.cpp
@@ -21,7 +21,7 @@ QUrl GetDisplayNameJob::makeRequestUrl(const HomeserverData& hsData, const QStri
 
 GetDisplayNameJob::GetDisplayNameJob(const QString& userId)
     : BaseJob(HttpVerb::Get, u"GetDisplayNameJob"_s,
-              makePath("/_matrix/client/v3", "/profile/", userId, "/displayname"), false)
+              makePath("/_matrix/client/v3", "/profile/", userId, "/displayname"))
 {}
 
 SetAvatarUrlJob::SetAvatarUrlJob(const QString& userId, const QUrl& avatarUrl)
@@ -41,7 +41,7 @@ QUrl GetAvatarUrlJob::makeRequestUrl(const HomeserverData& hsData, const QString
 
 GetAvatarUrlJob::GetAvatarUrlJob(const QString& userId)
     : BaseJob(HttpVerb::Get, u"GetAvatarUrlJob"_s,
-              makePath("/_matrix/client/v3", "/profile/", userId, "/avatar_url"), false)
+              makePath("/_matrix/client/v3", "/profile/", userId, "/avatar_url"))
 {}
 
 QUrl GetUserProfileJob::makeRequestUrl(const HomeserverData& hsData, const QString& userId)
@@ -51,5 +51,5 @@ QUrl GetUserProfileJob::makeRequestUrl(const HomeserverData& hsData, const QStri
 
 GetUserProfileJob::GetUserProfileJob(const QString& userId)
     : BaseJob(HttpVerb::Get, u"GetUserProfileJob"_s,
-              makePath("/_matrix/client/v3", "/profile/", userId), false)
+              makePath("/_matrix/client/v3", "/profile/", userId))
 {}

--- a/Quotient/eventitem.cpp
+++ b/Quotient/eventitem.cpp
@@ -10,8 +10,6 @@ using namespace Quotient;
 
 void PendingEventItem::setFileUploaded(const FileSourceInfo& uploadedFileData)
 {
-    // TODO: eventually we might introduce hasFileContent to RoomEvent,
-    // and unify the code below.
     if (auto* rme = getAs<RoomMessageEvent>()) {
         Q_ASSERT(rme->hasFileContent());
         auto fc = rme->fileContent();
@@ -19,7 +17,6 @@ void PendingEventItem::setFileUploaded(const FileSourceInfo& uploadedFileData)
         rme->setContent(std::move(fc));
     }
     if (auto* rae = getAs<RoomAvatarEvent>()) {
-        Q_ASSERT(rae->content().fileInfo());
         rae->editContent([&uploadedFileData](EventContent::FileInfo& fi) {
             fi.source = uploadedFileData;
         });

--- a/Quotient/events/event.h
+++ b/Quotient/events/event.h
@@ -474,19 +474,17 @@ public:
 /// To retrieve the value the getter uses a JSON key name that corresponds to
 /// its own (getter's) name but written in snake_case. \p GetterName_ must be
 /// in camelCase, no quotes (an identifier, not a literal).
-#define DEFINE_SIMPLE_EVENT(Name_, Base_, TypeId_, ValueType_, GetterName_,  \
-                            JsonKey_)                                        \
-    constexpr inline auto Name_##ContentKey = JsonKey_##_L1;                 \
-    class QUOTIENT_API Name_                                                 \
-        : public EventTemplate<                                              \
-              Name_, Base_,                                                  \
-              EventContent::SingleKeyValue<ValueType_, Name_##ContentKey>> { \
-    public:                                                                  \
-        QUO_EVENT(Name_, TypeId_)                                            \
-        using value_type = ValueType_;                                       \
-        using EventTemplate::EventTemplate;                                  \
-        QUO_CONTENT_GETTER_X(ValueType_, GetterName_, Name_##ContentKey)     \
-    };                                                                       \
+#define DEFINE_SIMPLE_EVENT(Name_, Base_, TypeId_, ValueType_, GetterName_, JsonKey_)      \
+    constexpr inline auto Name_##ContentKey = JsonKey_##_L1;                               \
+    class QUOTIENT_API Name_                                                               \
+        : public ::Quotient::EventTemplate<                                                \
+              Name_, Base_, EventContent::SingleKeyValue<ValueType_, Name_##ContentKey>> { \
+    public:                                                                                \
+        QUO_EVENT(Name_, TypeId_)                                                          \
+        using value_type = ValueType_;                                                     \
+        using EventTemplate::EventTemplate;                                                \
+        QUO_CONTENT_GETTER_X(ValueType_, GetterName_, Name_##ContentKey)                   \
+    };                                                                                     \
     // End of macro
 
 // === is<>(), eventCast<>() and switchOnType<>() ===

--- a/Quotient/events/simplestateevents.h
+++ b/Quotient/events/simplestateevents.h
@@ -9,18 +9,16 @@
 
 namespace Quotient {
 
-#define DEFINE_SIMPLE_STATE_EVENT(Name_, TypeId_, ValueType_, GetterName_,   \
-                                  JsonKey_)                                  \
-    constexpr inline auto Name_##Key = JsonKey_##_L1;                        \
-    class QUOTIENT_API Name_                                                 \
-        : public KeylessStateEventBase<                                      \
-              Name_, EventContent::SingleKeyValue<ValueType_, Name_##Key>> { \
-    public:                                                                  \
-        using value_type = ValueType_;                                       \
-        QUO_EVENT(Name_, TypeId_)                                            \
-        using KeylessStateEventBase::KeylessStateEventBase;                  \
-        auto GetterName_() const { return content().value; }                 \
-    };                                                                       \
+#define DEFINE_SIMPLE_STATE_EVENT(Name_, TypeId_, ValueType_, GetterName_, JsonKey_)              \
+    constexpr inline auto Name_##Key = JsonKey_##_L1;                                             \
+    class QUOTIENT_API Name_ : public ::Quotient::KeylessStateEventBase<                          \
+                                   Name_, EventContent::SingleKeyValue<ValueType_, Name_##Key>> { \
+    public:                                                                                       \
+        using value_type = ValueType_;                                                            \
+        QUO_EVENT(Name_, TypeId_)                                                                 \
+        using KeylessStateEventBase::KeylessStateEventBase;                                       \
+        auto GetterName_() const { return content().value; }                                      \
+    };                                                                                            \
     // End of macro
 
 DEFINE_SIMPLE_STATE_EVENT(RoomNameEvent, "m.room.name", QString, name, "name")

--- a/Quotient/room.h
+++ b/Quotient/room.h
@@ -721,6 +721,9 @@ public:
         return post(makeEvent<EvT>(std::forward<ArgTs>(args)...));
     }
 
+    QString postFile(const QString& plainText,
+                     std::unique_ptr<EventContent::FileContentBase> fileContent);
+
     PendingEventItem::future_type whenMessageMerged(QString txnId) const;
 
     //! Send a request to update the room state with the given event
@@ -753,8 +756,6 @@ public Q_SLOTS:
     QString postHtmlText(const QString& plainText, const QString& html);
     /// Send a reaction on a given event with a given key
     QString postReaction(const QString& eventId, const QString& key);
-
-    QString postFile(const QString& plainText, EventContent::TypedBase* content);
 
     /** Post a pre-created room message event
      *

--- a/Quotient/util.h
+++ b/Quotient/util.h
@@ -58,7 +58,7 @@ namespace _impl {
 //! input was QChar/u16-based, it creates a temporary buffer to store the UTF-8 representation that
 //! is destroyed once the statement containing QUO_CSTR() is done (therefore, ALWAYS copy the result
 //! based on QUO_CSTR() contents if you need to store it).
-#define QUO_CSTR(StringConvertible_) std::data(_impl::toUtf8(StringConvertible_))
+#define QUO_CSTR(StringConvertible_) std::data(::Quotient::_impl::toUtf8(StringConvertible_))
 
 inline bool alarmX(bool alarmCondition, const auto& msg,
                    [[maybe_unused]] std::source_location loc = std::source_location::current())
@@ -80,12 +80,13 @@ inline bool alarmX(bool alarmCondition, const auto& msg,
 //! if \p AlarmCondition holds, not the other way around.
 //!
 //! This macro is a trivial wrapper around alarmX(), provided for API uniformity with QUO_ALARM()
-#define QUO_ALARM_X(...) alarmX(__VA_ARGS__)
+#define QUO_ALARM_X(...) ::Quotient::alarmX(__VA_ARGS__)
 
-#define QUO_ALARM(...) alarmX((__VA_ARGS__) ? true : false, "Alarm: " #__VA_ARGS__)
+#define QUO_ALARM(...) ::Quotient::alarmX((__VA_ARGS__) ? true : false, "Alarm: " #__VA_ARGS__)
 
 //! Evaluate the boolean expression and, in Debug mode, assert it to be true
-#define QUO_CHECK(...) !alarmX(!(__VA_ARGS__) ? true : false, "Failing expression: " #__VA_ARGS__)
+#define QUO_CHECK(...) \
+    !::Quotient::alarmX(!(__VA_ARGS__) ? true : false, "Failing expression: " #__VA_ARGS__)
 
 #if Quotient_VERSION_MAJOR == 0 && Quotient_VERSION_MINOR < 10
 /// This is only to make UnorderedMap alias work until we get rid of it

--- a/autotests/testolmaccount.cpp
+++ b/autotests/testolmaccount.cpp
@@ -429,7 +429,7 @@ void TestOlmAccount::enableEncryption()
                                 });
     QVERIFY(waitForFuture(futureRoom));
     alice->syncLoop();
-    QVERIFY(QTest::qWaitFor([room = futureRoom.result()] { return room->usesEncryption(); }, 20000));
+    QVERIFY(QTest::qWaitFor([room = futureRoom.result()] { return room->usesEncryption(); }, 40000));
 }
 
 QTEST_GUILESS_MAIN(TestOlmAccount)

--- a/quotest/quotest.cpp
+++ b/quotest/quotest.cpp
@@ -522,9 +522,9 @@ bool TestSuite::checkFileSendingOutcome(const TestToken& thisTest,
                     // TODO: check #366 once #368 is implemented
                     FINISH_TEST(!e.id().isEmpty() && evt.transactionId() == txnId
                                 && e.hasFileContent()
-                                && e.content()->fileInfo()->originalName == fileName
+                                && e.fileContent()->originalName == fileName
                                 && testDownload(targetRoom->connection()->makeMediaUrl(
-                                    e.content()->fileInfo()->url())));
+                                    e.fileContent()->url())));
                 },
                 [this, thisTest](const RoomEvent&) { FAIL_TEST(); });
         });

--- a/quotest/quotest.cpp
+++ b/quotest/quotest.cpp
@@ -438,7 +438,7 @@ TEST_IMPL(sendFile)
     const auto tfName = tfi.fileName();
     clog << "Sending file " << tfName.toStdString() << endl;
     const auto txnId = targetRoom->postFile(
-        "Test file"_L1, new EventContent::FileContent(tfi));
+        "Test file"_L1, std::make_unique<EventContent::FileContent>(tfi));
     if (!validatePendingEvent<RoomMessageEvent>(txnId)) {
         clog << "Invalid pending event right after submitting" << endl;
         tf->deleteLater();


### PR DESCRIPTION
1. Finally fixed #797 
2. Fixed regressions introduced by #807 (see the last commit message)
3. Fixed inconvenience in using `QUO_ALARM`/`QUO_CHECK` from client code.

Not adding this PR to the project because all things are regressions, and it will be mentioned as closing #797 anyway.