### PR TITLE
RoomMessageEvent  Edit Helpers

### DIFF
--- a/Quotient/events/roommessageevent.cpp
+++ b/Quotient/events/roommessageevent.cpp
@@ -193,6 +193,18 @@ std::unique_ptr<Base> RoomMessageEvent::content() const
     return {};
 }
 
+void RoomMessageEvent::setPlainBody(const QString& newPlainBody)
+{
+    editJson()[ContentKey] =
+        assembleContentJson(newPlainBody, rawMsgtype(), content(), relatesTo());
+}
+
+void RoomMessageEvent::setMsgType(MsgType newMsgType)
+{
+    editJson()[ContentKey] =
+        assembleContentJson(plainBody(), msgTypeToJson(newMsgType), content(), relatesTo());
+}
+
 void RoomMessageEvent::setContent(std::unique_ptr<Base> content)
 {
     editJson()[ContentKey] =

--- a/Quotient/events/roommessageevent.h
+++ b/Quotient/events/roommessageevent.h
@@ -59,6 +59,12 @@ public:
     //! \return an event content object if the event has content, nullptr otherwise.
     std::unique_ptr<EventContent::Base> content() const;
 
+    //! Update the message JSON with the given plain body
+    void setPlainBody(const QString& newPlainBody);
+
+    //! Update the message JSON with the given message type
+    void setMsgType(MsgType newMsgType);
+
     //! Update the message JSON with the given content
     void setContent(std::unique_ptr<EventContent::Base> content);
 


### PR DESCRIPTION
Add some helper functions to allow the editing of the message type and plain body. This is useful as for example in NeoChat we have slash commands where these are modified and I want to do it after event creation