### PR TITLE
Use the error message provided by the server's media endpoints

### DIFF
--- a/Quotient/mxcreply.cpp
+++ b/Quotient/mxcreply.cpp
@@ -24,7 +24,10 @@ MxcReply::MxcReply(QNetworkReply* reply,
     connect(d->m_reply, &QNetworkReply::finished, this, [this, fileMetadata] {
         setError(d->m_reply->error(), d->m_reply->errorString());
 
-        if (fileMetadata.isValid()) {
+        if (d->m_reply->error() != NoError) {
+            const QJsonDocument doc = QJsonDocument::fromJson(d->m_reply->readAll());
+            setErrorString(QStringLiteral("%1 (%2)").arg(doc["error"_L1].toString(), d->m_reply->url().toString()));
+        } else if (fileMetadata.isValid()) {
             auto buffer = new QBuffer(this);
             buffer->setData(decryptFile(d->m_reply->readAll(), fileMetadata));
             buffer->open(ReadOnly);


### PR DESCRIPTION
This is usually more descriptive than what Qt gives us, like "remote media download failed" instead of an empty error message.

## Before

```
QML QQuickImage: Error transferring https://pyra.sh/_matrix/media/v3/download/kde.org/a0912dce19090768b1ccd789de10e5cc18766012?allow_remote=true&timeout_ms=20000&allow_redirect=false - server replied: 
```

## After

```
QML QQuickImage: Not found (https://pyra.sh/_matrix/media/v3/download/kde.org/bf5be8d9178cadaf45cc6d2d00653f69b04f2b84?allow_remote=true&timeout_ms=20000&allow_redirect=false)
```