### PR TITLE
Rename event() functions

### DIFF
--- a/Quotient/csapi/event_context.h
+++ b/Quotient/csapi/event_context.h
@@ -62,7 +62,7 @@ public:
     RoomEvents eventsBefore() { return takeFromJson<RoomEvents>("events_before"_L1); }
 
     //! Details of the requested event.
-    RoomEventPtr event() { return takeFromJson<RoomEventPtr>("event"_L1); }
+    RoomEventPtr requestedEvent() { return takeFromJson<RoomEventPtr>("event"_L1); }
 
     //! A list of room events that happened just after the
     //! requested event, in chronological order.
@@ -83,7 +83,7 @@ public:
         RoomEvents eventsBefore{};
 
         //! Details of the requested event.
-        RoomEventPtr event{};
+        RoomEventPtr requestedEvent{};
 
         //! A list of room events that happened just after the
         //! requested event, in chronological order.
@@ -96,7 +96,8 @@ public:
 
 template <std::derived_from<GetEventContextJob> JobT>
 constexpr inline auto doCollectResponse<JobT> = [](JobT* j) -> GetEventContextJob::Response {
-    return { j->begin(), j->end(), j->eventsBefore(), j->event(), j->eventsAfter(), j->state() };
+    return { j->begin(),          j->end(),         j->eventsBefore(),
+             j->requestedEvent(), j->eventsAfter(), j->state() };
 };
 
 } // namespace Quotient

--- a/Quotient/csapi/rooms.h
+++ b/Quotient/csapi/rooms.h
@@ -31,10 +31,10 @@ public:
     // Result properties
 
     //! The full event.
-    RoomEventPtr event() { return fromJson<RoomEventPtr>(jsonData()); }
+    RoomEventPtr requestedEvent() { return fromJson<RoomEventPtr>(jsonData()); }
 };
 
-inline auto collectResponse(GetOneRoomEventJob* job) { return job->event(); }
+inline auto collectResponse(GetOneRoomEventJob* job) { return job->requestedEvent(); }
 
 //! \brief Get the state identified by the type and key.
 //!

--- a/gtad/gtad.yaml
+++ b/gtad/gtad.yaml
@@ -11,7 +11,6 @@ analyzer:
     PushRule/default: isDefault
     default: defaultVersion # getCapabilities/RoomVersionsCapability
     origin_server_ts: originServerTimestamp # Instead of originServerTs
-    start: begin # Because start() is a method in BaseJob
     /^.*/m\.([a-z].*)$/: '$1' # Strip leading m. from all identifiers
     /^.*/org\.matrix\.msc\d{4}\.([a-z].*)$/: '$1' # Strip m.org's unstable prefixes from identifiers
     m.3pid_changes: ThirdPartyIdChanges # Special case because there's a digit after m.
@@ -28,12 +27,14 @@ analyzer:
     setRoomStateWithKey>/data: content
     requestOpenIdToken>/data: dontUse # parameter reserved for future use
     # Change some response names
+    start: begin # Because start() is a method of BaseJob
+    /^.*</event$/: requestedEvent # Because event() is a method of QObject
+    getOneRoomEvent</data: requestedEvent
     /requestTokenTo.*</data/: response
     requestOpenIdToken</data: tokenData
     getDevice</data: device
     getFilter</data: filter
     getProtocols</data: protocols
-    getOneRoomEvent</data: event
     getRoomState</data: events
     getRoomStateWithKey</data: content
     getPushRule</data: pushRule


### PR DESCRIPTION
Generated code has two cases where job classes have an `event()` method, causing a warning that these functions hide `virtual QObject::event()` even though it has a different number of arguments. This PR renames them to `requestedEvent()`, to eliminate the warning.