### PR TITLE
Fix pendingEventAdded event ref

### DIFF
--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -1932,7 +1932,7 @@ Room::PendingEvents::iterator Room::Private::addAsPending(RoomEventPtr&& event)
         event->setSender(connection->userId());
     emit q->pendingEventAboutToAdd(std::to_address(event));
     auto it = unsyncedEvents.emplace(unsyncedEvents.end(), std::move(event));
-    emit q->pendingEventAdded(std::to_address(event));
+    emit q->pendingEventAdded(it->event());
     return it;
 }
 


### PR DESCRIPTION
https://invent.kde.org/network/neochat/-/merge_requests/1953 added an event ref to the `pendingEventAdded` signal but we can't actually use `event` after it has been added to the unsynced events as it has been std::move'd. Instead we need to get the event from the returned iterator.