### PR TITLE
pendingEventAdded event param

### DIFF
--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -1932,7 +1932,7 @@ Room::PendingEvents::iterator Room::Private::addAsPending(RoomEventPtr&& event)
         event->setSender(connection->userId());
     emit q->pendingEventAboutToAdd(std::to_address(event));
     auto it = unsyncedEvents.emplace(unsyncedEvents.end(), std::move(event));
-    emit q->pendingEventAdded();
+    emit q->pendingEventAdded(std::to_address(event));
     return it;
 }
 

--- a/Quotient/room.h
+++ b/Quotient/room.h
@@ -838,7 +838,7 @@ Q_SIGNALS:
     /// The event is about to be appended to the list of pending events
     void pendingEventAboutToAdd(Quotient::RoomEvent* event);
     /// An event has been appended to the list of pending events
-    void pendingEventAdded();
+    void pendingEventAdded(Quotient::RoomEvent* event);
     /// The remote echo has arrived with the sync and will be merged
     /// with its local counterpart
     /** NB: Requires a sync loop to be emitted */

--- a/Quotient/room.h
+++ b/Quotient/room.h
@@ -838,7 +838,7 @@ Q_SIGNALS:
     /// The event is about to be appended to the list of pending events
     void pendingEventAboutToAdd(Quotient::RoomEvent* event);
     /// An event has been appended to the list of pending events
-    void pendingEventAdded(Quotient::RoomEvent* event);
+    void pendingEventAdded(const Quotient::RoomEvent* event);
     /// The remote echo has arrived with the sync and will be merged
     /// with its local counterpart
     /** NB: Requires a sync loop to be emitted */


### PR DESCRIPTION
It is useful to have a reference to the event when the pendingEventAdded signal is called. In Neochat and it's MessageEventModels we just keep the event ID and search for the event on demand. We need to ideally do this after the pending event has been added to unsyncedEvents and this makes it easier.