### PR TITLE
Don't warn about unsupported RoomType values

### DIFF
--- a/Quotient/converters.cpp
+++ b/Quotient/converters.cpp
@@ -7,13 +7,6 @@
 
 #include <QtCore/QVariant>
 
-void Quotient::_impl::warnUnknownEnumValue(const QString& stringValue,
-                                           const char* enumTypeName)
-{
-    qWarning(EVENTS).noquote()
-        << "Unknown" << enumTypeName << "value:" << stringValue;
-}
-
 void Quotient::_impl::reportEnumOutOfBounds(uint32_t v, const char* enumTypeName)
 {
     qCritical(MAIN).noquote()

--- a/Quotient/converters.h
+++ b/Quotient/converters.h
@@ -160,16 +160,13 @@ namespace _impl {
 //! matching respective enum values, 0-based.
 //! \sa enumToJsonString
 template <typename EnumT, typename EnumStringValuesT>
-inline EnumT enumFromJsonString(const QString& s, const EnumStringValuesT& enumValues,
-                                EnumT defaultValue)
+inline std::optional<EnumT> enumFromJsonString(const QString& s, const EnumStringValuesT& enumValues)
 {
     static_assert(std::is_unsigned_v<std::underlying_type_t<EnumT>>);
     if (const auto it = std::ranges::find(enumValues, s); it != cend(enumValues))
         return static_cast<EnumT>(it - cbegin(enumValues));
 
-    if (!s.isEmpty())
-        _impl::warnUnknownEnumValue(s, qt_getEnumName(EnumT()));
-    return defaultValue;
+    return std::nullopt;
 }
 
 //! \brief Facility enum-to-string converter

--- a/Quotient/converters.h
+++ b/Quotient/converters.h
@@ -197,22 +197,18 @@ inline QString enumToJsonString(EnumT v, const EnumStringValuesT& enumValues)
 //! enumeration is assumed to be of a 'flag' kind - i.e. its values must be
 //! a power-of-two sequence starting from 1, without gaps, so exactly 1,2,4,8,16
 //! and so on.
-//! \note Unlike enumFromJsonString, the values start from 1 and not from 0,
-//!       with 0 being used for an invalid value by default.
+//! \note Unlike enumFromJsonString, the values start from 1 and not from 0.
 //! \note This function does not support flag combinations.
 //! \sa QUO_DECLARE_FLAGS, QUO_DECLARE_FLAGS_NS
 template <typename FlagT, typename FlagStringValuesT>
-inline FlagT flagFromJsonString(const QString& s, const FlagStringValuesT& flagValues,
-                                FlagT defaultValue = FlagT(0U))
+inline std::optional<FlagT> flagFromJsonString(const QString& s, const FlagStringValuesT& flagValues)
 {
     // Enums based on signed integers don't make much sense for flag types
     static_assert(std::is_unsigned_v<std::underlying_type_t<FlagT>>);
     if (const auto it = std::ranges::find(flagValues, s); it != cend(flagValues))
         return static_cast<FlagT>(1U << (it - cbegin(flagValues)));
 
-    if (!s.isEmpty())
-        _impl::warnUnknownEnumValue(s, qt_getEnumName(FlagT()));
-    return defaultValue;
+    return std::nullopt;
 }
 
 template <typename FlagT, typename FlagStringValuesT>

--- a/Quotient/converters.h
+++ b/Quotient/converters.h
@@ -147,7 +147,6 @@ inline void fillFromJson(const QJsonValue& jv, T& pod)
 }
 
 namespace _impl {
-    QUOTIENT_API void warnUnknownEnumValue(const QString& stringValue, const char* enumTypeName);
     QUOTIENT_API void reportEnumOutOfBounds(uint32_t v, const char* enumTypeName);
 }
 

--- a/Quotient/events/roomcreateevent.cpp
+++ b/Quotient/events/roomcreateevent.cpp
@@ -8,7 +8,7 @@ using namespace Quotient;
 template <>
 RoomType Quotient::fromJson(const QJsonValue& jv)
 {
-    return enumFromJsonString<RoomType>(jv.toString(), RoomTypeStrings).or_else([] -> std::optional<RoomType> { return RoomType::Undefined; }).value();
+    return enumFromJsonString<RoomType>(jv.toString(), RoomTypeStrings).value_or(RoomType::Undefined);
 }
 
 bool RoomCreateEvent::isFederated() const

--- a/Quotient/events/roomcreateevent.cpp
+++ b/Quotient/events/roomcreateevent.cpp
@@ -8,8 +8,7 @@ using namespace Quotient;
 template <>
 RoomType Quotient::fromJson(const QJsonValue& jv)
 {
-    return enumFromJsonString(jv.toString(), RoomTypeStrings,
-                              RoomType::Undefined);
+    return enumFromJsonString<RoomType>(jv.toString(), RoomTypeStrings).or_else([] -> std::optional<RoomType> { return RoomType::Undefined; }).value();
 }
 
 bool RoomCreateEvent::isFederated() const

--- a/Quotient/events/roommemberevent.cpp
+++ b/Quotient/events/roommemberevent.cpp
@@ -12,7 +12,7 @@ struct JsonConverter<Membership> {
     static Membership load(const QJsonValue& jv)
     {
         if (const auto& ms = jv.toString(); !ms.isEmpty())
-            return flagFromJsonString<Membership>(ms, MembershipStrings);
+            return flagFromJsonString<Membership>(ms, MembershipStrings).value_or(Membership::Invalid);
 
         qCWarning(EVENTS) << "Empty membership state";
         return Membership::Invalid;


### PR DESCRIPTION
enumFromJsonString is changed to return a std::optional, and lets the callee handle returning a default value and warning if they want to.

Fixes #790