### PR TITLE
New Thread Signal

### DIFF
--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -1776,10 +1776,9 @@ void Room::Private::updateThread(const RoomEvent* event)
         return;
     }
 
-    auto isNew = false;
     auto& thread = threads[rme->threadRootEventId()];
+    const auto isNew = thread.threadRpotId.isEmpty();
     if (thread.threadRootId.isEmpty()) {
-        isNew = true;
         thread.threadRootId = rme->threadRootEventId();
         // If we can't find the root we assume it's a historical event and will be loaded later.
         if (auto rootIt = q->findInTimeline(thread.threadRootId); rootIt != historyEdge()) {

--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -1776,8 +1776,10 @@ void Room::Private::updateThread(const RoomEvent* event)
         return;
     }
 
+    auto isNew = false;
     auto& thread = threads[rme->threadRootEventId()];
     if (thread.threadRootId.isEmpty()) {
+        isNew = true;
         thread.threadRootId = rme->threadRootEventId();
         // If we can't find the root we assume it's a historical event and will be loaded later.
         if (auto rootIt = q->findInTimeline(thread.threadRootId); rootIt != historyEdge()) {
@@ -1798,6 +1800,8 @@ void Room::Private::updateThread(const RoomEvent* event)
     thread.addEvent(rme,
                     (threadLatestIndex == eventsIndex.cend() || *eventIndexIt > *threadLatestIndex),
                     rme->senderId() == connection->userId());
+
+    if (isNew) { emit q->newThread(thread); }
 }
 
 const Avatar& Room::memberAvatarObject(const QString& memberId) const

--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -1777,7 +1777,7 @@ void Room::Private::updateThread(const RoomEvent* event)
     }
 
     auto& thread = threads[rme->threadRootEventId()];
-    const auto isNew = thread.threadRpotId.isEmpty();
+    const auto isNew = thread.threadRootId.isEmpty();
     if (thread.threadRootId.isEmpty()) {
         thread.threadRootId = rme->threadRootEventId();
         // If we can't find the root we assume it's a historical event and will be loaded later.

--- a/Quotient/room.h
+++ b/Quotient/room.h
@@ -870,6 +870,9 @@ Q_SIGNALS:
      */
     void messageSent(QString txnId, QString eventId);
 
+    //! A new thread has been created/added in the room
+    void newThread(const Thread& newThread);
+
     /** A common signal for various kinds of changes in the room
      * Aside from all changes in the room state
      * @param changes a set of flags describing what changes occurred


### PR DESCRIPTION
Add a signal for when a new thread is created in the room which is useful for when an exisiting event is turned into a thread.