### PR TITLE
MediaThumbnailJob: Look for the correct spec version for auth media

### DIFF
--- a/Quotient/jobs/mediathumbnailjob.cpp
+++ b/Quotient/jobs/mediathumbnailjob.cpp
@@ -22,7 +22,7 @@ QUrl MediaThumbnailJob::makeRequestUrl(const HomeserverData& hsData, const QStri
                                        std::optional<bool> animated)
 {
     QT_IGNORE_DEPRECATIONS( // For GetContentThumbnailJob
-        return hsData.checkMatrixSpecVersion(u"1.11")
+        return hsData.checkMatrixSpecVersion(u"v1.11")
                    ? GetContentThumbnailAuthedJob::makeRequestUrl(hsData, serverName, mediaId,
                                                                   requestedSize.width(),
                                                                   requestedSize.height(),


### PR DESCRIPTION
It is supposed to be "v1.11", "1.11" is not a valid version and thus this would always use the old media endpoints.