### PR TITLE
Another round of modernization and cleanup

### DIFF
--- a/Quotient/application-service/definitions/location.h
+++ b/Quotient/application-service/definitions/location.h
@@ -21,9 +21,9 @@ template <>
 struct JsonObjectConverter<ThirdPartyLocation> {
     static void dumpTo(QJsonObject& jo, const ThirdPartyLocation& pod)
     {
-        addParam<>(jo, "alias"_L1, pod.alias);
-        addParam<>(jo, "protocol"_L1, pod.protocol);
-        addParam<>(jo, "fields"_L1, pod.fields);
+        addParam(jo, "alias"_L1, pod.alias);
+        addParam(jo, "protocol"_L1, pod.protocol);
+        addParam(jo, "fields"_L1, pod.fields);
     }
     static void fillFrom(const QJsonObject& jo, ThirdPartyLocation& pod)
     {

--- a/Quotient/application-service/definitions/protocol.h
+++ b/Quotient/application-service/definitions/protocol.h
@@ -20,8 +20,8 @@ template <>
 struct JsonObjectConverter<FieldType> {
     static void dumpTo(QJsonObject& jo, const FieldType& pod)
     {
-        addParam<>(jo, "regexp"_L1, pod.regexp);
-        addParam<>(jo, "placeholder"_L1, pod.placeholder);
+        addParam(jo, "regexp"_L1, pod.regexp);
+        addParam(jo, "placeholder"_L1, pod.placeholder);
     }
     static void fillFrom(const QJsonObject& jo, FieldType& pod)
     {
@@ -49,9 +49,9 @@ template <>
 struct JsonObjectConverter<ProtocolInstance> {
     static void dumpTo(QJsonObject& jo, const ProtocolInstance& pod)
     {
-        addParam<>(jo, "desc"_L1, pod.desc);
-        addParam<>(jo, "fields"_L1, pod.fields);
-        addParam<>(jo, "network_id"_L1, pod.networkId);
+        addParam(jo, "desc"_L1, pod.desc);
+        addParam(jo, "fields"_L1, pod.fields);
+        addParam(jo, "network_id"_L1, pod.networkId);
         addParam<IfNotEmpty>(jo, "icon"_L1, pod.icon);
     }
     static void fillFrom(const QJsonObject& jo, ProtocolInstance& pod)
@@ -96,11 +96,11 @@ template <>
 struct JsonObjectConverter<ThirdPartyProtocol> {
     static void dumpTo(QJsonObject& jo, const ThirdPartyProtocol& pod)
     {
-        addParam<>(jo, "user_fields"_L1, pod.userFields);
-        addParam<>(jo, "location_fields"_L1, pod.locationFields);
-        addParam<>(jo, "icon"_L1, pod.icon);
-        addParam<>(jo, "field_types"_L1, pod.fieldTypes);
-        addParam<>(jo, "instances"_L1, pod.instances);
+        addParam(jo, "user_fields"_L1, pod.userFields);
+        addParam(jo, "location_fields"_L1, pod.locationFields);
+        addParam(jo, "icon"_L1, pod.icon);
+        addParam(jo, "field_types"_L1, pod.fieldTypes);
+        addParam(jo, "instances"_L1, pod.instances);
     }
     static void fillFrom(const QJsonObject& jo, ThirdPartyProtocol& pod)
     {

--- a/Quotient/application-service/definitions/user.h
+++ b/Quotient/application-service/definitions/user.h
@@ -21,9 +21,9 @@ template <>
 struct JsonObjectConverter<ThirdPartyUser> {
     static void dumpTo(QJsonObject& jo, const ThirdPartyUser& pod)
     {
-        addParam<>(jo, "userid"_L1, pod.userid);
-        addParam<>(jo, "protocol"_L1, pod.protocol);
-        addParam<>(jo, "fields"_L1, pod.fields);
+        addParam(jo, "userid"_L1, pod.userid);
+        addParam(jo, "protocol"_L1, pod.protocol);
+        addParam(jo, "fields"_L1, pod.fields);
     }
     static void fillFrom(const QJsonObject& jo, ThirdPartyUser& pod)
     {

--- a/Quotient/connection.cpp
+++ b/Quotient/connection.cpp
@@ -835,7 +835,7 @@ QFuture<Room*> Connection::getDirectChat(const QString& otherUserId)
                 continue;
             qCDebug(MAIN) << "Requested direct chat with" << otherUserId
                           << "is already available as" << r->id();
-            return QtFuture::makeReadyFuture(r);
+            return makeReadyValueFuture(r);
         }
         if (auto ir = invitation(roomId)) {
             Q_ASSERT(ir->id() == roomId);

--- a/Quotient/connection.cpp
+++ b/Quotient/connection.cpp
@@ -48,6 +48,8 @@
 #include <QtNetwork/QDnsLookup>
 #include <qt6keychain/keychain.h>
 
+#include <ranges>
+
 using namespace Quotient;
 
 namespace {
@@ -1123,7 +1125,7 @@ QVector<Room*> Connection::allRooms() const
 {
     QVector<Room*> result;
     result.resize(d->roomMap.size());
-    std::copy(d->roomMap.cbegin(), d->roomMap.cend(), result.begin());
+    std::ranges::copy(d->roomMap, result.begin());
     return result;
 }
 
@@ -1203,9 +1205,8 @@ QStringList Connection::tagNames() const
 QVector<Room*> Connection::roomsWithTag(const QString& tagName) const
 {
     QVector<Room*> rooms;
-    std::copy_if(d->roomMap.cbegin(), d->roomMap.cend(),
-                 std::back_inserter(rooms),
-                 [&tagName](Room* r) { return r->tags().contains(tagName); });
+    std::ranges::copy_if(d->roomMap, std::back_inserter(rooms),
+                         [&tagName](Room* r) { return r->tags().contains(tagName); });
     return rooms;
 }
 
@@ -1657,31 +1658,30 @@ void Connection::enableDirectChatEncryption(bool enable)
     emit directChatsEncryptionChanged(enable);
 }
 
-inline bool roomVersionLess(const Connection::SupportedRoomVersion& v1,
-                            const Connection::SupportedRoomVersion& v2)
-{
-    bool ok1 = false, ok2 = false;
-    const auto vNum1 = v1.id.toFloat(&ok1);
-    const auto vNum2 = v2.id.toFloat(&ok2);
-    return ok1 && ok2 ? vNum1 < vNum2 : v1.id < v2.id;
-}
-
 QVector<Connection::SupportedRoomVersion> Connection::availableRoomVersions() const
 {
-    QVector<SupportedRoomVersion> result;
-    if (d->capabilities.roomVersions) {
-        const auto& allVersions = d->capabilities.roomVersions->available;
-        result.reserve(allVersions.size());
-        for (auto it = allVersions.begin(); it != allVersions.end(); ++it)
-            result.push_back({ it.key(), it.value() });
-        // Put stable versions over unstable; within each group,
-        // sort numeric versions as numbers, the rest as strings.
-        const auto mid =
-            std::partition(result.begin(), result.end(),
-                           std::mem_fn(&SupportedRoomVersion::isStable));
-        std::sort(result.begin(), mid, roomVersionLess);
-        std::sort(mid, result.end(), roomVersionLess);
-    }
+    if (!d->capabilities.roomVersions)
+        return {};
+
+    // Can't stuff QKeyValueRange in a std:: view directly because it's not move-assignable and
+    // most views require that - using std::views::all to go around this
+    // TODO: use std::ranges::to() when all toolchains support it
+    const auto allVersions = d->capabilities.roomVersions->available.asKeyValueRange();
+    auto allVersionsView = std::views::all(allVersions) | std::views::transform([](const auto& p) {
+                               return SupportedRoomVersion{ p.first, p.second };
+                           });
+    QVector<SupportedRoomVersion> result(allVersionsView.begin(), allVersionsView.end());
+    // Put stable versions over unstable; for
+    std::ranges::sort(result, [](const SupportedRoomVersion& v1, const SupportedRoomVersion& v2) {
+        if (const auto stable1 = v1.isStable(), stable2 = v2.isStable(); stable1 != stable2)
+            return stable1 && !stable2; // Put all stable versions over unstable
+        // For two versions with the same stability, if both versions are numeric order them as
+        // numbers, otherwise compare strings.
+        bool ok1 = false, ok2 = false;
+        const auto vNum1 = v1.id.toFloat(&ok1);
+        const auto vNum2 = v2.id.toFloat(&ok2);
+        return ok1 && ok2 ? vNum1 < vNum2 : v1.id < v2.id;
+    });
     return result;
 }
 

--- a/Quotient/connectiondata.cpp
+++ b/Quotient/connectiondata.cpp
@@ -82,7 +82,7 @@ void ConnectionData::submit(BaseJob* job)
 {
     job->setStatus(BaseJob::Pending);
     if (!d->rateLimiter.isActive()) {
-        QTimer::singleShot(0, job, &BaseJob::sendRequest);
+        QMetaObject::invokeMethod(job, &BaseJob::sendRequest, Qt::QueuedConnection);
         return;
     }
     d->jobs[size_t(job->isBackground())].emplace(job);

--- a/Quotient/connectionencryptiondata_p.cpp
+++ b/Quotient/connectionencryptiondata_p.cpp
@@ -53,7 +53,7 @@ QFuture<void> setupPicklingKey(Connection* connection,
                     qDebug(E2EE) << "Successfully loaded pickling key from keychain";
                     encryptionData = std::make_unique<ConnectionEncryptionData>(
                         connection, PicklingKey::fromByteArray(std::move(data)));
-                    return QtFuture::makeReadyFuture<Job*>(nullptr);
+                    return makeReadyValueFuture<Job*>(nullptr);
                 }
                 qCritical(E2EE)
                     << "The pickling key loaded from" << keychainId << "has length"

--- a/Quotient/connectionencryptiondata_p.cpp
+++ b/Quotient/connectionencryptiondata_p.cpp
@@ -592,8 +592,7 @@ void ConnectionEncryptionData::handleDevicesList(
                     << device.userId << user;
                 continue;
             }
-            if (!std::all_of(device.algorithms.cbegin(),
-                             device.algorithms.cend(), isSupportedAlgorithm)) {
+            if (!std::ranges::all_of(device.algorithms, isSupportedAlgorithm)) {
                 qWarning(E2EE) << "Unsupported encryption algorithms found"
                                << device.algorithms;
                 continue;
@@ -755,8 +754,7 @@ std::pair<QByteArray, QByteArray> doDecryptMessage(const QOlmSession& session,
 {
     const auto expectedMessage = session.decrypt(message);
     if (expectedMessage) {
-        const auto result =
-            std::make_pair(*expectedMessage, session.sessionId());
+        const auto result = std::pair{ *expectedMessage, session.sessionId() };
         andThen();
         return result;
     }

--- a/Quotient/csapi/administrative_contact.cpp
+++ b/Quotient/csapi/administrative_contact.cpp
@@ -18,7 +18,7 @@ Post3PIDsJob::Post3PIDsJob(const ThreePidCredentials& threePidCreds)
     : BaseJob(HttpVerb::Post, u"Post3PIDsJob"_s, makePath("/_matrix/client/v3", "/account/3pid"))
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, "three_pid_creds"_L1, threePidCreds);
+    addParam(_dataJson, "three_pid_creds"_L1, threePidCreds);
     setRequestData({ _dataJson });
 }
 
@@ -28,8 +28,8 @@ Add3PIDJob::Add3PIDJob(const QString& clientSecret, const QString& sid,
 {
     QJsonObject _dataJson;
     addParam<IfNotEmpty>(_dataJson, "auth"_L1, auth);
-    addParam<>(_dataJson, "client_secret"_L1, clientSecret);
-    addParam<>(_dataJson, "sid"_L1, sid);
+    addParam(_dataJson, "client_secret"_L1, clientSecret);
+    addParam(_dataJson, "sid"_L1, sid);
     setRequestData({ _dataJson });
 }
 
@@ -38,10 +38,10 @@ Bind3PIDJob::Bind3PIDJob(const QString& clientSecret, const QString& idServer,
     : BaseJob(HttpVerb::Post, u"Bind3PIDJob"_s, makePath("/_matrix/client/v3", "/account/3pid/bind"))
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, "client_secret"_L1, clientSecret);
-    addParam<>(_dataJson, "id_server"_L1, idServer);
-    addParam<>(_dataJson, "id_access_token"_L1, idAccessToken);
-    addParam<>(_dataJson, "sid"_L1, sid);
+    addParam(_dataJson, "client_secret"_L1, clientSecret);
+    addParam(_dataJson, "id_server"_L1, idServer);
+    addParam(_dataJson, "id_access_token"_L1, idAccessToken);
+    addParam(_dataJson, "sid"_L1, sid);
     setRequestData({ _dataJson });
 }
 
@@ -52,8 +52,8 @@ Delete3pidFromAccountJob::Delete3pidFromAccountJob(const QString& medium, const 
 {
     QJsonObject _dataJson;
     addParam<IfNotEmpty>(_dataJson, "id_server"_L1, idServer);
-    addParam<>(_dataJson, "medium"_L1, medium);
-    addParam<>(_dataJson, "address"_L1, address);
+    addParam(_dataJson, "medium"_L1, medium);
+    addParam(_dataJson, "address"_L1, address);
     setRequestData({ _dataJson });
     addExpectedKey(u"id_server_unbind_result"_s);
 }
@@ -65,8 +65,8 @@ Unbind3pidFromAccountJob::Unbind3pidFromAccountJob(const QString& medium, const 
 {
     QJsonObject _dataJson;
     addParam<IfNotEmpty>(_dataJson, "id_server"_L1, idServer);
-    addParam<>(_dataJson, "medium"_L1, medium);
-    addParam<>(_dataJson, "address"_L1, address);
+    addParam(_dataJson, "medium"_L1, medium);
+    addParam(_dataJson, "address"_L1, address);
     setRequestData({ _dataJson });
     addExpectedKey(u"id_server_unbind_result"_s);
 }

--- a/Quotient/csapi/administrative_contact.h
+++ b/Quotient/csapi/administrative_contact.h
@@ -140,10 +140,10 @@ template <>
 struct QUOTIENT_API JsonObjectConverter<Post3PIDsJob::ThreePidCredentials> {
     static void dumpTo(QJsonObject& jo, const Post3PIDsJob::ThreePidCredentials& pod)
     {
-        addParam<>(jo, "client_secret"_L1, pod.clientSecret);
-        addParam<>(jo, "id_server"_L1, pod.idServer);
-        addParam<>(jo, "id_access_token"_L1, pod.idAccessToken);
-        addParam<>(jo, "sid"_L1, pod.sid);
+        addParam(jo, "client_secret"_L1, pod.clientSecret);
+        addParam(jo, "id_server"_L1, pod.idServer);
+        addParam(jo, "id_access_token"_L1, pod.idAccessToken);
+        addParam(jo, "sid"_L1, pod.sid);
     }
 };
 QT_WARNING_POP

--- a/Quotient/csapi/appservice_room_directory.cpp
+++ b/Quotient/csapi/appservice_room_directory.cpp
@@ -11,6 +11,6 @@ UpdateAppserviceRoomDirectoryVisibilityJob::UpdateAppserviceRoomDirectoryVisibil
               false)
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, "visibility"_L1, visibility);
+    addParam(_dataJson, "visibility"_L1, visibility);
     setRequestData({ _dataJson });
 }

--- a/Quotient/csapi/authed-content-repo.cpp
+++ b/Quotient/csapi/authed-content-repo.cpp
@@ -63,8 +63,8 @@ auto queryToGetContentThumbnailAuthed(int width, int height, const QString& meth
                                       qint64 timeoutMs, std::optional<bool> animated)
 {
     QUrlQuery _q;
-    addParam<>(_q, u"width"_s, width);
-    addParam<>(_q, u"height"_s, height);
+    addParam(_q, u"width"_s, width);
+    addParam(_q, u"height"_s, height);
     addParam<IfNotEmpty>(_q, u"method"_s, method);
     addParam<IfNotEmpty>(_q, u"timeout_ms"_s, timeoutMs);
     addParam<IfNotEmpty>(_q, u"animated"_s, animated);
@@ -96,7 +96,7 @@ GetContentThumbnailAuthedJob::GetContentThumbnailAuthedJob(const QString& server
 auto queryToGetUrlPreviewAuthed(const QUrl& url, std::optional<qint64> ts)
 {
     QUrlQuery _q;
-    addParam<>(_q, u"url"_s, url);
+    addParam(_q, u"url"_s, url);
     addParam<IfNotEmpty>(_q, u"ts"_s, ts);
     return _q;
 }

--- a/Quotient/csapi/banning.cpp
+++ b/Quotient/csapi/banning.cpp
@@ -8,7 +8,7 @@ BanJob::BanJob(const QString& roomId, const QString& userId, const QString& reas
     : BaseJob(HttpVerb::Post, u"BanJob"_s, makePath("/_matrix/client/v3", "/rooms/", roomId, "/ban"))
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, "user_id"_L1, userId);
+    addParam(_dataJson, "user_id"_L1, userId);
     addParam<IfNotEmpty>(_dataJson, "reason"_L1, reason);
     setRequestData({ _dataJson });
 }
@@ -18,7 +18,7 @@ UnbanJob::UnbanJob(const QString& roomId, const QString& userId, const QString& 
               makePath("/_matrix/client/v3", "/rooms/", roomId, "/unban"))
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, "user_id"_L1, userId);
+    addParam(_dataJson, "user_id"_L1, userId);
     addParam<IfNotEmpty>(_dataJson, "reason"_L1, reason);
     setRequestData({ _dataJson });
 }

--- a/Quotient/csapi/capabilities.h
+++ b/Quotient/csapi/capabilities.h
@@ -15,7 +15,7 @@ template <>
 struct JsonObjectConverter<BooleanCapability> {
     static void dumpTo(QJsonObject& jo, const BooleanCapability& pod)
     {
-        addParam<>(jo, "enabled"_L1, pod.enabled);
+        addParam(jo, "enabled"_L1, pod.enabled);
     }
     static void fillFrom(const QJsonObject& jo, BooleanCapability& pod)
     {

--- a/Quotient/csapi/content-repo.cpp
+++ b/Quotient/csapi/content-repo.cpp
@@ -112,8 +112,8 @@ auto queryToGetContentThumbnail(int width, int height, const QString& method, bo
                                 qint64 timeoutMs, bool allowRedirect, std::optional<bool> animated)
 {
     QUrlQuery _q;
-    addParam<>(_q, u"width"_s, width);
-    addParam<>(_q, u"height"_s, height);
+    addParam(_q, u"width"_s, width);
+    addParam(_q, u"height"_s, height);
     addParam<IfNotEmpty>(_q, u"method"_s, method);
     addParam<IfNotEmpty>(_q, u"allow_remote"_s, allowRemote);
     addParam<IfNotEmpty>(_q, u"timeout_ms"_s, timeoutMs);
@@ -151,7 +151,7 @@ GetContentThumbnailJob::GetContentThumbnailJob(const QString& serverName, const 
 auto queryToGetUrlPreview(const QUrl& url, std::optional<qint64> ts)
 {
     QUrlQuery _q;
-    addParam<>(_q, u"url"_s, url);
+    addParam(_q, u"url"_s, url);
     addParam<IfNotEmpty>(_q, u"ts"_s, ts);
     return _q;
 }

--- a/Quotient/csapi/create_room.h
+++ b/Quotient/csapi/create_room.h
@@ -186,10 +186,10 @@ template <>
 struct QUOTIENT_API JsonObjectConverter<CreateRoomJob::Invite3pid> {
     static void dumpTo(QJsonObject& jo, const CreateRoomJob::Invite3pid& pod)
     {
-        addParam<>(jo, "id_server"_L1, pod.idServer);
-        addParam<>(jo, "id_access_token"_L1, pod.idAccessToken);
-        addParam<>(jo, "medium"_L1, pod.medium);
-        addParam<>(jo, "address"_L1, pod.address);
+        addParam(jo, "id_server"_L1, pod.idServer);
+        addParam(jo, "id_access_token"_L1, pod.idAccessToken);
+        addParam(jo, "medium"_L1, pod.medium);
+        addParam(jo, "address"_L1, pod.address);
     }
 };
 
@@ -197,8 +197,8 @@ template <>
 struct QUOTIENT_API JsonObjectConverter<CreateRoomJob::StateEvent> {
     static void dumpTo(QJsonObject& jo, const CreateRoomJob::StateEvent& pod)
     {
-        addParam<>(jo, "type"_L1, pod.type);
-        addParam<>(jo, "content"_L1, pod.content);
+        addParam(jo, "type"_L1, pod.type);
+        addParam(jo, "content"_L1, pod.content);
         addParam<IfNotEmpty>(jo, "state_key"_L1, pod.stateKey);
     }
 };

--- a/Quotient/csapi/definitions/client_device.h
+++ b/Quotient/csapi/definitions/client_device.h
@@ -28,7 +28,7 @@ template <>
 struct JsonObjectConverter<Device> {
     static void dumpTo(QJsonObject& jo, const Device& pod)
     {
-        addParam<>(jo, "device_id"_L1, pod.deviceId);
+        addParam(jo, "device_id"_L1, pod.deviceId);
         addParam<IfNotEmpty>(jo, "display_name"_L1, pod.displayName);
         addParam<IfNotEmpty>(jo, "last_seen_ip"_L1, pod.lastSeenIp);
         addParam<IfNotEmpty>(jo, "last_seen_ts"_L1, pod.lastSeenTs);

--- a/Quotient/csapi/definitions/cross_signing_key.h
+++ b/Quotient/csapi/definitions/cross_signing_key.h
@@ -28,9 +28,9 @@ template <>
 struct JsonObjectConverter<CrossSigningKey> {
     static void dumpTo(QJsonObject& jo, const CrossSigningKey& pod)
     {
-        addParam<>(jo, "user_id"_L1, pod.userId);
-        addParam<>(jo, "usage"_L1, pod.usage);
-        addParam<>(jo, "keys"_L1, pod.keys);
+        addParam(jo, "user_id"_L1, pod.userId);
+        addParam(jo, "usage"_L1, pod.usage);
+        addParam(jo, "keys"_L1, pod.keys);
         addParam<IfNotEmpty>(jo, "signatures"_L1, pod.signatures);
     }
     static void fillFrom(const QJsonObject& jo, CrossSigningKey& pod)

--- a/Quotient/csapi/definitions/device_keys.h
+++ b/Quotient/csapi/definitions/device_keys.h
@@ -35,11 +35,11 @@ template <>
 struct JsonObjectConverter<DeviceKeys> {
     static void dumpTo(QJsonObject& jo, const DeviceKeys& pod)
     {
-        addParam<>(jo, "user_id"_L1, pod.userId);
-        addParam<>(jo, "device_id"_L1, pod.deviceId);
-        addParam<>(jo, "algorithms"_L1, pod.algorithms);
-        addParam<>(jo, "keys"_L1, pod.keys);
-        addParam<>(jo, "signatures"_L1, pod.signatures);
+        addParam(jo, "user_id"_L1, pod.userId);
+        addParam(jo, "device_id"_L1, pod.deviceId);
+        addParam(jo, "algorithms"_L1, pod.algorithms);
+        addParam(jo, "keys"_L1, pod.keys);
+        addParam(jo, "signatures"_L1, pod.signatures);
     }
     static void fillFrom(const QJsonObject& jo, DeviceKeys& pod)
     {

--- a/Quotient/csapi/definitions/key_backup_data.h
+++ b/Quotient/csapi/definitions/key_backup_data.h
@@ -27,10 +27,10 @@ template <>
 struct JsonObjectConverter<KeyBackupData> {
     static void dumpTo(QJsonObject& jo, const KeyBackupData& pod)
     {
-        addParam<>(jo, "first_message_index"_L1, pod.firstMessageIndex);
-        addParam<>(jo, "forwarded_count"_L1, pod.forwardedCount);
-        addParam<>(jo, "is_verified"_L1, pod.isVerified);
-        addParam<>(jo, "session_data"_L1, pod.sessionData);
+        addParam(jo, "first_message_index"_L1, pod.firstMessageIndex);
+        addParam(jo, "forwarded_count"_L1, pod.forwardedCount);
+        addParam(jo, "is_verified"_L1, pod.isVerified);
+        addParam(jo, "session_data"_L1, pod.sessionData);
     }
     static void fillFrom(const QJsonObject& jo, KeyBackupData& pod)
     {

--- a/Quotient/csapi/definitions/openid_token.h
+++ b/Quotient/csapi/definitions/openid_token.h
@@ -28,10 +28,10 @@ template <>
 struct JsonObjectConverter<OpenIdCredentials> {
     static void dumpTo(QJsonObject& jo, const OpenIdCredentials& pod)
     {
-        addParam<>(jo, "access_token"_L1, pod.accessToken);
-        addParam<>(jo, "token_type"_L1, pod.tokenType);
-        addParam<>(jo, "matrix_server_name"_L1, pod.matrixServerName);
-        addParam<>(jo, "expires_in"_L1, pod.expiresIn);
+        addParam(jo, "access_token"_L1, pod.accessToken);
+        addParam(jo, "token_type"_L1, pod.tokenType);
+        addParam(jo, "matrix_server_name"_L1, pod.matrixServerName);
+        addParam(jo, "expires_in"_L1, pod.expiresIn);
     }
     static void fillFrom(const QJsonObject& jo, OpenIdCredentials& pod)
     {

--- a/Quotient/csapi/definitions/public_rooms_response.h
+++ b/Quotient/csapi/definitions/public_rooms_response.h
@@ -47,10 +47,10 @@ template <>
 struct JsonObjectConverter<PublicRoomsChunk> {
     static void dumpTo(QJsonObject& jo, const PublicRoomsChunk& pod)
     {
-        addParam<>(jo, "num_joined_members"_L1, pod.numJoinedMembers);
-        addParam<>(jo, "room_id"_L1, pod.roomId);
-        addParam<>(jo, "world_readable"_L1, pod.worldReadable);
-        addParam<>(jo, "guest_can_join"_L1, pod.guestCanJoin);
+        addParam(jo, "num_joined_members"_L1, pod.numJoinedMembers);
+        addParam(jo, "room_id"_L1, pod.roomId);
+        addParam(jo, "world_readable"_L1, pod.worldReadable);
+        addParam(jo, "guest_can_join"_L1, pod.guestCanJoin);
         addParam<IfNotEmpty>(jo, "canonical_alias"_L1, pod.canonicalAlias);
         addParam<IfNotEmpty>(jo, "name"_L1, pod.name);
         addParam<IfNotEmpty>(jo, "topic"_L1, pod.topic);

--- a/Quotient/csapi/definitions/push_condition.h
+++ b/Quotient/csapi/definitions/push_condition.h
@@ -40,7 +40,7 @@ template <>
 struct JsonObjectConverter<PushCondition> {
     static void dumpTo(QJsonObject& jo, const PushCondition& pod)
     {
-        addParam<>(jo, "kind"_L1, pod.kind);
+        addParam(jo, "kind"_L1, pod.kind);
         addParam<IfNotEmpty>(jo, "key"_L1, pod.key);
         addParam<IfNotEmpty>(jo, "pattern"_L1, pod.pattern);
         addParam<IfNotEmpty>(jo, "is"_L1, pod.is);

--- a/Quotient/csapi/definitions/push_rule.h
+++ b/Quotient/csapi/definitions/push_rule.h
@@ -35,10 +35,10 @@ template <>
 struct JsonObjectConverter<PushRule> {
     static void dumpTo(QJsonObject& jo, const PushRule& pod)
     {
-        addParam<>(jo, "actions"_L1, pod.actions);
-        addParam<>(jo, "default"_L1, pod.isDefault);
-        addParam<>(jo, "enabled"_L1, pod.enabled);
-        addParam<>(jo, "rule_id"_L1, pod.ruleId);
+        addParam(jo, "actions"_L1, pod.actions);
+        addParam(jo, "default"_L1, pod.isDefault);
+        addParam(jo, "enabled"_L1, pod.enabled);
+        addParam(jo, "rule_id"_L1, pod.ruleId);
         addParam<IfNotEmpty>(jo, "conditions"_L1, pod.conditions);
         addParam<IfNotEmpty>(jo, "pattern"_L1, pod.pattern);
     }

--- a/Quotient/csapi/definitions/request_email_validation.h
+++ b/Quotient/csapi/definitions/request_email_validation.h
@@ -51,9 +51,9 @@ template <>
 struct JsonObjectConverter<EmailValidationData> {
     static void dumpTo(QJsonObject& jo, const EmailValidationData& pod)
     {
-        addParam<>(jo, "client_secret"_L1, pod.clientSecret);
-        addParam<>(jo, "email"_L1, pod.email);
-        addParam<>(jo, "send_attempt"_L1, pod.sendAttempt);
+        addParam(jo, "client_secret"_L1, pod.clientSecret);
+        addParam(jo, "email"_L1, pod.email);
+        addParam(jo, "send_attempt"_L1, pod.sendAttempt);
         addParam<IfNotEmpty>(jo, "next_link"_L1, pod.nextLink);
         addParam<IfNotEmpty>(jo, "id_server"_L1, pod.idServer);
         addParam<IfNotEmpty>(jo, "id_access_token"_L1, pod.idAccessToken);

--- a/Quotient/csapi/definitions/request_msisdn_validation.h
+++ b/Quotient/csapi/definitions/request_msisdn_validation.h
@@ -54,10 +54,10 @@ template <>
 struct JsonObjectConverter<MsisdnValidationData> {
     static void dumpTo(QJsonObject& jo, const MsisdnValidationData& pod)
     {
-        addParam<>(jo, "client_secret"_L1, pod.clientSecret);
-        addParam<>(jo, "country"_L1, pod.country);
-        addParam<>(jo, "phone_number"_L1, pod.phoneNumber);
-        addParam<>(jo, "send_attempt"_L1, pod.sendAttempt);
+        addParam(jo, "client_secret"_L1, pod.clientSecret);
+        addParam(jo, "country"_L1, pod.country);
+        addParam(jo, "phone_number"_L1, pod.phoneNumber);
+        addParam(jo, "send_attempt"_L1, pod.sendAttempt);
         addParam<IfNotEmpty>(jo, "next_link"_L1, pod.nextLink);
         addParam<IfNotEmpty>(jo, "id_server"_L1, pod.idServer);
         addParam<IfNotEmpty>(jo, "id_access_token"_L1, pod.idAccessToken);

--- a/Quotient/csapi/definitions/request_token_response.h
+++ b/Quotient/csapi/definitions/request_token_response.h
@@ -29,7 +29,7 @@ template <>
 struct JsonObjectConverter<RequestTokenResponse> {
     static void dumpTo(QJsonObject& jo, const RequestTokenResponse& pod)
     {
-        addParam<>(jo, "sid"_L1, pod.sid);
+        addParam(jo, "sid"_L1, pod.sid);
         addParam<IfNotEmpty>(jo, "submit_url"_L1, pod.submitUrl);
     }
     static void fillFrom(const QJsonObject& jo, RequestTokenResponse& pod)

--- a/Quotient/csapi/definitions/room_key_backup.h
+++ b/Quotient/csapi/definitions/room_key_backup.h
@@ -17,7 +17,7 @@ template <>
 struct JsonObjectConverter<RoomKeyBackup> {
     static void dumpTo(QJsonObject& jo, const RoomKeyBackup& pod)
     {
-        addParam<>(jo, "sessions"_L1, pod.sessions);
+        addParam(jo, "sessions"_L1, pod.sessions);
     }
     static void fillFrom(const QJsonObject& jo, RoomKeyBackup& pod)
     {

--- a/Quotient/csapi/definitions/third_party_signed.h
+++ b/Quotient/csapi/definitions/third_party_signed.h
@@ -25,10 +25,10 @@ template <>
 struct JsonObjectConverter<ThirdPartySigned> {
     static void dumpTo(QJsonObject& jo, const ThirdPartySigned& pod)
     {
-        addParam<>(jo, "sender"_L1, pod.sender);
-        addParam<>(jo, "mxid"_L1, pod.mxid);
-        addParam<>(jo, "token"_L1, pod.token);
-        addParam<>(jo, "signatures"_L1, pod.signatures);
+        addParam(jo, "sender"_L1, pod.sender);
+        addParam(jo, "mxid"_L1, pod.mxid);
+        addParam(jo, "token"_L1, pod.token);
+        addParam(jo, "signatures"_L1, pod.signatures);
     }
     static void fillFrom(const QJsonObject& jo, ThirdPartySigned& pod)
     {

--- a/Quotient/csapi/definitions/user_identifier.h
+++ b/Quotient/csapi/definitions/user_identifier.h
@@ -20,7 +20,7 @@ struct JsonObjectConverter<UserIdentifier> {
     static void dumpTo(QJsonObject& jo, const UserIdentifier& pod)
     {
         fillJson(jo, pod.additionalProperties);
-        addParam<>(jo, "type"_L1, pod.type);
+        addParam(jo, "type"_L1, pod.type);
     }
     static void fillFrom(QJsonObject jo, UserIdentifier& pod)
     {

--- a/Quotient/csapi/definitions/wellknown/full.h
+++ b/Quotient/csapi/definitions/wellknown/full.h
@@ -24,7 +24,7 @@ struct JsonObjectConverter<DiscoveryInformation> {
     static void dumpTo(QJsonObject& jo, const DiscoveryInformation& pod)
     {
         fillJson(jo, pod.additionalProperties);
-        addParam<>(jo, "m.homeserver"_L1, pod.homeserver);
+        addParam(jo, "m.homeserver"_L1, pod.homeserver);
         addParam<IfNotEmpty>(jo, "m.identity_server"_L1, pod.identityServer);
     }
     static void fillFrom(QJsonObject jo, DiscoveryInformation& pod)

--- a/Quotient/csapi/definitions/wellknown/homeserver.h
+++ b/Quotient/csapi/definitions/wellknown/homeserver.h
@@ -15,7 +15,7 @@ template <>
 struct JsonObjectConverter<HomeserverInformation> {
     static void dumpTo(QJsonObject& jo, const HomeserverInformation& pod)
     {
-        addParam<>(jo, "base_url"_L1, pod.baseUrl);
+        addParam(jo, "base_url"_L1, pod.baseUrl);
     }
     static void fillFrom(const QJsonObject& jo, HomeserverInformation& pod)
     {

--- a/Quotient/csapi/definitions/wellknown/identity_server.h
+++ b/Quotient/csapi/definitions/wellknown/identity_server.h
@@ -15,7 +15,7 @@ template <>
 struct JsonObjectConverter<IdentityServerInformation> {
     static void dumpTo(QJsonObject& jo, const IdentityServerInformation& pod)
     {
-        addParam<>(jo, "base_url"_L1, pod.baseUrl);
+        addParam(jo, "base_url"_L1, pod.baseUrl);
     }
     static void fillFrom(const QJsonObject& jo, IdentityServerInformation& pod)
     {

--- a/Quotient/csapi/device_management.cpp
+++ b/Quotient/csapi/device_management.cpp
@@ -48,7 +48,7 @@ DeleteDevicesJob::DeleteDevicesJob(const QStringList& devices,
               makePath("/_matrix/client/v3", "/delete_devices"))
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, "devices"_L1, devices);
+    addParam(_dataJson, "devices"_L1, devices);
     addParam<IfNotEmpty>(_dataJson, "auth"_L1, auth);
     setRequestData({ _dataJson });
 }

--- a/Quotient/csapi/directory.cpp
+++ b/Quotient/csapi/directory.cpp
@@ -9,7 +9,7 @@ SetRoomAliasJob::SetRoomAliasJob(const QString& roomAlias, const QString& roomId
               makePath("/_matrix/client/v3", "/directory/room/", roomAlias))
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, "room_id"_L1, roomId);
+    addParam(_dataJson, "room_id"_L1, roomId);
     setRequestData({ _dataJson });
 }
 

--- a/Quotient/csapi/inviting.cpp
+++ b/Quotient/csapi/inviting.cpp
@@ -9,7 +9,7 @@ InviteUserJob::InviteUserJob(const QString& roomId, const QString& userId, const
               makePath("/_matrix/client/v3", "/rooms/", roomId, "/invite"))
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, "user_id"_L1, userId);
+    addParam(_dataJson, "user_id"_L1, userId);
     addParam<IfNotEmpty>(_dataJson, "reason"_L1, reason);
     setRequestData({ _dataJson });
 }

--- a/Quotient/csapi/key_backup.cpp
+++ b/Quotient/csapi/key_backup.cpp
@@ -9,8 +9,8 @@ PostRoomKeysVersionJob::PostRoomKeysVersionJob(const QString& algorithm, const Q
               makePath("/_matrix/client/v3", "/room_keys/version"))
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, "algorithm"_L1, algorithm);
-    addParam<>(_dataJson, "auth_data"_L1, authData);
+    addParam(_dataJson, "algorithm"_L1, algorithm);
+    addParam(_dataJson, "auth_data"_L1, authData);
     setRequestData({ _dataJson });
     addExpectedKey(u"version"_s);
 }
@@ -54,8 +54,8 @@ PutRoomKeysVersionJob::PutRoomKeysVersionJob(const QString& version, const QStri
               makePath("/_matrix/client/v3", "/room_keys/version/", version))
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, "algorithm"_L1, algorithm);
-    addParam<>(_dataJson, "auth_data"_L1, authData);
+    addParam(_dataJson, "algorithm"_L1, algorithm);
+    addParam(_dataJson, "auth_data"_L1, authData);
     setRequestData({ _dataJson });
 }
 
@@ -73,7 +73,7 @@ DeleteRoomKeysVersionJob::DeleteRoomKeysVersionJob(const QString& version)
 auto queryToPutRoomKeyBySessionId(const QString& version)
 {
     QUrlQuery _q;
-    addParam<>(_q, u"version"_s, version);
+    addParam(_q, u"version"_s, version);
     return _q;
 }
 
@@ -91,7 +91,7 @@ PutRoomKeyBySessionIdJob::PutRoomKeyBySessionIdJob(const QString& roomId, const 
 auto queryToGetRoomKeyBySessionId(const QString& version)
 {
     QUrlQuery _q;
-    addParam<>(_q, u"version"_s, version);
+    addParam(_q, u"version"_s, version);
     return _q;
 }
 
@@ -114,7 +114,7 @@ GetRoomKeyBySessionIdJob::GetRoomKeyBySessionIdJob(const QString& roomId, const 
 auto queryToDeleteRoomKeyBySessionId(const QString& version)
 {
     QUrlQuery _q;
-    addParam<>(_q, u"version"_s, version);
+    addParam(_q, u"version"_s, version);
     return _q;
 }
 
@@ -141,7 +141,7 @@ DeleteRoomKeyBySessionIdJob::DeleteRoomKeyBySessionIdJob(const QString& roomId,
 auto queryToPutRoomKeysByRoomId(const QString& version)
 {
     QUrlQuery _q;
-    addParam<>(_q, u"version"_s, version);
+    addParam(_q, u"version"_s, version);
     return _q;
 }
 
@@ -159,7 +159,7 @@ PutRoomKeysByRoomIdJob::PutRoomKeysByRoomIdJob(const QString& roomId, const QStr
 auto queryToGetRoomKeysByRoomId(const QString& version)
 {
     QUrlQuery _q;
-    addParam<>(_q, u"version"_s, version);
+    addParam(_q, u"version"_s, version);
     return _q;
 }
 
@@ -180,7 +180,7 @@ GetRoomKeysByRoomIdJob::GetRoomKeysByRoomIdJob(const QString& roomId, const QStr
 auto queryToDeleteRoomKeysByRoomId(const QString& version)
 {
     QUrlQuery _q;
-    addParam<>(_q, u"version"_s, version);
+    addParam(_q, u"version"_s, version);
     return _q;
 }
 
@@ -204,7 +204,7 @@ DeleteRoomKeysByRoomIdJob::DeleteRoomKeysByRoomIdJob(const QString& roomId, cons
 auto queryToPutRoomKeys(const QString& version)
 {
     QUrlQuery _q;
-    addParam<>(_q, u"version"_s, version);
+    addParam(_q, u"version"_s, version);
     return _q;
 }
 
@@ -213,7 +213,7 @@ PutRoomKeysJob::PutRoomKeysJob(const QString& version, const QHash<RoomId, RoomK
               queryToPutRoomKeys(version))
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, "rooms"_L1, rooms);
+    addParam(_dataJson, "rooms"_L1, rooms);
     setRequestData({ _dataJson });
     addExpectedKey(u"etag"_s);
     addExpectedKey(u"count"_s);
@@ -222,7 +222,7 @@ PutRoomKeysJob::PutRoomKeysJob(const QString& version, const QHash<RoomId, RoomK
 auto queryToGetRoomKeys(const QString& version)
 {
     QUrlQuery _q;
-    addParam<>(_q, u"version"_s, version);
+    addParam(_q, u"version"_s, version);
     return _q;
 }
 
@@ -242,7 +242,7 @@ GetRoomKeysJob::GetRoomKeysJob(const QString& version)
 auto queryToDeleteRoomKeys(const QString& version)
 {
     QUrlQuery _q;
-    addParam<>(_q, u"version"_s, version);
+    addParam(_q, u"version"_s, version);
     return _q;
 }
 

--- a/Quotient/csapi/keys.cpp
+++ b/Quotient/csapi/keys.cpp
@@ -21,7 +21,7 @@ QueryKeysJob::QueryKeysJob(const QHash<UserId, QStringList>& deviceKeys, std::op
 {
     QJsonObject _dataJson;
     addParam<IfNotEmpty>(_dataJson, "timeout"_L1, timeout);
-    addParam<>(_dataJson, "device_keys"_L1, deviceKeys);
+    addParam(_dataJson, "device_keys"_L1, deviceKeys);
     setRequestData({ _dataJson });
 }
 
@@ -31,7 +31,7 @@ ClaimKeysJob::ClaimKeysJob(const QHash<UserId, QHash<QString, QString>>& oneTime
 {
     QJsonObject _dataJson;
     addParam<IfNotEmpty>(_dataJson, "timeout"_L1, timeout);
-    addParam<>(_dataJson, "one_time_keys"_L1, oneTimeKeys);
+    addParam(_dataJson, "one_time_keys"_L1, oneTimeKeys);
     setRequestData({ _dataJson });
     addExpectedKey(u"one_time_keys"_s);
 }
@@ -39,8 +39,8 @@ ClaimKeysJob::ClaimKeysJob(const QHash<UserId, QHash<QString, QString>>& oneTime
 auto queryToGetKeysChanges(const QString& from, const QString& to)
 {
     QUrlQuery _q;
-    addParam<>(_q, u"from"_s, from);
-    addParam<>(_q, u"to"_s, to);
+    addParam(_q, u"from"_s, from);
+    addParam(_q, u"to"_s, to);
     return _q;
 }
 

--- a/Quotient/csapi/kicking.cpp
+++ b/Quotient/csapi/kicking.cpp
@@ -9,7 +9,7 @@ KickJob::KickJob(const QString& roomId, const QString& userId, const QString& re
               makePath("/_matrix/client/v3", "/rooms/", roomId, "/kick"))
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, "user_id"_L1, userId);
+    addParam(_dataJson, "user_id"_L1, userId);
     addParam<IfNotEmpty>(_dataJson, "reason"_L1, reason);
     setRequestData({ _dataJson });
 }

--- a/Quotient/csapi/login.cpp
+++ b/Quotient/csapi/login.cpp
@@ -19,7 +19,7 @@ LoginJob::LoginJob(const QString& type, const std::optional<UserIdentifier>& ide
     : BaseJob(HttpVerb::Post, u"LoginJob"_s, makePath("/_matrix/client/v3", "/login"), false)
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, "type"_L1, type);
+    addParam(_dataJson, "type"_L1, type);
     addParam<IfNotEmpty>(_dataJson, "identifier"_L1, identifier);
     addParam<IfNotEmpty>(_dataJson, "password"_L1, password);
     addParam<IfNotEmpty>(_dataJson, "token"_L1, token);

--- a/Quotient/csapi/message_pagination.cpp
+++ b/Quotient/csapi/message_pagination.cpp
@@ -10,7 +10,7 @@ auto queryToGetRoomEvents(const QString& from, const QString& to, const QString&
     QUrlQuery _q;
     addParam<IfNotEmpty>(_q, u"from"_s, from);
     addParam<IfNotEmpty>(_q, u"to"_s, to);
-    addParam<>(_q, u"dir"_s, dir);
+    addParam(_q, u"dir"_s, dir);
     addParam<IfNotEmpty>(_q, u"limit"_s, limit);
     addParam<IfNotEmpty>(_q, u"filter"_s, filter);
     return _q;

--- a/Quotient/csapi/presence.cpp
+++ b/Quotient/csapi/presence.cpp
@@ -10,7 +10,7 @@ SetPresenceJob::SetPresenceJob(const QString& userId, const QString& presence,
               makePath("/_matrix/client/v3", "/presence/", userId, "/status"))
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, "presence"_L1, presence);
+    addParam(_dataJson, "presence"_L1, presence);
     addParam<IfNotEmpty>(_dataJson, "status_msg"_L1, statusMsg);
     setRequestData({ _dataJson });
 }

--- a/Quotient/csapi/profile.cpp
+++ b/Quotient/csapi/profile.cpp
@@ -9,7 +9,7 @@ SetDisplayNameJob::SetDisplayNameJob(const QString& userId, const QString& displ
               makePath("/_matrix/client/v3", "/profile/", userId, "/displayname"))
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, "displayname"_L1, displayname);
+    addParam(_dataJson, "displayname"_L1, displayname);
     setRequestData({ _dataJson });
 }
 
@@ -29,7 +29,7 @@ SetAvatarUrlJob::SetAvatarUrlJob(const QString& userId, const QUrl& avatarUrl)
               makePath("/_matrix/client/v3", "/profile/", userId, "/avatar_url"))
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, "avatar_url"_L1, avatarUrl);
+    addParam(_dataJson, "avatar_url"_L1, avatarUrl);
     setRequestData({ _dataJson });
 }
 

--- a/Quotient/csapi/pusher.cpp
+++ b/Quotient/csapi/pusher.cpp
@@ -20,9 +20,9 @@ PostPusherJob::PostPusherJob(const QString& pushkey, const QString& kind, const 
     : BaseJob(HttpVerb::Post, u"PostPusherJob"_s, makePath("/_matrix/client/v3", "/pushers/set"))
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, "pushkey"_L1, pushkey);
-    addParam<>(_dataJson, "kind"_L1, kind);
-    addParam<>(_dataJson, "app_id"_L1, appId);
+    addParam(_dataJson, "pushkey"_L1, pushkey);
+    addParam(_dataJson, "kind"_L1, kind);
+    addParam(_dataJson, "app_id"_L1, appId);
     addParam<IfNotEmpty>(_dataJson, "app_display_name"_L1, appDisplayName);
     addParam<IfNotEmpty>(_dataJson, "device_display_name"_L1, deviceDisplayName);
     addParam<IfNotEmpty>(_dataJson, "profile_tag"_L1, profileTag);

--- a/Quotient/csapi/pushrules.cpp
+++ b/Quotient/csapi/pushrules.cpp
@@ -66,7 +66,7 @@ SetPushRuleJob::SetPushRuleJob(const QString& kind, const QString& ruleId,
               queryToSetPushRule(before, after))
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, "actions"_L1, actions);
+    addParam(_dataJson, "actions"_L1, actions);
     addParam<IfNotEmpty>(_dataJson, "conditions"_L1, conditions);
     addParam<IfNotEmpty>(_dataJson, "pattern"_L1, pattern);
     setRequestData({ _dataJson });
@@ -92,7 +92,7 @@ SetPushRuleEnabledJob::SetPushRuleEnabledJob(const QString& kind, const QString&
               makePath("/_matrix/client/v3", "/pushrules/global/", kind, "/", ruleId, "/enabled"))
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, "enabled"_L1, enabled);
+    addParam(_dataJson, "enabled"_L1, enabled);
     setRequestData({ _dataJson });
 }
 
@@ -116,6 +116,6 @@ SetPushRuleActionsJob::SetPushRuleActionsJob(const QString& kind, const QString&
               makePath("/_matrix/client/v3", "/pushrules/global/", kind, "/", ruleId, "/actions"))
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, "actions"_L1, actions);
+    addParam(_dataJson, "actions"_L1, actions);
     setRequestData({ _dataJson });
 }

--- a/Quotient/csapi/refresh.cpp
+++ b/Quotient/csapi/refresh.cpp
@@ -8,7 +8,7 @@ RefreshJob::RefreshJob(const QString& refreshToken)
     : BaseJob(HttpVerb::Post, u"RefreshJob"_s, makePath("/_matrix/client/v3", "/refresh"), false)
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, "refresh_token"_L1, refreshToken);
+    addParam(_dataJson, "refresh_token"_L1, refreshToken);
     setRequestData({ _dataJson });
     addExpectedKey(u"access_token"_s);
 }

--- a/Quotient/csapi/registration.cpp
+++ b/Quotient/csapi/registration.cpp
@@ -50,7 +50,7 @@ ChangePasswordJob::ChangePasswordJob(const QString& newPassword, bool logoutDevi
               makePath("/_matrix/client/v3", "/account/password"))
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, "new_password"_L1, newPassword);
+    addParam(_dataJson, "new_password"_L1, newPassword);
     addParam<IfNotEmpty>(_dataJson, "logout_devices"_L1, logoutDevices);
     addParam<IfNotEmpty>(_dataJson, "auth"_L1, auth);
     setRequestData({ _dataJson });
@@ -88,7 +88,7 @@ DeactivateAccountJob::DeactivateAccountJob(const std::optional<AuthenticationDat
 auto queryToCheckUsernameAvailability(const QString& username)
 {
     QUrlQuery _q;
-    addParam<>(_q, u"username"_s, username);
+    addParam(_q, u"username"_s, username);
     return _q;
 }
 

--- a/Quotient/csapi/registration_tokens.cpp
+++ b/Quotient/csapi/registration_tokens.cpp
@@ -7,7 +7,7 @@ using namespace Quotient;
 auto queryToRegistrationTokenValidity(const QString& token)
 {
     QUrlQuery _q;
-    addParam<>(_q, u"token"_s, token);
+    addParam(_q, u"token"_s, token);
     return _q;
 }
 

--- a/Quotient/csapi/room_event_by_timestamp.cpp
+++ b/Quotient/csapi/room_event_by_timestamp.cpp
@@ -7,8 +7,8 @@ using namespace Quotient;
 auto queryToGetEventByTimestamp(int ts, const QString& dir)
 {
     QUrlQuery _q;
-    addParam<>(_q, u"ts"_s, ts);
-    addParam<>(_q, u"dir"_s, dir);
+    addParam(_q, u"ts"_s, ts);
+    addParam(_q, u"dir"_s, dir);
     return _q;
 }
 

--- a/Quotient/csapi/room_upgrades.cpp
+++ b/Quotient/csapi/room_upgrades.cpp
@@ -9,7 +9,7 @@ UpgradeRoomJob::UpgradeRoomJob(const QString& roomId, const QString& newVersion)
               makePath("/_matrix/client/v3", "/rooms/", roomId, "/upgrade"))
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, "new_version"_L1, newVersion);
+    addParam(_dataJson, "new_version"_L1, newVersion);
     setRequestData({ _dataJson });
     addExpectedKey(u"replacement_room"_s);
 }

--- a/Quotient/csapi/search.cpp
+++ b/Quotient/csapi/search.cpp
@@ -16,7 +16,7 @@ SearchJob::SearchJob(const Categories& searchCategories, const QString& nextBatc
               queryToSearch(nextBatch))
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, "search_categories"_L1, searchCategories);
+    addParam(_dataJson, "search_categories"_L1, searchCategories);
     setRequestData({ _dataJson });
     addExpectedKey(u"search_categories"_s);
 }

--- a/Quotient/csapi/search.h
+++ b/Quotient/csapi/search.h
@@ -230,7 +230,7 @@ template <>
 struct QUOTIENT_API JsonObjectConverter<SearchJob::RoomEventsCriteria> {
     static void dumpTo(QJsonObject& jo, const SearchJob::RoomEventsCriteria& pod)
     {
-        addParam<>(jo, "search_term"_L1, pod.searchTerm);
+        addParam(jo, "search_term"_L1, pod.searchTerm);
         addParam<IfNotEmpty>(jo, "keys"_L1, pod.keys);
         addParam<IfNotEmpty>(jo, "filter"_L1, pod.filter);
         addParam<IfNotEmpty>(jo, "order_by"_L1, pod.orderBy);

--- a/Quotient/csapi/sso_login_redirect.cpp
+++ b/Quotient/csapi/sso_login_redirect.cpp
@@ -7,7 +7,7 @@ using namespace Quotient;
 auto queryToRedirectToSSO(const QString& redirectUrl)
 {
     QUrlQuery _q;
-    addParam<>(_q, u"redirectUrl"_s, redirectUrl);
+    addParam(_q, u"redirectUrl"_s, redirectUrl);
     return _q;
 }
 
@@ -26,7 +26,7 @@ RedirectToSSOJob::RedirectToSSOJob(const QString& redirectUrl)
 auto queryToRedirectToIdP(const QString& redirectUrl)
 {
     QUrlQuery _q;
-    addParam<>(_q, u"redirectUrl"_s, redirectUrl);
+    addParam(_q, u"redirectUrl"_s, redirectUrl);
     return _q;
 }
 

--- a/Quotient/csapi/third_party_lookup.cpp
+++ b/Quotient/csapi/third_party_lookup.cpp
@@ -72,7 +72,7 @@ QueryUserByProtocolJob::QueryUserByProtocolJob(const QString& protocol,
 auto queryToQueryLocationByAlias(const QString& alias)
 {
     QUrlQuery _q;
-    addParam<>(_q, u"alias"_s, alias);
+    addParam(_q, u"alias"_s, alias);
     return _q;
 }
 
@@ -91,7 +91,7 @@ QueryLocationByAliasJob::QueryLocationByAliasJob(const QString& alias)
 auto queryToQueryUserByID(const QString& userid)
 {
     QUrlQuery _q;
-    addParam<>(_q, u"userid"_s, userid);
+    addParam(_q, u"userid"_s, userid);
     return _q;
 }
 

--- a/Quotient/csapi/third_party_membership.cpp
+++ b/Quotient/csapi/third_party_membership.cpp
@@ -11,9 +11,9 @@ InviteBy3PIDJob::InviteBy3PIDJob(const QString& roomId, const QString& idServer,
               makePath("/_matrix/client/v3", "/rooms/", roomId, "/invite"))
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, "id_server"_L1, idServer);
-    addParam<>(_dataJson, "id_access_token"_L1, idAccessToken);
-    addParam<>(_dataJson, "medium"_L1, medium);
-    addParam<>(_dataJson, "address"_L1, address);
+    addParam(_dataJson, "id_server"_L1, idServer);
+    addParam(_dataJson, "id_access_token"_L1, idAccessToken);
+    addParam(_dataJson, "medium"_L1, medium);
+    addParam(_dataJson, "address"_L1, address);
     setRequestData({ _dataJson });
 }

--- a/Quotient/csapi/to_device.cpp
+++ b/Quotient/csapi/to_device.cpp
@@ -10,6 +10,6 @@ SendToDeviceJob::SendToDeviceJob(const QString& eventType, const QString& txnId,
               makePath("/_matrix/client/v3", "/sendToDevice/", eventType, "/", txnId))
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, "messages"_L1, messages);
+    addParam(_dataJson, "messages"_L1, messages);
     setRequestData({ _dataJson });
 }

--- a/Quotient/csapi/typing.cpp
+++ b/Quotient/csapi/typing.cpp
@@ -10,7 +10,7 @@ SetTypingJob::SetTypingJob(const QString& userId, const QString& roomId, bool ty
               makePath("/_matrix/client/v3", "/rooms/", roomId, "/typing/", userId))
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, "typing"_L1, typing);
+    addParam(_dataJson, "typing"_L1, typing);
     addParam<IfNotEmpty>(_dataJson, "timeout"_L1, timeout);
     setRequestData({ _dataJson });
 }

--- a/Quotient/csapi/users.cpp
+++ b/Quotient/csapi/users.cpp
@@ -9,7 +9,7 @@ SearchUserDirectoryJob::SearchUserDirectoryJob(const QString& searchTerm, std::o
               makePath("/_matrix/client/v3", "/user_directory/search"))
 {
     QJsonObject _dataJson;
-    addParam<>(_dataJson, "search_term"_L1, searchTerm);
+    addParam(_dataJson, "search_term"_L1, searchTerm);
     addParam<IfNotEmpty>(_dataJson, "limit"_L1, limit);
     setRequestData({ _dataJson });
     addExpectedKey(u"results"_s);

--- a/Quotient/e2ee/cryptoutils.cpp
+++ b/Quotient/e2ee/cryptoutils.cpp
@@ -315,7 +315,7 @@ std::vector<byte_t> Quotient::base58Decode(const QByteArray& encoded)
         result.push_back(0x0);
     }
 
-    std::reverse(result.begin(), result.end());
+    std::ranges::reverse(result);
     return result;
 }
 

--- a/Quotient/e2ee/e2ee_common.cpp
+++ b/Quotient/e2ee/e2ee_common.cpp
@@ -156,7 +156,7 @@ void FixedBufferBase::fillFrom(QByteArray&& source)
     }
 
     data_ = allocate(size_);
-    std::copy(source.cbegin(), source.cend(), std::bit_cast<char*>(data_));
+    std::ranges::copy(source, std::bit_cast<char*>(data_));
     if (source.isDetached())
         source.clear();
     else

--- a/Quotient/e2ee/e2ee_common.h
+++ b/Quotient/e2ee/e2ee_common.h
@@ -39,9 +39,7 @@ constexpr std::array SupportedAlgorithms { OlmV1Curve25519AesSha2AlgoKey,
 
 inline bool isSupportedAlgorithm(const QString& algorithm)
 {
-    return std::find(SupportedAlgorithms.cbegin(), SupportedAlgorithms.cend(),
-                     algorithm)
-           != SupportedAlgorithms.cend();
+    return std::ranges::find(SupportedAlgorithms, algorithm) != SupportedAlgorithms.cend();
 }
 
 #define QOLM_INTERNAL_ERROR_X(Message_, LastError_) \

--- a/Quotient/e2ee/sssshandler.cpp
+++ b/Quotient/e2ee/sssshandler.cpp
@@ -35,7 +35,7 @@ QByteArray SSSSHandler::decryptKey(event_type_t keyType, const QString& defaultK
     const auto& encrypted =
         encryptedKeyObject->contentPart<QJsonObject>("encrypted"_L1).value(defaultKey).toObject();
 
-    auto hkdfResult = hkdfSha256(decryptionKey, zeroes<32>(), asCBytes<>(keyType));
+    auto hkdfResult = hkdfSha256(decryptionKey, zeroes<32>(), asCBytes(keyType));
     if (!hkdfResult.has_value()) {
         qCWarning(E2EE) << "Failed to calculate HKDF for" << keyType;
         emit error(DecryptionError);

--- a/Quotient/e2ee/sssshandler.cpp
+++ b/Quotient/e2ee/sssshandler.cpp
@@ -280,7 +280,7 @@ void SSSSHandler::unlockSSSSFromSecurityKey(const QString& encodedKey)
         emit error(WrongKeyError);
         return;
     }
-    if (std::accumulate(decoded.cbegin(), decoded.cend(), uint8_t{ 0 }, std::bit_xor<>()) != 0) {
+    if (std::reduce(decoded.cbegin(), decoded.cend(), uint8_t{ 0 }, std::bit_xor<>()) != 0) {
         qCWarning(E2EE) << "SSSS: invalid parity byte in the decryption key";
         emit error(WrongKeyError);
         return;

--- a/Quotient/events/event.cpp
+++ b/Quotient/events/event.cpp
@@ -7,6 +7,7 @@
 #include "../ranges_extras.h"
 
 #include <QtCore/QJsonDocument>
+#include <QtCore/QStringBuilder>
 
 #if Quotient_VERSION_MAJOR == 0 && Quotient_VERSION_MINOR <= 9
 #include "stateevent.h" // For deprecated isStateEvent(); remove, once Event::isStateEvent() is gone
@@ -23,13 +24,13 @@ void AbstractEventMetaType::addDerived(const AbstractEventMetaType* newType)
             return;
         // Two different metatype objects claim the same Matrix type id; this
         // is not normal, so give as much information as possible to diagnose
-        if ((*existing)->className == newType->className) {
-            qCritical(EVENTS) << newType->className << "claims" << newType->matrixId
-                              << "repeatedly; check that it's exported across translation "
-                                 "units or shared objects";
-            Q_ASSERT(false); // That situation is plain wrong
-            return; // So maybe std::terminate() even?
-        }
+        if (QUO_ALARM_X(
+                (*existing)->className == newType->className,
+                QLatin1StringView(newType->className) % " claims '"_L1 % newType->matrixId
+                    % "' repeatedly;"
+                      " check that it's exported across translation units or shared objects"_L1))
+            return; // That situation is very wrong so maybe std::terminate() even?
+
         qWarning(EVENTS).nospace() << newType->matrixId << " is already mapped to "
                                    << (*existing)->className << " before " << newType->className
                                    << "; unless the two have different isValid() conditions, the "

--- a/Quotient/events/filesourceinfo.cpp
+++ b/Quotient/events/filesourceinfo.cpp
@@ -67,11 +67,11 @@ std::pair<EncryptedFileMetadata, QByteArray> Quotient::encryptFile(
 void JsonObjectConverter<EncryptedFileMetadata>::dumpTo(
     QJsonObject& jo, const EncryptedFileMetadata& pod)
 {
-    addParam<>(jo, "url"_L1, pod.url);
-    addParam<>(jo, "key"_L1, pod.key);
-    addParam<>(jo, "iv"_L1, pod.iv);
-    addParam<>(jo, "hashes"_L1, pod.hashes);
-    addParam<>(jo, "v"_L1, pod.v);
+    addParam(jo, "url"_L1, pod.url);
+    addParam(jo, "key"_L1, pod.key);
+    addParam(jo, "iv"_L1, pod.iv);
+    addParam(jo, "hashes"_L1, pod.hashes);
+    addParam(jo, "v"_L1, pod.v);
 }
 
 void JsonObjectConverter<EncryptedFileMetadata>::fillFrom(
@@ -86,11 +86,11 @@ void JsonObjectConverter<EncryptedFileMetadata>::fillFrom(
 
 void JsonObjectConverter<JWK>::dumpTo(QJsonObject& jo, const JWK& pod)
 {
-    addParam<>(jo, "kty"_L1, pod.kty);
-    addParam<>(jo, "key_ops"_L1, pod.keyOps);
-    addParam<>(jo, "alg"_L1, pod.alg);
-    addParam<>(jo, "k"_L1, pod.k);
-    addParam<>(jo, "ext"_L1, pod.ext);
+    addParam(jo, "kty"_L1, pod.kty);
+    addParam(jo, "key_ops"_L1, pod.keyOps);
+    addParam(jo, "alg"_L1, pod.alg);
+    addParam(jo, "k"_L1, pod.k);
+    addParam(jo, "ext"_L1, pod.ext);
 }
 
 void JsonObjectConverter<JWK>::fillFrom(const QJsonObject& jo, JWK& pod)

--- a/Quotient/jobs/basejob.cpp
+++ b/Quotient/jobs/basejob.cpp
@@ -363,7 +363,7 @@ void BaseJob::initiate(ConnectionData* connData, bool inBackground)
         setStatus(IncorrectRequest, tr("Invalid server connection"));
     }
     // The status is no good, finalise
-    QTimer::singleShot(0, this, &BaseJob::finishJob);
+    QMetaObject::invokeMethod(this, &BaseJob::finishJob, Qt::QueuedConnection);
 }
 
 void BaseJob::sendRequest()

--- a/Quotient/keyverificationsession.cpp
+++ b/Quotient/keyverificationsession.cpp
@@ -164,7 +164,12 @@ void KeyVerificationSession::handleEvent(const KeyVerificationEvent& baseEvent)
                     cancelVerification(UNKNOWN_METHOD);
                     return false;
                 }
-                m_commitment = event.commitment();
+                m_commitment = event.commitment().toLatin1();
+                if (!QByteArray::fromBase64Encoding(m_commitment,
+                                                    QByteArray::AbortOnBase64DecodingErrors)) {
+                    cancelVerification(INVALID_MESSAGE);
+                    return false;
+                }
                 sendKey();
                 setState(WAITINGFORKEY);
                 return true;
@@ -228,12 +233,10 @@ void KeyVerificationSession::handleKey(const KeyVerificationKeyEvent& event)
     olm_sas_set_their_key(olmData, eventKey.data(), unsignedSize(eventKey));
 
     if (startSentByUs) {
-        const auto paddedCommitment =
+        const auto unpaddedCommitment =
             QCryptographicHash::hash((event.key() % m_startEvent).toLatin1(),
                                      QCryptographicHash::Sha256)
-                .toBase64();
-        const QLatin1String unpaddedCommitment(paddedCommitment.constData(),
-                                               QString::fromLatin1(paddedCommitment).indexOf(u'='));
+                .toBase64(QByteArray::OmitTrailingEquals);
         if (unpaddedCommitment != m_commitment) {
             qCWarning(E2EE) << "Commitment mismatch; aborting verification";
             cancelVerification(MISMATCHED_COMMITMENT);

--- a/Quotient/keyverificationsession.h
+++ b/Quotient/keyverificationsession.h
@@ -158,7 +158,7 @@ private:
     State m_state = INCOMING;
     Error m_error = NONE;
     QString m_startEvent{};
-    QString m_commitment{};
+    QByteArray m_commitment{};
     bool macReceived = false;
     bool m_verified = false;
     QString m_pendingEdKeyId{};

--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -1686,7 +1686,7 @@ void Room::Private::removeMemberFromMap(const QString& memberId)
         // (for release builds) if there's one. That search is O(n), which
         // may come rather expensive for larger rooms.
         QElapsedTimer et;
-        auto it = std::find(memberNameMap.cbegin(), memberNameMap.cend(), memberId);
+        auto it = std::ranges::find(memberNameMap, memberId);
         if (et.nsecsElapsed() > ProfilerMinNsecs / 10)
             qCDebug(MEMBERS) << "...done in" << et;
         if (it != memberNameMap.cend()) {
@@ -2097,10 +2097,7 @@ auto FileTransferCancelledMsg() { return Room::tr("File transfer cancelled"); }
 
 void Room::discardMessage(const QString& txnId)
 {
-    auto it = std::find_if(d->unsyncedEvents.begin(), d->unsyncedEvents.end(),
-                           [txnId](const auto& evt) {
-                               return evt->transactionId() == txnId;
-                           });
+    auto it = std::ranges::find(d->unsyncedEvents, txnId, &RoomEvent::transactionId);
     Q_ASSERT(it != d->unsyncedEvents.end());
     qCDebug(EVENTS) << "Discarding transaction" << txnId;
     const auto& transferIt = d->fileTransfers.find(txnId);
@@ -2500,8 +2497,7 @@ void Room::downloadFile(const QString& eventId, const QUrl& localFilename)
             eventId, fileUrl, QUrl::fromLocalFile(job->targetFileName()));
     });
     connect(job, &BaseJob::failure, this,
-            std::bind(&Private::failedTransfer, d, eventId,
-                      job->errorString()));
+            std::bind_front(&Private::failedTransfer, d, eventId, job->errorString()));
     emit newFileTransfer(eventId, localFilename);
 }
 
@@ -2759,8 +2755,7 @@ void Room::Private::addRelation(const ReactionEvent& reactionEvt)
     };
 
     auto& thisEventReactions = relations[{ content.eventId, content.type }];
-    if (std::any_of(thisEventReactions.cbegin(), thisEventReactions.cend(),
-                    isSameReaction)) {
+    if (std::ranges::any_of(thisEventReactions, isSameReaction)) {
         qDebug(MESSAGES) << "Skipping a duplicate reaction from"
                          << reactionEvt.senderId();
         return;
@@ -2825,7 +2820,7 @@ Room::Changes Room::Private::addNewMessageEvents(RoomEvents&& events)
         // treated.
         // NB: We have to store redacting/replacing events to the timeline too -
         // see #220.
-        auto it = std::find_if(events.begin(), events.end(), isEditing);
+        auto it = std::ranges::find_if(events, isEditing);
         for (const auto& eptr : std::ranges::subrange(it, events.end())) {
             if (auto* r = eventCast<RedactionEvent>(eptr)) {
                 // Try to find the target in the timeline, then in the batch.
@@ -3298,13 +3293,10 @@ Room::Private::buildShortlist(const QStringList& userIds) const
     // the name of the room. The below code selects 3 topmost users,
     // slightly extending the spec.
     users_shortlist_t shortlist {}; // Prefill with nullptrs
-    std::partial_sort_copy(
-        userIds.begin(), userIds.end(), shortlist.begin(), shortlist.end(),
-        [this](const QString& u1, const QString& u2) {
-            // localUser(), if it's in the list, is sorted
-            // below all others
-            return isLocalMember(u2) || (!isLocalMember(u1) && u1 < u2);
-        });
+    std::ranges::partial_sort_copy(userIds, shortlist, [this](const QString& u1, const QString& u2) {
+        // localUser(), if it's in the list, is sorted below all others
+        return isLocalMember(u2) || (!isLocalMember(u1) && u1 < u2);
+    });
     return shortlist;
 }
 

--- a/Quotient/uri.cpp
+++ b/Quotient/uri.cpp
@@ -17,17 +17,31 @@ struct ReplacePair { QLatin1String uriString; char sigil; };
 ///
 /// When there are two prefixes for the same sigil, the first matching
 /// entry for a given sigil is used.
-const ReplacePair replacePairs[] = {
-    { "u/"_L1, '@' },
-    { "user/"_L1, '@' },
-    { "roomid/"_L1, '!' },
-    { "r/"_L1, '#' },
-    { "room/"_L1, '#' },
-    // The notation for bare event ids is not proposed in MSC2312 but there's
-    // https://github.com/matrix-org/matrix-doc/pull/2644
-    { "e/"_L1, '$' },
-    { "event/"_L1, '$' }
-};
+constexpr auto replacePairs = std::to_array<ReplacePair>({ { "u/"_L1, '@' },
+                                                           { "user/"_L1, '@' },
+                                                           { "roomid/"_L1, '!' },
+                                                           { "r/"_L1, '#' },
+                                                           { "room/"_L1, '#' },
+                                                           // This is here to support bare (without
+                                                           // roomid) event ids proposed in MSC2644
+                                                           { "e/"_L1, '$' },
+                                                           { "event/"_L1, '$' } });
+
+inline auto encodedPath(const QUrl& url)
+{
+    return url.path(QUrl::EncodeDelimiters | QUrl::EncodeUnicode);
+}
+
+QString pathSegment(const QUrl& url, int which)
+{
+    return QUrl::fromPercentEncoding(
+        encodedPath(url).section(u'/', which, which).toUtf8());
+}
+
+auto decodeFragmentPart(QStringView part)
+{
+    return QUrl::fromPercentEncoding(part.toLatin1()).toUtf8();
+}
 
 }
 
@@ -64,32 +78,6 @@ Uri::Uri(QByteArray primaryId, QByteArray secondaryId, QString query)
         setQuery(query);
 }
 
-static inline auto encodedPath(const QUrl& url)
-{
-    return url.path(QUrl::EncodeDelimiters | QUrl::EncodeUnicode);
-}
-
-static QString pathSegment(const QUrl& url, int which)
-{
-    return QUrl::fromPercentEncoding(
-        encodedPath(url).section(u'/', which, which).toUtf8());
-}
-
-static auto decodeFragmentPart(QStringView part)
-{
-    return QUrl::fromPercentEncoding(part.toLatin1()).toUtf8();
-}
-
-static inline auto matrixToUrlRegexInit()
-{
-    // See https://matrix.org/docs/spec/appendices#matrix-to-navigation
-    const QRegularExpression MatrixToUrlRE {
-        "^/(?<main>[^:]+(:|%3A|%3a)[^/?]+)(/(?<sec>(\\$|%24)[^?]+))?(\\?(?<query>.+))?$"_L1
-    };
-    Q_ASSERT(MatrixToUrlRE.isValid());
-    return MatrixToUrlRE;
-}
-
 Uri::Uri(QUrl url) : QUrl(std::move(url))
 {
     // NB: don't try to use `url` from here on, it's moved-from and empty
@@ -101,7 +89,7 @@ Uri::Uri(QUrl url) : QUrl(std::move(url))
         return;
 
     if (scheme() == "matrix"_L1) {
-        // Check sanity as per https://github.com/matrix-org/matrix-doc/pull/2312
+        // Check sanity according to MSC2312
         const auto& urlPath = encodedPath(*this);
         const auto& splitPath = urlPath.split(u'/');
         switch (splitPath.size()) {
@@ -127,7 +115,9 @@ Uri::Uri(QUrl url) : QUrl(std::move(url))
 
     primaryType_ = NonMatrix; // Default, unless overridden by the code below
     if (scheme() == "https"_L1 && authority() == "matrix.to"_L1) {
-        static const auto MatrixToUrlRE = matrixToUrlRegexInit();
+        static const QRegularExpression MatrixToUrlRE(
+            "^/(?<main>[^:]+(:|%3A|%3a)[^/?]+)(/(?<sec>(\\$|%24)[^?]+))?(\\?(?<query>.+))?$"_L1);
+        static const auto _ [[maybe_unused]] = QUO_CHECK(MatrixToUrlRE.isValid());
         // matrix.to accepts both literal sigils (as well as & and ? used in
         // its "query" substitute) and their %-encoded forms;
         // so force QUrl to decode everything.

--- a/Quotient/util.cpp
+++ b/Quotient/util.cpp
@@ -12,12 +12,14 @@
 #include <QtCore/QStringBuilder>
 #include <QtCore/QtEndian>
 
-static const auto RegExpOptions =
+namespace Quotient { // To avoid having to prepend Quotient:: to all the free functions below
+
+inline constexpr auto RegExpOptions =
     QRegularExpression::CaseInsensitiveOption
     | QRegularExpression::UseUnicodePropertiesOption;
 
 // Converts all that looks like a URL into HTML links
-void Quotient::linkifyUrls(QString& htmlEscapedText)
+void linkifyUrls(QString& htmlEscapedText)
 {
     // Note: outer parentheses are a part of C++ raw string delimiters, not of
     // the regex (see http://en.cppreference.com/w/cpp/language/string_literal).
@@ -48,7 +50,7 @@ void Quotient::linkifyUrls(QString& htmlEscapedText)
     htmlEscapedText.replace(MxIdRegExp, uR"(\1<a href='https://matrix.to/#/\2'>\2</a>)"_s);
 }
 
-QString Quotient::sanitized(const QString& plainText)
+QString sanitized(const QString& plainText)
 {
     auto text = plainText;
     text.remove(QChar(0x202e)); // RLO
@@ -57,7 +59,7 @@ QString Quotient::sanitized(const QString& plainText)
     return text;
 }
 
-QString Quotient::prettyPrint(const QString& plainText)
+QString prettyPrint(const QString& plainText)
 {
     auto pt = plainText.toHtmlEscaped();
     linkifyUrls(pt);
@@ -65,7 +67,7 @@ QString Quotient::prettyPrint(const QString& plainText)
     return "<span style='white-space:pre-wrap'>"_L1 % pt % "</span>"_L1;
 }
 
-QString Quotient::cacheLocation(QStringView dirName)
+QString cacheLocation(QStringView dirName)
 {
     const QString cachePath =
         QStandardPaths::writableLocation(QStandardPaths::CacheLocation) % u'/'
@@ -75,7 +77,7 @@ QString Quotient::cacheLocation(QStringView dirName)
     return cachePath;
 }
 
-qreal Quotient::stringToHueF(const QString& s)
+qreal stringToHueF(const QString& s)
 {
     Q_ASSERT(!s.isEmpty());
     const auto hash =
@@ -89,13 +91,11 @@ qreal Quotient::stringToHueF(const QString& s)
     return hueF;
 }
 
-namespace {
 inline constexpr auto ServerPartRegEx =
-    QLatin1StringView("(\\[[^][:space:]]+]|[-[:alnum:].]+)" // IPv6 address or hostname/IPv4 address
-                      "(?::(\\d{1,5}))?"); // Optional port
-}
+    "(\\[[^][:space:]]+]|[-[:alnum:].]+)" // IPv6 address or hostname/IPv4 address
+    "(?::(\\d{1,5}))?"_L1; // Optional port
 
-QString Quotient::serverPart(const QString& mxId)
+QString serverPart(const QString& mxId)
 {
     static const QString re("^[@!#$+].*?:("_L1 // Localpart and colon
                             % ServerPartRegEx % ")$"_L1);
@@ -106,34 +106,26 @@ QString Quotient::serverPart(const QString& mxId)
     return parser.match(mxId).captured(1);
 }
 
-QString Quotient::versionString()
-{
-    return QStringLiteral(Quotient_VERSION_STRING);
-}
+QString versionString() { return QStringLiteral(Quotient_VERSION_STRING); }
 
-int Quotient::majorVersion()
-{
-    return Quotient_VERSION_MAJOR;
-}
+int majorVersion() { return Quotient_VERSION_MAJOR; }
 
-int Quotient::minorVersion()
-{
-    return Quotient_VERSION_MINOR;
-}
+int minorVersion() { return Quotient_VERSION_MINOR; }
 
-int Quotient::patchVersion() { return Quotient_VERSION_PATCH; }
+int patchVersion() { return Quotient_VERSION_PATCH; }
 
-bool Quotient::isGuestUserId(const UserId& uId)
+bool isGuestUserId(const UserId& uId)
 {
     static const QRegularExpression guestMxIdRe{ u"^@\\d+:"_s };
     return guestMxIdRe.match(uId).hasMatch();
 }
 
-bool Quotient::HomeserverData::checkMatrixSpecVersion(QStringView targetVersion) const
+bool HomeserverData::checkMatrixSpecVersion(QStringView targetVersion) const
 {
     // TODO: Replace this naïve implementation with something smarter that can check things like
     //   1.12 > 1.11 and maybe even 1.10 > 1.9
     return std::ranges::any_of(supportedSpecVersions, [targetVersion](const QString& v) {
         return v.startsWith(targetVersion);
     });
+}
 }

--- a/Quotient/util.h
+++ b/Quotient/util.h
@@ -11,6 +11,7 @@
 #include <QtCore/QHashFunctions>
 #include <QtCore/QLatin1String>
 #include <QtCore/QUrl>
+#include <QtCore/QFuture>
 
 #include <memory>
 #include <optional>
@@ -87,6 +88,27 @@ inline bool alarmX(bool alarmCondition, const auto& msg,
 //! Evaluate the boolean expression and, in Debug mode, assert it to be true
 #define QUO_CHECK(...) \
     !::Quotient::alarmX(!(__VA_ARGS__) ? true : false, "Failing expression: " #__VA_ARGS__)
+
+//! A substitute for QtFuture::makeReadyVoidFuture() for compatibility with Qt pre-6.6
+inline auto makeReadyVoidFuture()
+{
+#if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
+    return QtFuture::makeReadyVoidFuture();
+#else
+    return QtFuture::makeReadyFuture<void>();
+#endif
+}
+
+//! A substitute for QtFuture::makeReadyValueFuture() for compatibility with Qt pre-6.6
+template <typename T>
+inline auto makeReadyValueFuture(T&& value)
+{
+#if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
+    return QtFuture::makeReadyValueFuture(std::forward<T>(value));
+#else
+    return QtFuture::makeReadyFuture(std::forward<T>(value));
+#endif
+}
 
 #if Quotient_VERSION_MAJOR == 0 && Quotient_VERSION_MINOR < 10
 /// This is only to make UnorderedMap alias work until we get rid of it

--- a/autotests/testkeyverification.cpp
+++ b/autotests/testkeyverification.cpp
@@ -9,6 +9,7 @@
 
 #include <Quotient/connection.h>
 #include <Quotient/e2ee/qolmaccount.h>
+#include <Quotient/e2ee/cryptoutils.h>
 
 using namespace Quotient;
 
@@ -26,7 +27,8 @@ private Q_SLOTS:
         QVERIFY(session->state() == KeyVerificationSession::WAITINGFORREADY);
         session->handleEvent(KeyVerificationReadyEvent(transactionId, "ABCDEF"_L1, {SasV1Method}));
         QVERIFY(session->state() == KeyVerificationSession::WAITINGFORACCEPT);
-        session->handleEvent(KeyVerificationAcceptEvent(transactionId, "commitment_TODO"_L1));
+        session->handleEvent(KeyVerificationAcceptEvent(
+            transactionId, QString::fromLatin1("commitment_TODO"_ba.toBase64())));
         QVERIFY(session->state() == KeyVerificationSession::WAITINGFORKEY);
         // Since we can't get the events sent by the session, we're limited by what we can test. This means that continuing here would force us to test
         // the exact same path as the other test, which is useless.
@@ -51,8 +53,8 @@ private Q_SLOTS:
         auto sas = olm_sas(new std::byte[olm_sas_size()]);
         const auto randomLength = olm_create_sas_random_length(sas);
         olm_create_sas(sas, getRandom(randomLength).data(), randomLength);
-        QByteArray keyBytes(olm_sas_pubkey_length(sas), '\0');
-        olm_sas_get_pubkey(sas, keyBytes.data(), keyBytes.size());
+        auto keyBytes = byteArrayForOlm(olm_sas_pubkey_length(sas));
+        olm_sas_get_pubkey(sas, keyBytes.data(), unsignedSize(keyBytes));
         session->handleEvent(KeyVerificationKeyEvent(transactionId, QString::fromLatin1(keyBytes)));
         QVERIFY(session->state() == KeyVerificationSession::WAITINGFORVERIFICATION);
         session->sendMac();

--- a/autotests/testolmaccount.cpp
+++ b/autotests/testolmaccount.cpp
@@ -187,9 +187,7 @@ void TestOlmAccount::uploadIdentityKey()
             QFAIL("upload failed");
         const auto& oneTimeKeyCounts = request->oneTimeKeyCounts();
         // Allow the response to have entries with zero counts
-        QCOMPARE(std::accumulate(oneTimeKeyCounts.begin(),
-                                 oneTimeKeyCounts.end(), 0),
-                 0);
+        QVERIFY(std::ranges::all_of(oneTimeKeyCounts, std::bind_front(std::equal_to{}, 0)));
     });
     conn->run(request);
     QSignalSpy spy3(request, &BaseJob::result);

--- a/autotests/testolmutility.cpp
+++ b/autotests/testolmutility.cpp
@@ -63,27 +63,22 @@ void TestOlmUtility::verifySignedOneTimeKey()
     auto utilityBuf = new uint8_t[olm_utility_size()];
     auto utility = olm_utility(utilityBuf);
 
+    const auto signatureBuf1 = sig; // sig can be written to in olm_ed25519_verify
 
-    QByteArray signatureBuf1(sig.size(), '\0');
-    std::copy(sig.begin(), sig.end(), signatureBuf1.begin());
-
-    auto res =
-        olm_ed25519_verify(utility,
-                           aliceOlm.identityKeys().ed25519.toLatin1().data(),
-                           aliceOlm.identityKeys().ed25519.size(), msg.data(),
-                           msg.size(), sig.data(), sig.size());
-
+    // Verify via bare Olm, to make sure we test on the valid material
+    const auto res = olm_ed25519_verify(utility, aliceOlm.identityKeys().ed25519.toLatin1().data(),
+                                        unsignedSize(aliceOlm.identityKeys().ed25519), msg.data(),
+                                        unsignedSize(msg), sig.data(), unsignedSize(sig));
     QCOMPARE(olm_utility_last_error_code(utility), OLM_SUCCESS);
     QCOMPARE(res, 0);
 
     delete[](reinterpret_cast<uint8_t *>(utility));
 
+    // Now verify using libQuotient wrapper and test that the result is the same
     QOlmUtility utility2;
-    auto res2 =
-        utility2.ed25519Verify(aliceOlm.identityKeys().ed25519.toLatin1(), msg,
-                               signatureBuf1);
-
-    //QCOMPARE(std::string(olm_utility_last_error(utility)), "SUCCESS");
+    const auto res2 =
+        utility2.ed25519Verify(aliceOlm.identityKeys().ed25519.toLatin1(), msg, signatureBuf1);
+    QCOMPARE(utility2.lastErrorCode(), OLM_SUCCESS);
     QVERIFY(res2);
 }
 

--- a/gtad/define_models.mustache
+++ b/gtad/define_models.mustache
@@ -11,7 +11,7 @@ template <> struct JsonObjectConverter<{{name}}>
             {{/propertyMap}}{{#parents}}
         fillJson<{{name}}>(jo, pod);
             {{/parents}}{{#vars}}
-        addParam<{{^required?}}IfNotEmpty{{/required?}}>(jo, "{{baseName}}"_L1,
+        addParam{{^required?}}<IfNotEmpty>{{/required?}}(jo, "{{baseName}}"_L1,
                                                          pod.{{nameCamelCase}});
             {{/vars}}
         }

--- a/gtad/operation.cpp.mustache
+++ b/gtad/operation.cpp.mustache
@@ -12,7 +12,7 @@ auto queryTo{{>titleCaseOperationId}}(
             {{#queryParams}}{{>joinedParamDef}}{{/queryParams}})
 {
     QUrlQuery _q;{{#queryParams}}
-    addParam<{{^required?}}IfNotEmpty{{/required?}}>(_q, u"{{baseName}}"_s,
+    addParam{{^required?}}<IfNotEmpty>{{/required?}}(_q, u"{{baseName}}"_s,
                                                      {{paramName}});{{/queryParams}}
     return _q;
 }
@@ -43,7 +43,7 @@ QUrl {{>titleCaseOperationId}}Job::makeRequestUrl(const HomeserverData& hsData{{
         {{/propertyMap}}{{#inlineBody}}
     fillJson<{{>maybeOptionalType}}>(_dataJson, {{paramName}});
         {{/inlineBody}}{{#bodyParams}}
-    addParam<{{^required?}}IfNotEmpty{{/required?}}>(_dataJson, "{{baseName}}"_L1, {{paramName}});
+    addParam{{^required?}}<IfNotEmpty>{{/required?}}(_dataJson, "{{baseName}}"_L1, {{paramName}});
         {{/bodyParams}}
     setRequestData({ _dataJson });
     {{/bodyParams?}}{{/consumesNonJson?}}{{#producesNonJson?}}

--- a/gtad/operation.h.mustache
+++ b/gtad/operation.h.mustache
@@ -108,7 +108,7 @@ template <> struct QUOTIENT_API JsonObjectConverter<{{qualifiedName}}> {
             {{/propertyMap}}{{#parents}}
         fillJson<{{name}}>(jo, pod);
             {{/parents}}{{#vars}}
-        addParam<{{^required?}}IfNotEmpty{{/required?}}>(jo, "{{baseName}}"_L1,
+        addParam{{^required?}}<IfNotEmpty>{{/required?}}(jo, "{{baseName}}"_L1,
                                                          pod.{{nameCamelCase}});
             {{/vars}}
     }

--- a/quotest/quotest.cpp
+++ b/quotest/quotest.cpp
@@ -840,38 +840,32 @@ TEST_IMPL(visitResources)
     static const auto joinRoomAlias = u"##/?.@\"unjoined:example.org"_s;
     static const auto& encodedRoomAliasNoSigil =
         QString::fromLatin1(QUrl::toPercentEncoding(joinRoomAlias.mid(1), ":"_ba));
-    static const QString joinQuery { "?action=join"_L1 };
+    static const auto joinQuery = u"?action=join"_s;
     // These URIs are not supposed to be actually joined (and even exist,
     // as yet) - only to be syntactically correct
-    static const QStringList joinByAliasUris {
+    static const QStringList joinByAliasUris{
         Uri(joinRoomAlias.toUtf8(), {}, joinQuery.mid(1)).toDisplayString(),
-        "matrix:room/"_L1 + encodedRoomAliasNoSigil + joinQuery,
-        "matrix:r/"_L1 + encodedRoomAliasNoSigil + joinQuery,
-        "https://matrix.to/#/%23"_L1/*`#`*/ + encodedRoomAliasNoSigil + joinQuery,
-        "https://matrix.to/#/%23"_L1 + joinRoomAlias.mid(1) /* unencoded */ + joinQuery
+        "matrix:room/"_L1 % encodedRoomAliasNoSigil % joinQuery,
+        "matrix:r/"_L1 % encodedRoomAliasNoSigil % joinQuery,
+        "https://matrix.to/#/%23"_L1 /*`#`*/ % encodedRoomAliasNoSigil % joinQuery,
+        "https://matrix.to/#/%23"_L1 % joinRoomAlias.mid(1) /* unencoded */ % joinQuery
     };
     static const auto joinRoomId = u"!anyid:example.org"_s;
-    static const QStringList viaServers { "matrix.org"_L1, "example.org"_L1 };
-    static const auto viaQuery =
-        std::accumulate(viaServers.cbegin(), viaServers.cend(), joinQuery,
-                        [](const QString& q, const QString& s) {
-                            return q + "&via="_L1 + s;
-                        });
-    static const QStringList joinByIdUris {
-        "matrix:roomid/"_L1 + joinRoomId.mid(1) + viaQuery,
-        "https://matrix.to/#/"_L1 + joinRoomId + viaQuery
-    };
+    static constexpr auto viaServers = std::to_array({ "matrix.org"_L1, "example.org"_L1 });
+    static const auto viaQuery = std::apply(
+        [](const auto&... servers) { return QString((joinQuery % ... % (u"&via="_s % servers))); },
+        viaServers);
+    static const QStringList joinByIdUris{ "matrix:roomid/"_L1 % joinRoomId.mid(1) % viaQuery,
+                                           "https://matrix.to/#/"_L1 % joinRoomId % viaQuery };
     // If any test breaks, the breaking call will return true, and further
     // execution will be cut by ||'s short-circuiting
     if (testResourceResolver(roomUris, &UriDispatcher::roomAction, room())
-        || testResourceResolver(userUris, &UriDispatcher::userAction,
-                                connection()->user())
-        || testResourceResolver(eventUris, &UriDispatcher::roomAction,
-                                room(), { eventId })
-        || testResourceResolver(joinByAliasUris, &UriDispatcher::joinAction,
-                                connection(), { joinRoomAlias })
-        || testResourceResolver(joinByIdUris, &UriDispatcher::joinAction,
-                                connection(), { joinRoomId, viaServers }))
+        || testResourceResolver(userUris, &UriDispatcher::userAction, connection()->user())
+        || testResourceResolver(eventUris, &UriDispatcher::roomAction, room(), { eventId })
+        || testResourceResolver(joinByAliasUris, &UriDispatcher::joinAction, connection(),
+                                { joinRoomAlias })
+        || testResourceResolver(joinByIdUris, &UriDispatcher::joinAction, connection(),
+                                { joinRoomId, QStringList(viaServers.cbegin(), viaServers.cend()) }))
         return true;
     // TODO: negative cases
     FINISH_TEST(true);
@@ -925,23 +919,22 @@ void TestManager::conclude()
 
     auto txnId = room->postHtmlText(plainReport, htmlReport);
     // Now just wait until all the pending events reach the server
-    connectUntil(room, &Room::messageSent, this,
-        [this, txnId, room, plainReport] {
-            const auto& pendingEvents = room->pendingEvents();
-            if (auto stillFlyingCount = std::count_if(pendingEvents.cbegin(), pendingEvents.cend(),
-                                                      [](const PendingEventItem& pe) {
-                                                          return pe.deliveryStatus()
-                                                                 < EventStatus::ReachedServer;
-                                                      });
-                stillFlyingCount > 0) {
-                clog << "Events to reach the server: " << stillFlyingCount << ", not leaving yet\n";
-                return false;
-            }
+    connectUntil(room, &Room::messageSent, this, [this, txnId, room, plainReport] {
+        const auto& pendingEvents = room->pendingEvents();
+        if (const auto stillFlyingCount =
+                std::ranges::count_if(pendingEvents,
+                                      [](const PendingEventItem& pe) {
+                                          return pe.deliveryStatus() < EventStatus::ReachedServer;
+                                      });
+            stillFlyingCount > 0) {
+            clog << "Events to reach the server: " << stillFlyingCount << ", not leaving yet\n";
+            return false;
+        }
 
-            clog << "Leaving the room" << endl;
-            room->leaveRoom().then(this, std::bind_front(&TestManager::finalize, this, plainReport));
-            return true;
-        });
+        clog << "Leaving the room" << endl;
+        room->leaveRoom().then(this, std::bind_front(&TestManager::finalize, this, plainReport));
+        return true;
+    });
 }
 
 void TestManager::finalize(const QString& lastWords)


### PR DESCRIPTION
Best reviewed commit by commit. This is mainly about using `std::ranges` and dropping deprecated or unnecessary pieces; on top of that, `util.cpp` is now entirely in `namespace Quotient` because I got tired of remembering to prepend `Quotient::` when it comes to free functions; and I tried to improve commitment validation in `KeyVerificationSession` a bit. I stopped short from comparing decoded hashes instead of base64-encoded ones but maybe decoding and comparing decoded hashes should be fiiine too?..