### PR TITLE
Rework RoomMessageEvent content API again

### DIFF
--- a/Quotient/eventitem.cpp
+++ b/Quotient/eventitem.cpp
@@ -10,12 +10,9 @@ using namespace Quotient;
 
 void PendingEventItem::setFileUploaded(const FileSourceInfo& uploadedFileData)
 {
-    if (auto* rme = getAs<RoomMessageEvent>()) {
-        auto fc = rme->get<EventContent::FileContent>();
-        Q_ASSERT(fc != nullptr);
-        fc->source = uploadedFileData;
-        rme->setContent(std::move(fc));
-    }
+    if (auto* rme = getAs<RoomMessageEvent>())
+        rme->updateFileSourceInfo(uploadedFileData);
+
     if (auto* rae = getAs<RoomAvatarEvent>()) {
         rae->editContent([&uploadedFileData](EventContent::FileInfo& fi) {
             fi.source = uploadedFileData;

--- a/Quotient/eventitem.cpp
+++ b/Quotient/eventitem.cpp
@@ -11,8 +11,8 @@ using namespace Quotient;
 void PendingEventItem::setFileUploaded(const FileSourceInfo& uploadedFileData)
 {
     if (auto* rme = getAs<RoomMessageEvent>()) {
-        Q_ASSERT(rme->hasFileContent());
-        auto fc = rme->fileContent();
+        auto fc = rme->get<EventContent::FileContent>();
+        Q_ASSERT(fc != nullptr);
         fc->source = uploadedFileData;
         rme->setContent(std::move(fc));
     }

--- a/Quotient/events/eventcontent.cpp
+++ b/Quotient/events/eventcontent.cpp
@@ -103,14 +103,10 @@ QJsonObject Quotient::EventContent::toInfoJson(const ImageInfo& info)
     return infoJson;
 }
 
-Thumbnail::Thumbnail(const QJsonObject& infoJson,
-                     const std::optional<EncryptedFileMetadata> &efm)
-    : ImageInfo(QUrl(infoJson["thumbnail_url"_L1].toString()),
+Thumbnail::Thumbnail(const QJsonObject& infoJson)
+    : ImageInfo(fileSourceInfoFromJson(infoJson, { "thumbnail_url"_L1, "thumbnail_file"_L1 }),
                 infoJson["thumbnail_info"_L1].toObject())
-{
-    if (efm)
-        source = *efm;
-}
+{}
 
 void Thumbnail::dumpTo(QJsonObject& infoJson) const
 {

--- a/Quotient/events/eventcontent.h
+++ b/Quotient/events/eventcontent.h
@@ -142,8 +142,7 @@ QUOTIENT_API QJsonObject toInfoJson(const ImageInfo& info);
 //! `info/thumbnail_info` fields are used.
 struct QUOTIENT_API Thumbnail : public ImageInfo {
     using ImageInfo::ImageInfo;
-    explicit Thumbnail(const QJsonObject& infoJson,
-                       const std::optional<EncryptedFileMetadata>& efm = {});
+    explicit Thumbnail(const QJsonObject& infoJson);
 
     //! \brief Add thumbnail information to the passed `info` JSON object
     void dumpTo(QJsonObject& infoJson) const;
@@ -213,12 +212,10 @@ public:
     using InfoT::InfoT;
     explicit UrlBasedContent(const QJsonObject& json)
         : FileContentBase(json)
-        , InfoT(fromJson<QUrl>(json["url"_L1]), json[InfoKey].toObject(),
+        , InfoT(fileSourceInfoFromJson(json, { "url"_L1, "file"_L1 }), json[InfoKey].toObject(),
                 json["filename"_L1].toString())
         , thumbnail(FileInfo::originalInfoJson)
     {
-        if (const auto efmJson = json.value("file"_L1).toObject(); !efmJson.isEmpty())
-            InfoT::source = fromJson<EncryptedFileMetadata>(efmJson);
         // Two small hacks on originalJson to expose mediaIds to QML
         originalJson.insert("mediaId"_L1, InfoT::mediaId());
         originalJson.insert("thumbnailMediaId"_L1, thumbnail.mediaId());

--- a/Quotient/events/eventcontent.h
+++ b/Quotient/events/eventcontent.h
@@ -16,6 +16,10 @@
 
 class QFileInfo;
 
+namespace Quotient {
+constexpr inline auto InfoKey = "info"_L1;
+}
+
 namespace Quotient::EventContent {
 //! \brief Base for all content types that can be stored in RoomMessageEvent
 //!
@@ -209,12 +213,11 @@ public:
     using InfoT::InfoT;
     explicit UrlBasedContent(const QJsonObject& json)
         : FileContentBase(json)
-        , InfoT(fromJson<QUrl>(json["url"_L1]), json["info"_L1].toObject(),
+        , InfoT(fromJson<QUrl>(json["url"_L1]), json[InfoKey].toObject(),
                 json["filename"_L1].toString())
         , thumbnail(FileInfo::originalInfoJson)
     {
-        if (const auto efmJson = json.value("file"_L1).toObject();
-                !efmJson.isEmpty())
+        if (const auto efmJson = json.value("file"_L1).toObject(); !efmJson.isEmpty())
             InfoT::source = fromJson<EncryptedFileMetadata>(efmJson);
         // Two small hacks on originalJson to expose mediaIds to QML
         originalJson.insert("mediaId"_L1, InfoT::mediaId());
@@ -240,7 +243,7 @@ protected:
         if (thumbnail.isValid())
             thumbnail.dumpTo(infoJson);
         fillInfoJson(infoJson);
-        json.insert("info"_L1, infoJson);
+        json.insert(InfoKey, infoJson);
     }
 };
 

--- a/Quotient/events/eventcontent.h
+++ b/Quotient/events/eventcontent.h
@@ -151,8 +151,27 @@ struct QUOTIENT_API Thumbnail : public ImageInfo {
 //! The base for all file-based content classes
 class QUOTIENT_API FileContentBase : public Base {
 public:
-    using Base::Base;
+    FileContentBase(const QJsonObject& contentJson = {})
+        : Base(contentJson), thumbnail(contentJson[InfoKey].toObject())
+    {}
     virtual QUrl url() const = 0;
+    virtual FileInfo commonInfo() const = 0;
+
+    Thumbnail thumbnail;
+
+protected:
+    virtual QJsonObject makeInfoJson() const = 0;
+
+    void fillJson(QJsonObject& json) const override
+    {
+        const auto fileInfo = commonInfo();
+        Quotient::fillJson(json, { "url"_L1, "file"_L1 }, fileInfo.source);
+        addParam<IfNotEmpty>(json, "filename"_L1, fileInfo.originalName);
+        auto infoJson = makeInfoJson();
+        if (thumbnail.isValid())
+            thumbnail.dumpTo(infoJson);
+        json.insert(InfoKey, infoJson);
+    }
 };
 
 //! \brief Rich text content for m.text, m.emote, m.notice
@@ -214,7 +233,6 @@ public:
         : FileContentBase(json)
         , InfoT(fileSourceInfoFromJson(json, { "url"_L1, "file"_L1 }), json[InfoKey].toObject(),
                 json["filename"_L1].toString())
-        , thumbnail(FileInfo::originalInfoJson)
     {
         // Two small hacks on originalJson to expose mediaIds to QML
         originalJson.insert("mediaId"_L1, InfoT::mediaId());
@@ -223,25 +241,10 @@ public:
 
     QMimeType type() const override { return InfoT::mimeType; }
     QUrl url() const override { return InfoT::url(); }
-
-public:
-    Thumbnail thumbnail;
+    FileInfo commonInfo() const override { return SLICE(*this, FileInfo); }
 
 protected:
-    virtual void fillInfoJson(QJsonObject& infoJson [[maybe_unused]]) const
-    {}
-
-    void fillJson(QJsonObject& json) const override
-    {
-        Quotient::fillJson(json, { "url"_L1, "file"_L1 }, InfoT::source);
-        if (!InfoT::originalName.isEmpty())
-            json.insert("filename"_L1, InfoT::originalName);
-        auto infoJson = toInfoJson(*this);
-        if (thumbnail.isValid())
-            thumbnail.dumpTo(infoJson);
-        fillInfoJson(infoJson);
-        json.insert(InfoKey, infoJson);
-    }
+    QJsonObject makeInfoJson() const override { return toInfoJson(*this); }
 };
 
 //! \brief Content class for m.image
@@ -288,9 +291,11 @@ public:
     {}
 
 protected:
-    void fillInfoJson(QJsonObject& infoJson) const override
+    QJsonObject makeInfoJson() const override
     {
+        auto infoJson = UrlBasedContent<InfoT>::makeInfoJson();
         infoJson.insert("duration"_L1, duration);
+        return infoJson;
 }
 
 public:

--- a/Quotient/events/filesourceinfo.cpp
+++ b/Quotient/events/filesourceinfo.cpp
@@ -117,16 +117,17 @@ QUrl Quotient::getUrlFromSourceInfo(const FileSourceInfo& fsi) { return getUrl(f
 
 void Quotient::setUrlInSourceInfo(FileSourceInfo& fsi, const QUrl& newUrl) { getUrl(fsi) = newUrl; }
 
-void Quotient::fillJson(QJsonObject& jo,
-                        const std::array<QLatin1String, 2>& jsonKeys,
+void Quotient::fillJson(QJsonObject& jo, const FileSourceInfoKeys& jsonKeys,
                         const FileSourceInfo& fsi)
 {
-    // NB: Keeping variant_size_v out of the function signature for readability.
-    // NB2: Can't use jsonKeys directly inside static_assert as its value is
-    // unknown so the compiler cannot ensure size() is constexpr (go figure...)
-    static_assert(
-        std::variant_size_v<FileSourceInfo> == decltype(jsonKeys) {}.size());
     jo.insert(jsonKeys[fsi.index()], toJson(fsi));
+}
+
+FileSourceInfo Quotient::fileSourceInfoFromJson(const QJsonObject& jo,
+                                                const FileSourceInfoKeys& jsonKeys)
+{
+    return jo.contains(jsonKeys[1]) ? fromJson<EncryptedFileMetadata>(jo[jsonKeys[1]])
+                                    : FileSourceInfo(fromJson<QUrl>(jo[jsonKeys[0]]));
 }
 
 namespace {

--- a/Quotient/events/filesourceinfo.h
+++ b/Quotient/events/filesourceinfo.h
@@ -69,6 +69,8 @@ struct QUOTIENT_API JsonObjectConverter<JWK> {
 
 using FileSourceInfo = std::variant<QUrl, EncryptedFileMetadata>;
 
+using FileSourceInfoKeys = std::array<QLatin1String, std::variant_size_v<FileSourceInfo>>;
+
 QUOTIENT_API QUrl getUrlFromSourceInfo(const FileSourceInfo& fsi);
 
 QUOTIENT_API void setUrlInSourceInfo(FileSourceInfo& fsi, const QUrl& newUrl);
@@ -86,9 +88,11 @@ void fillJson(QJsonObject&, const FileSourceInfo&) = delete;
 //! - a key-to-object mapping where key is taken from jsonKeys[1] and the object
 //!   is the result of converting EncryptedFileMetadata to JSON,
 //!   if FileSourceInfo stores EncryptedFileMetadata
-QUOTIENT_API void fillJson(QJsonObject& jo,
-                           const std::array<QLatin1String, 2>& jsonKeys,
+QUOTIENT_API void fillJson(QJsonObject& jo, const FileSourceInfoKeys& jsonKeys,
                            const FileSourceInfo& fsi);
+
+QUOTIENT_API FileSourceInfo fileSourceInfoFromJson(const QJsonObject& jo,
+                                                   const FileSourceInfoKeys& jsonKeys);
 
 namespace FileMetadataMap {
     QUOTIENT_API void add(const QString& roomId,

--- a/Quotient/events/roommessageevent.cpp
+++ b/Quotient/events/roommessageevent.cpp
@@ -27,9 +27,10 @@ constexpr auto TextTypeId = "m.text"_L1;
 constexpr auto EmoteTypeId = "m.emote"_L1;
 constexpr auto NoticeTypeId = "m.notice"_L1;
 constexpr auto FileTypeId = "m.file"_L1;
-constexpr auto ImageTypeId = "m.file"_L1;
-constexpr auto AudioTypeId = "m.file"_L1;
-constexpr auto VideoTypeId = "m.file"_L1;
+constexpr auto ImageTypeId = "m.image"_L1;
+constexpr auto AudioTypeId = "m.audio"_L1;
+constexpr auto VideoTypeId = "m.video"_L1;
+constexpr auto LocationTypeId = "m.location"_L1;
 constexpr auto HtmlContentTypeId = "org.matrix.custom.html"_L1;
 
 template <typename ContentT>
@@ -57,11 +58,11 @@ constexpr auto msgTypes = std::to_array<MsgTypeDesc>({
     { TextTypeId, MsgType::Text, false, make<TextContent> },
     { EmoteTypeId, MsgType::Emote, false, make<TextContent> },
     { NoticeTypeId, MsgType::Notice, false, make<TextContent> },
-    { "m.image"_L1, MsgType::Image, true, make<ImageContent> },
-    { "m.file"_L1, MsgType::File, true, make<FileContent> },
-    { "m.location"_L1, MsgType::Location, false, make<LocationContent> },
-    { "m.video"_L1, MsgType::Video, true, make<VideoContent> },
-    { "m.audio"_L1, MsgType::Audio, true, make<AudioContent> },
+    { ImageTypeId, MsgType::Image, true, make<ImageContent> },
+    { FileTypeId, MsgType::File, true, make<FileContent> },
+    { LocationTypeId, MsgType::Location, false, make<LocationContent> },
+    { VideoTypeId, MsgType::Video, true, make<VideoContent> },
+    { AudioTypeId, MsgType::Audio, true, make<AudioContent> },
     { "m.key.verification.request"_L1, MsgType::Text, false, make<TextContent> },
 });
 
@@ -249,7 +250,7 @@ Thumbnail RoomMessageEvent::getThumbnail() const
 template <>
 bool RoomMessageEvent::has<LocationContent>() const
 {
-    return msgtype() == MsgType::Location;
+    return rawMsgtype() == LocationTypeId;
 }
 
 std::optional<EventRelation> RoomMessageEvent::relatesTo() const
@@ -362,10 +363,10 @@ QString RoomMessageEvent::fileNameToDownload() const
 QString rawMsgTypeForMimeType(const QMimeType& mimeType)
 {
     auto name = mimeType.name();
-    return name.startsWith("image/"_L1)   ? u"m.image"_s
-           : name.startsWith("video/"_L1) ? u"m.video"_s
-           : name.startsWith("audio/"_L1) ? u"m.audio"_s
-                                          : u"m.file"_s;
+    return name.startsWith("image/"_L1)   ? ImageTypeId
+           : name.startsWith("video/"_L1) ? VideoTypeId
+           : name.startsWith("audio/"_L1) ? AudioTypeId
+                                          : FileTypeId;
 }
 
 QString RoomMessageEvent::rawMsgTypeForUrl(const QUrl& url)

--- a/Quotient/events/roommessageevent.cpp
+++ b/Quotient/events/roommessageevent.cpp
@@ -360,6 +360,13 @@ QString RoomMessageEvent::fileNameToDownload() const
     return fileName;
 }
 
+void RoomMessageEvent::updateFileSourceInfo(const FileSourceInfo& fsi)
+{
+    editSubobject(editJson(), ContentKey, [&fsi](QJsonObject& contentJson) {
+        Quotient::fillJson(contentJson, { "url"_L1, "file"_L1 }, fsi);
+    });
+}
+
 QString rawMsgTypeForMimeType(const QMimeType& mimeType)
 {
     auto name = mimeType.name();

--- a/Quotient/events/roommessageevent.cpp
+++ b/Quotient/events/roommessageevent.cpp
@@ -333,13 +333,15 @@ QString safeFileName(QString rawName)
 
 QString RoomMessageEvent::fileNameToDownload() const
 {
-    const auto fileInfo = get<FileContent>();
-    if (QUO_ALARM(fileInfo == nullptr))
+    const auto fileContent = get<FileContentBase>();
+    if (QUO_ALARM(fileContent == nullptr))
         return {};
 
+    const auto fileInfo = fileContent->commonInfo();
+
     QString fileName;
-    if (!fileInfo->originalName.isEmpty())
-        fileName = QFileInfo(safeFileName(fileInfo->originalName)).fileName();
+    if (!fileInfo.originalName.isEmpty())
+        fileName = QFileInfo(safeFileName(fileInfo.originalName)).fileName();
     else if (QUrl u { plainBody() }; u.isValid()) {
         qDebug(MAIN) << id()
                      << "has no file name supplied but the event body "
@@ -347,15 +349,15 @@ QString RoomMessageEvent::fileNameToDownload() const
         fileName = u.fileName();
     }
     if (fileName.isEmpty())
-        return safeFileName(fileInfo->mediaId()).replace(u'.', u'-') % u'.'
-               % fileInfo->mimeType.preferredSuffix();
+        return safeFileName(fileInfo.mediaId()).replace(u'.', u'-') % u'.'
+               % fileInfo.mimeType.preferredSuffix();
 
     if (QSysInfo::productType() == "windows"_L1) {
-        if (const auto& suffixes = fileInfo->mimeType.suffixes();
+        if (const auto& suffixes = fileInfo.mimeType.suffixes();
             !suffixes.isEmpty() && std::ranges::none_of(suffixes, [&fileName](const QString& s) {
                 return fileName.endsWith(s);
             }))
-            return fileName % u'.' % fileInfo->mimeType.preferredSuffix();
+            return fileName % u'.' % fileInfo.mimeType.preferredSuffix();
     }
     return fileName;
 }

--- a/Quotient/events/roommessageevent.h
+++ b/Quotient/events/roommessageevent.h
@@ -160,6 +160,8 @@ public:
 
     QString fileNameToDownload() const;
 
+    void updateFileSourceInfo(const FileSourceInfo& fsi);
+
     static QString rawMsgTypeForUrl(const QUrl& url);
     static QString rawMsgTypeForFile(const QFileInfo& fi);
 

--- a/Quotient/events/roommessageevent.h
+++ b/Quotient/events/roommessageevent.h
@@ -62,49 +62,37 @@ public:
     //! Update the message JSON with the given content
     void setContent(std::unique_ptr<EventContent::Base> content);
 
+    //! \brief Determine whether the message has content/attachment of a specified type
+    //!
+    //! \return true, if the message has type and content corresponding to \p ContentT (e.g.
+    //!         `m.file` or `m.audio` for FileContent); false otherwise
+    template <std::derived_from<EventContent::Base> ContentT>
+    bool has() const { return false; }
+
+    //! \brief Get the message content and try to cast it to the specified type
+    //!
+    //! \return A pointer to the object of the requested type if the event has content of this type;
+    //!         nullptr, if the event has no content or the content cannot be cast to this type
+    template <std::derived_from<EventContent::Base> ContentT>
+    std::unique_ptr<ContentT> get() const
+    {
+        return has<ContentT>()
+                   ? std::unique_ptr<ContentT>(static_cast<ContentT*>(content().release()))
+                   : nullptr;
+    }
+
     QMimeType mimeType() const;
-
-    //! \brief Determine whether the message has text content
-    //!
-    //! \return true, if the message type is one of m.text, m.notice, m.emote,
-    //!         or the message type is unspecified (in which case plainBody()
-    //!         can still be examined); false otherwise
-    bool hasTextContent() const;
-
-    //! \brief Get the TextContent object for the event
-    //!
-    //! \return A TextContent object if the message has one; std::nullopt otherwise.
-    std::unique_ptr<EventContent::TextContent> richTextContent() const;
-
-    //! \brief Determine whether the message has a file/attachment
-    //!
-    //! \return true, if the message has a data structure corresponding to
-    //!         a file (such as m.file or m.audio); false otherwise
-    bool hasFileContent() const;
-
-    //! \brief Get the FileContent object for the event
-    //!
-    //! \return A FileContent object if the message has one; std::nullopt otherwise.
-    std::unique_ptr<EventContent::FileContent> fileContent() const;
 
     //! \brief Determine whether the message has a thumbnail
     //!
     //! \return true, if the message has a data structure corresponding to
     //!         a thumbnail (the message type may be one for visual content,
-    //!         such as m.image, or generic binary content, i.e. m.file);
+    //!         such as m.image, or non-visual, i.e. m.file or m.location);
     //!         false otherwise
     bool hasThumbnail() const;
 
-    //! \brief Determine whether the message has a location
-    //!
-    //! \return true, if the message has a data structure corresponding to
-    //!         a location; false otherwise
-    bool hasLocationContent() const;
-
-    //! \brief Get the LocationContent object for the event
-    //!
-    //! \return A LocationContent object if the message has one; std::nullopt otherwise.
-    std::unique_ptr<EventContent::LocationContent> locationContent() const;
+    //! Retrieve a thumbnail from the message event
+    EventContent::Thumbnail getThumbnail() const;
 
     //! \brief The EventRelation for this event.
     //!
@@ -183,6 +171,14 @@ private:
 
     Q_ENUM(MsgType)
 };
+
+template <> QUOTIENT_API bool RoomMessageEvent::has<EventContent::TextContent>() const;
+template <> QUOTIENT_API bool RoomMessageEvent::has<EventContent::LocationContent>() const;
+template <> QUOTIENT_API bool RoomMessageEvent::has<EventContent::FileContentBase>() const;
+template <> QUOTIENT_API bool RoomMessageEvent::has<EventContent::FileContent>() const;
+template <> QUOTIENT_API bool RoomMessageEvent::has<EventContent::ImageContent>() const;
+template <> QUOTIENT_API bool RoomMessageEvent::has<EventContent::AudioContent>() const;
+template <> QUOTIENT_API bool RoomMessageEvent::has<EventContent::VideoContent>() const;
 
 using MessageEventType = RoomMessageEvent::MsgType;
 } // namespace Quotient

--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -1422,7 +1422,7 @@ Room::Private::getEventWithFile(const QString& eventId) const
     auto evtIt = q->findInTimeline(eventId);
     if (evtIt != timeline.rend() && is<RoomMessageEvent>(**evtIt)) {
         auto* event = evtIt->viewAs<RoomMessageEvent>();
-        if (event->hasFileContent())
+        if (event->has<EventContent::FileContent>())
             return event;
     }
     qCWarning(MAIN) << "No files to download in event" << eventId;
@@ -1431,10 +1431,13 @@ Room::Private::getEventWithFile(const QString& eventId) const
 
 QUrl Room::urlToThumbnail(const QString& eventId) const
 {
-    if (auto* event = d->getEventWithFile(eventId); event && event->hasThumbnail()) {
-        const auto thumbnail = event->fileContent()->thumbnail;
-        return connection()->getUrlForApi<MediaThumbnailJob>(thumbnail.url(), thumbnail.imageSize);
-    }
+    if (const auto evtIt = findInTimeline(eventId); evtIt != historyEdge())
+        if (const auto* const evt = evtIt->viewAs<RoomMessageEvent>())
+            if (evt->hasThumbnail()) {
+                const auto thumbnail = evt->getThumbnail();
+                return connection()->getUrlForApi<MediaThumbnailJob>(thumbnail.url(),
+                                                                     thumbnail.imageSize);
+            }
     qCDebug(MAIN) << "Event" << eventId << "has no thumbnail";
     return {};
 }
@@ -1442,7 +1445,8 @@ QUrl Room::urlToThumbnail(const QString& eventId) const
 QUrl Room::urlToDownload(const QString& eventId) const
 {
     if (const auto* const event = d->getEventWithFile(eventId)) {
-        if (const auto fileInfo = event->fileContent(); QUO_CHECK(fileInfo != nullptr))
+        if (const auto fileInfo = event->get<EventContent::FileContent>();
+            QUO_CHECK(fileInfo != nullptr))
             return connection()->getUrlForApi<DownloadFileJob>(fileInfo->url());
     }
     return {};
@@ -1739,7 +1743,7 @@ Room::Private::moveEventsToTimeline(RoomEventsRange events,
         eventsIndex.insert(eId, index);
         if (usesEncryption)
             if (auto* const rme = ti.viewAs<RoomMessageEvent>())
-                if (const auto fileInfo = rme->fileContent()) {
+                if (const auto fileInfo = rme->get<EventContent::FileContent>()) {
                     if (const auto* const efm =
                             std::get_if<EncryptedFileMetadata>(&fileInfo->source))
                         FileMetadataMap::add(id, eId, *efm);
@@ -2456,7 +2460,7 @@ void Room::downloadFile(const QString& eventId, const QUrl& localFilename)
         Q_ASSERT(false);
         return;
     }
-    const auto fileInfo = event->fileContent();
+    const auto fileInfo = event->get<EventContent::FileContent>();
     if (!fileInfo->isValid()) {
         qCWarning(MAIN) << "Event" << eventId
                         << "has an empty or malformed mxc URL; won't download";
@@ -2465,7 +2469,7 @@ void Room::downloadFile(const QString& eventId, const QUrl& localFilename)
     const auto fileUrl = fileInfo->url();
     auto filePath = localFilename.toLocalFile();
     if (filePath.isEmpty()) { // Setup default file path
-        filePath = fileInfo->url().path().mid(1) % u'_' % event->fileNameToDownload();
+        filePath = fileUrl.path().mid(1) % u'_' % event->fileNameToDownload();
 
         if (filePath.size() > 200) // If too long, elide in the middle
             filePath.replace(128, filePath.size() - 192, "---"_L1);

--- a/quotest/quotest.cpp
+++ b/quotest/quotest.cpp
@@ -517,14 +517,15 @@ bool TestSuite::checkFileSendingOutcome(const TestToken& thisTest,
     targetRoom->whenMessageMerged(txnId).then(
         this, [this, thisTest, txnId, fileName](const RoomEvent& evt) {
             clog << "File event " << txnId.toStdString() << " arrived in the timeline" << endl;
+            using EventContent::FileContent;
             evt.switchOnType(
                 [&](const RoomMessageEvent& e) {
                     // TODO: check #366 once #368 is implemented
                     FINISH_TEST(!e.id().isEmpty() && evt.transactionId() == txnId
-                                && e.hasFileContent()
-                                && e.fileContent()->originalName == fileName
+                                && e.has<FileContent>()
+                                && e.get<FileContent>()->originalName == fileName
                                 && testDownload(targetRoom->connection()->makeMediaUrl(
-                                    e.fileContent()->url())));
+                                    e.get<FileContent>()->url())));
                 },
                 [this, thisTest](const RoomEvent&) { FAIL_TEST(); });
         });


### PR DESCRIPTION
It's really straightforward now :) `RoomMessageEvent::has<>()` - check that it's possible to extract event content of a given type; `RoomMessageEvent::get<>()` - actually try to get event content of that type. At this point `has()` is not optimised and in some cases effectively creates a content object any way. Can be tackled sometime later.