### PR TITLE
Only signal pending event as merged once the real one is in the timeline

### DIFF
--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -2793,9 +2793,9 @@ Room::Timeline::size_type Room::Private::mergePendingEvent(PendingEvents::iterat
     // unsyncedEvents (see #286). Fortunately, unsyncedEvents only grows at
     // its back so we can rely on the index staying valid at least.
     localEchoIt = unsyncedEvents.begin() + pendingEvtIdx;
+    const auto insertedSize = moveEventsToTimeline({ remoteEchoIt, remoteEchoIt + 1 }, Newer);
     localEchoIt->setMerged(*remoteEcho);
     unsyncedEvents.erase(localEchoIt);
-    const auto insertedSize = moveEventsToTimeline({ remoteEchoIt, remoteEchoIt + 1 }, Newer);
     if (insertedSize > 0)
         q->onAddNewTimelineEvents(syncEdge() - insertedSize);
 


### PR DESCRIPTION
Previously the future returned by PendingEventItem::whenMerged() was finished a bit too soon, just before the actual event showed up in the timeline. Originally spotted by @nvrWhere.