### PR TITLE
OIDC-awareness

### DIFF
--- a/Quotient/connection.cpp
+++ b/Quotient/connection.cpp
@@ -156,8 +156,8 @@ void Connection::loginWithPassword(const QString& userId,
                                    const QString& initialDeviceName,
                                    const QString& deviceId)
 {
-    d->ensureHomeserver(userId, LoginFlows::Password).then([=, this] {
-        d->loginToServer(LoginFlows::Password.type, makeUserIdentifier(userId),
+    d->ensureHomeserver(userId, LoginFlowTypes::Password).then([=, this] {
+        d->loginToServer(LoginFlowTypes::Password, makeUserIdentifier(userId),
                          password, /*token*/ QString(), deviceId, initialDeviceName);
     });
 }
@@ -172,8 +172,8 @@ void Connection::loginWithToken(const QString& loginToken,
                                 const QString& initialDeviceName,
                                 const QString& deviceId)
 {
-    Q_ASSERT(d->data->baseUrl().isValid() && d->loginFlows.contains(LoginFlows::Token));
-    d->loginToServer(LoginFlows::Token.type, std::nullopt /*user is encoded in loginToken*/,
+    Q_ASSERT(d->data->baseUrl().isValid() && d->supportsLoginFlow(LoginFlowTypes::Token));
+    d->loginToServer(LoginFlowTypes::Token, std::nullopt /*user is encoded in loginToken*/,
                      QString() /*password*/, loginToken, deviceId, initialDeviceName);
 }
 
@@ -355,28 +355,28 @@ void Connection::Private::completeSetup(const QString& mxId, bool newLogin,
 }
 
 QFuture<void> Connection::Private::ensureHomeserver(const QString& userId,
-                                                    const std::optional<LoginFlow>& flow)
+                                                    const LoginFlowType& flowType)
 {
     QPromise<void> promise;
     auto result = promise.future();
     promise.start();
-    if (data->baseUrl().isValid() && (!flow || loginFlows.contains(*flow))) {
+    if (data->baseUrl().isValid() && (flowType.isEmpty() || supportsLoginFlow(flowType))) {
         q->setObjectName(userId % u"(?)");
         promise.finish(); // Perfect, we're already good to go
     } else if (userId.startsWith(u'@') && userId.indexOf(u':') != -1) {
         // Try to ascertain the homeserver URL and flows
         q->setObjectName(userId % u"(?)");
         q->resolveServer(userId);
-        if (flow)
+        if (!flowType.isEmpty())
             QtFuture::connect(q, &Connection::loginFlowsChanged)
-                .then([this, flow, p = std::move(promise)]() mutable {
-                    if (loginFlows.contains(*flow))
+                .then([this, flowType, p = std::move(promise)]() mutable {
+                    if (supportsLoginFlow(flowType))
                         p.finish();
                     else // Leave the promise unfinished and emit the error
                         emit q->loginError(tr("Unsupported login flow"),
                                            tr("The homeserver at %1 does not support"
-                                              " the login flow '%2'")
-                                               .arg(data->baseUrl().toDisplayString(), flow->type));
+                                              " login flows of type '%2'")
+                                               .arg(data->baseUrl().toDisplayString(), flowType));
                 });
         else // Any flow is fine, just wait until the homeserver is resolved
             return QFuture<void>(QtFuture::connect(q, &Connection::homeserverChanged));
@@ -960,14 +960,22 @@ QVector<GetLoginFlowsJob::LoginFlow> Connection::loginFlows() const
     return d->loginFlows;
 }
 
+std::optional<LoginFlow> Connection::getLoginFlow(const QString& flowType) const
+{
+    if (auto it = std::ranges::find(d->loginFlows, flowType, &LoginFlow::type);
+        it != d->loginFlows.cend())
+        return *it;
+    return std::nullopt;
+}
+
 bool Connection::supportsPasswordAuth() const
 {
-    return d->loginFlows.contains(LoginFlows::Password);
+    return d->supportsLoginFlow(LoginFlowTypes::Password);
 }
 
 bool Connection::supportsSso() const
 {
-    return d->loginFlows.contains(LoginFlows::SSO);
+    return d->supportsLoginFlow(LoginFlowTypes::SSO);
 }
 
 Room* Connection::room(const QString& roomId, JoinStates states) const

--- a/Quotient/connection.cpp
+++ b/Quotient/connection.cpp
@@ -970,6 +970,9 @@ std::optional<LoginFlow> Connection::getLoginFlow(const QString& flowType) const
 
 bool Connection::supportsPasswordAuth() const
 {
+    if (auto ssoFlow = getLoginFlow(LoginFlowTypes::SSO);
+        ssoFlow && ssoFlow->delegatedOidcCompatibility)
+        return false; // See MSC3824
     return d->supportsLoginFlow(LoginFlowTypes::Password);
 }
 

--- a/Quotient/connection.h
+++ b/Quotient/connection.h
@@ -57,21 +57,34 @@ class QOlmAccount;
 class QOlmInboundGroupSession;
 
 using LoginFlow = GetLoginFlowsJob::LoginFlow;
+using LoginFlowType = QString;
+
+//! Predefined login flow types
+namespace LoginFlowTypes {
+    inline constexpr auto Password = "m.login.password"_L1, SSO = "m.login.sso"_L1,
+                          Token = "m.login.token"_L1;
+}
 
 //! Predefined login flows
-namespace LoginFlows {
-    inline const LoginFlow Password { "m.login.password"_L1 };
-    inline const LoginFlow SSO { "m.login.sso"_L1 };
-    inline const LoginFlow Token { "m.login.token"_L1 };
+namespace LoginFlows
+#ifndef Q_MOC_RUN
+    [[deprecated("Use login flow types and Connection::getLoginFlow() instead")]]
+#endif
+{
+    inline const LoginFlow Password { LoginFlowTypes::Password };
+    inline const LoginFlow SSO { LoginFlowTypes::SSO };
+    inline const LoginFlow Token { LoginFlowTypes::Token };
 }
 
 // To simplify comparisons of LoginFlows
 
+[[deprecated("Compare login flow types instead")]]
 inline bool operator==(const LoginFlow& lhs, const LoginFlow& rhs)
 {
     return lhs.type == rhs.type;
 }
 
+[[deprecated("Compare login flow types instead")]]
 inline bool operator!=(const LoginFlow& lhs, const LoginFlow& rhs)
 {
     return !(lhs == rhs);
@@ -297,6 +310,8 @@ public:
     bool isUsable() const;
     //! Get the list of supported login flows
     QVector<GetLoginFlowsJob::LoginFlow> loginFlows() const;
+    //! Get the login flow of a given type
+    Q_INVOKABLE std::optional<LoginFlow> getLoginFlow(const QString& flowType) const;
     //! Check whether the current homeserver supports password auth
     bool supportsPasswordAuth() const;
     //! Check whether the current homeserver supports SSO

--- a/Quotient/connection.h
+++ b/Quotient/connection.h
@@ -66,11 +66,11 @@ namespace LoginFlowTypes {
 }
 
 //! Predefined login flows
-namespace LoginFlows
+namespace
 #ifndef Q_MOC_RUN
     [[deprecated("Use login flow types and Connection::getLoginFlow() instead")]]
 #endif
-{
+    LoginFlows {
     inline const LoginFlow Password { LoginFlowTypes::Password };
     inline const LoginFlow SSO { LoginFlowTypes::SSO };
     inline const LoginFlow Token { LoginFlowTypes::Token };

--- a/Quotient/connection_p.h
+++ b/Quotient/connection_p.h
@@ -8,6 +8,7 @@
 #include "connection.h"
 #include "connectiondata.h"
 #include "connectionencryptiondata_p.h"
+#include "ranges_extras.h"
 #include "settings.h"
 #include "syncdata.h"
 
@@ -76,21 +77,27 @@ public:
         != "json"_L1;
     bool lazyLoading = false;
 
+    bool supportsLoginFlow(const LoginFlowType& flowType) const
+    {
+        return rangeContains(loginFlows, flowType, &LoginFlow::type);
+    }
+
     //! \brief Check the homeserver and resolve it if needed, before connecting
     //!
     //! A single entry for functions that need to check whether the homeserver is valid before
     //! running. Emits resolveError() if the homeserver URL is not valid and cannot be resolved
-    //! from \p userId; loginError() if the homeserver is accessible but doesn't support \p flow.
+    //! from \p userId; loginError() if the homeserver is accessible but doesn't support \p
+    //! flowType.
     //!
     //! \param userId    fully-qualified MXID to resolve HS from
-    //! \param flow      optionally, a login flow that should be supported;
-    //!                  `std::nullopt`, if there are no login flow requirements
+    //! \param flowType      optionally, a login flowType that should be supported;
+    //!                  `std::nullopt`, if there are no login flowType requirements
     //! \return a future that becomes ready once the homeserver is available; if the homeserver
     //!         URL is incorrect or other problems occur, the future is never resolved and is
     //!         deleted (along with associated continuations) as soon as the problem becomes
     //!         apparent
     //! \sa resolveServer, resolveError, loginError
-    QFuture<void> ensureHomeserver(const QString& userId, const std::optional<LoginFlow>& flow = {});
+    QFuture<void> ensureHomeserver(const QString& userId, const LoginFlowType& flowType = {});
     template <typename... LoginArgTs>
     void loginToServer(LoginArgTs&&... loginArgs);
     void completeSetup(const QString& mxId, bool newLogin = true,

--- a/Quotient/csapi/login.h
+++ b/Quotient/csapi/login.h
@@ -29,6 +29,8 @@ public:
         //! necessarily indicate that the user attempting to log in will
         //! be able to generate such a token.
         bool getLoginToken{ false };
+
+        bool delegatedOidcCompatibility{ false };
     };
 
     // Construction/destruction
@@ -55,6 +57,8 @@ struct QUOTIENT_API JsonObjectConverter<GetLoginFlowsJob::LoginFlow> {
     {
         fillFromJson(jo.value("type"_L1), result.type);
         fillFromJson(jo.value("get_login_token"_L1), result.getLoginToken);
+        fillFromJson(jo.value("org.matrix.msc3824.delegated_oidc_compatibility"_L1),
+                     result.delegatedOidcCompatibility);
     }
 };
 

--- a/Quotient/ranges_extras.h
+++ b/Quotient/ranges_extras.h
@@ -48,4 +48,13 @@ template <template <typename> class TargetT, typename SourceT>
 #endif
 }
 
+#ifdef __cpp_lib_ranges_contains
+constexpr auto rangeContains = std::ranges::contains;
+#else
+[[nodiscard]] constexpr auto rangeContains(const auto& c, const auto& v, auto proj)
+{
+    return std::ranges::find(c, v, std::move(proj)) != std::ranges::end(c);
+}
+#endif
+
 }

--- a/Quotient/ssosession.cpp
+++ b/Quotient/ssosession.cpp
@@ -77,7 +77,19 @@ SsoSession::SsoSession(Connection* connection, const QString& initialDeviceName,
     , d(makeImpl<Private>(this, initialDeviceName, deviceId, connection))
 {}
 
-QUrl SsoSession::ssoUrl() const { return d->ssoUrl; }
+namespace {
+QUrl withAction(QUrl url, const QString& value)
+{
+    QUrlQuery q{ url.query() };
+    q.addQueryItem(u"action"_s, value);
+    url.setQuery(q);
+    return url;
+}
+}
+
+QUrl SsoSession::ssoUrl() const { return withAction(d->ssoUrl, u"login"_s); }
+
+QUrl SsoSession::ssoUrlForRegistration() const { return withAction(d->ssoUrl, u"register"_s); }
 
 QUrl SsoSession::callbackUrl() const { return QUrl(d->callbackUrl); }
 

--- a/Quotient/ssosession.h
+++ b/Quotient/ssosession.h
@@ -36,6 +36,7 @@ public:
     ~SsoSession() override = default;
 
     QUrl ssoUrl() const;
+    QUrl ssoUrlForRegistration() const;
     QUrl callbackUrl() const;
 
 private:

--- a/gtad/gtad.yaml
+++ b/gtad/gtad.yaml
@@ -13,6 +13,7 @@ analyzer:
     origin_server_ts: originServerTimestamp # Instead of originServerTs
     start: begin # Because start() is a method in BaseJob
     /^.*/m\.([a-z].*)$/: '$1' # Strip leading m. from all identifiers
+    /^.*/org\.matrix\.msc\d{4}\.([a-z].*)$/: '$1' # Strip m.org's unstable prefixes from identifiers
     m.3pid_changes: ThirdPartyIdChanges # Special case because there's a digit after m.
     AuthenticationData/additionalProperties: authInfo
     /^/(Location|Protocol|User)$/: 'ThirdParty$1'


### PR DESCRIPTION
This implements https://github.com/matrix-org/matrix-spec-proposals/pull/3824, using the unstable prefix for `delegated_oidc_compatibility`. Mainly driven by https://matrix.org/blog/2025/01/06/authentication-changes/. Strictly speaking, adding this new flag to `LoginFlow` breaks ABI compatibility because it changes the structure size; so I guess it will have to land in 0.10. The good news is that the current libQuotient code already satisfies the "must" feature set described in MSC3824 so we don't need to race against January, 15.

The key change is actually in the last commit: when the mentioned flag is detected, `Connection::supportsPasswordAuth()` will return false even if the password flow is still there. You can still check for the password flow by using the newly introduced `Connection::getLoginFlow()`.