### PR TITLE
Refactor Settings

### DIFF
--- a/Quotient/settings.cpp
+++ b/Quotient/settings.cpp
@@ -3,6 +3,8 @@
 
 #include "settings.h"
 
+#include "logging_categories_p.h"
+
 #include "ranges_extras.h"
 
 #include <QtCore/QUrl>
@@ -19,14 +21,14 @@ void Settings::setLegacyNames(const QString& organizationName,
     legacyApplicationName = applicationName;
 }
 
-QString Settings::escapedForSettings(QString key)
+QString Settings::toEncoded(QString key)
 {
     key.replace(u'/', u"%2F"_s);
     key.replace(u'\\', u"%5C"_s);
     return key;
 }
 
-QString Settings::unescapedFromSettings(QString key)
+QString Settings::fromEncoded(QString key)
 {
     key.replace(u"%2F"_s, u"/"_s);
     key.replace(u"%5C"_s, u"\\"_s);
@@ -45,9 +47,9 @@ void Settings::setValue(const QString& key, const QVariant& value)
 
 void Settings::remove(const QString& key)
 {
-    QSettings::remove(key);
-    if (legacySettings.contains(key))
-        legacySettings.remove(key);
+    auto safeKey = group() == u"Accounts"_s ? toEncoded(key) : key;
+    QSettings::remove(safeKey);
+    legacySettings.remove(safeKey);
 }
 
 QVariant Settings::value(const QString& key, const QVariant& defaultValue) const
@@ -66,48 +68,28 @@ bool Settings::contains(const QString& key) const
     return QSettings::contains(key) || legacySettings.contains(key);
 }
 
-QStringList Settings::childGroups() const
+QStringList Settings::childGroups() const { return childGroups(true); }
+
+QStringList Settings::childGroups(bool decodeSlashes) const
 {
     auto groups = QSettings::childGroups();
     const auto& legacyGroups = legacySettings.childGroups();
     for (const auto& g: legacyGroups)
         if (!groups.contains(g))
             groups.push_back(g);
-    if (group() == u"Accounts")
-        std::ranges::for_each(groups, [](QString& g) { g = unescapedFromSettings(g); }); // See #842
+    if (group() == u"Accounts" && decodeSlashes) {
+        qWarning(MAIN)
+            << "Developers, use AccountSettingsGroup to work with the Accounts/ group of settings";
+        std::ranges::for_each(groups, [](QString& g) { g = fromEncoded(g); }); // See #842
+    }
     return groups;
 }
 
-void SettingsGroup::setValue(const QString& key, const QVariant& value)
+SettingsGroup::SettingsGroup(const QString& path, QObject* parent)
+    : Settings(parent)
 {
-    Settings::setValue(fullPath(key), value);
-}
-
-bool SettingsGroup::contains(const QString& key) const { return Settings::contains(fullPath(key)); }
-
-QVariant SettingsGroup::value(const QString& key, const QVariant& defaultValue) const
-{
-    return Settings::value(fullPath(key), defaultValue);
-}
-
-QString SettingsGroup::group() const { return groupPath; }
-
-QStringList SettingsGroup::childGroups() const
-{
-    const_cast<SettingsGroup*>(this)->beginGroup(groupPath);
-    const_cast<QSettings&>(legacySettings).beginGroup(groupPath);
-    auto l = Settings::childGroups();
-    const_cast<SettingsGroup*>(this)->endGroup();
-    const_cast<QSettings&>(legacySettings).endGroup();
-    return l;
-}
-
-void SettingsGroup::remove(const QString& key)
-{
-    QString fullKey { groupPath };
-    if (!key.isEmpty())
-        fullKey += u'/' + escapedForSettings(key);
-    Settings::remove(fullKey);
+    beginGroup(path);
+    legacySettings.beginGroup(path);
 }
 
 QUO_DEFINE_SETTING(AccountSettings, QString, deviceId, "device_id", {},
@@ -132,7 +114,11 @@ void AccountSettings::setHomeserver(const QUrl& url)
     setValue(HomeserverKey, url.toString());
 }
 
-QString AccountSettings::userId() const { return unescapedFromSettings(group().section(u'/', -1)); }
+AccountSettings::AccountSettings(const QString& accountId, QObject* parent)
+    : SettingsGroup(AccountSettingsGroup::name() % u'/' % toEncoded(accountId), parent)
+{}
+
+QString AccountSettings::userId() const { return fromEncoded(group().section(u'/', -1)); }
 
 QByteArray AccountSettings::encryptionAccountPickle()
 {
@@ -148,4 +134,11 @@ void AccountSettings::setEncryptionAccountPickle(
 void AccountSettings::clearEncryptionAccountPickle()
 {
     remove(EncryptionAccountPickleKey); // TODO: Force to re-issue it?
+}
+
+AccountSettingsGroup::AccountSettingsGroup(QObject* parent) : SettingsGroup(name(), parent) {}
+
+QStringList AccountSettingsGroup::accountNames() const
+{
+    return rangeTo<QStringList>(std::views::transform(childGroups(false), fromEncoded)); // See #842
 }

--- a/Quotient/settings.h
+++ b/Quotient/settings.h
@@ -9,6 +9,8 @@
 #include <QtCore/QUrl>
 #include <QtCore/QStringBuilder>
 
+#include <ranges>
+
 class QVariant;
 
 namespace Quotient {
@@ -24,8 +26,7 @@ public:
      * the organisation/application. Values in legacy locations are _removed_
      * when setValue() or remove() is called.
      */
-    static void setLegacyNames(const QString& organizationName,
-                               const QString& applicationName = {});
+    static void setLegacyNames(const QString& organizationName, const QString& applicationName = {});
 
     explicit Settings(QObject* parent = nullptr);
 
@@ -67,16 +68,15 @@ public:
     }
 
     Q_INVOKABLE bool contains(const QString& key) const;
-    //! \brief Obtain the list of child groups from the current or, if missing, legacy settings
-    //! \note Group names under `Accounts` group will be automatically unescaped
-    //! \sa AccountSettings
+
     Q_INVOKABLE QStringList childGroups() const;
+    Q_INVOKABLE QStringList childGroups(bool decodeSlashes) const;
 
     //! Escape forward- and backslashes in keys because QSettings doesn't (see #842)
-    static QString escapedForSettings(QString key);
+    static QString toEncoded(QString key);
 
     //! Unescape `\` and `/` in keys stored with escapedForSettings()
-    static QString unescapedFromSettings(QString key);
+    static QString fromEncoded(QString key);
 
 private:
     static QString legacyOrganizationName;
@@ -87,35 +87,9 @@ protected:
 };
 
 class QUOTIENT_API SettingsGroup : public Settings {
+    Q_OBJECT
 public:
-    explicit SettingsGroup(QString path, QObject* parent = nullptr)
-        : Settings(parent)
-        , groupPath(std::move(path))
-    {}
-
-    Q_INVOKABLE bool contains(const QString& key) const;
-    Q_INVOKABLE QVariant value(const QString& key, const QVariant& defaultValue = {}) const;
-
-    template <typename T>
-    T get(const QString& key, const T& defaultValue = {}) const
-    {
-        const auto qv = value(key);
-        return qv.isValid() && qv.canConvert<T>() ? qv.value<T>() : defaultValue;
-    }
-
-    //! \brief Get the path for this settings group
-    //! \note Unlike Settings::childGroups(), this function will not unescape group names under
-    //!       `Accounts`
-    Q_INVOKABLE QString group() const;
-    Q_INVOKABLE QStringList childGroups() const;
-    Q_INVOKABLE void setValue(const QString& key, const QVariant& value);
-
-    Q_INVOKABLE void remove(const QString& key);
-
-private:
-    QString fullPath(QAnyStringView key) const { return groupPath % u'/' % key.toString(); }
-
-    QString groupPath;
+    explicit SettingsGroup(const QString& path, QObject* parent = nullptr);
 };
 
 #define QUO_DECLARE_SETTING(type, propname, setter)      \
@@ -145,9 +119,7 @@ class QUOTIENT_API AccountSettings : public SettingsGroup {
     Q_PROPERTY(QByteArray encryptionAccountPickle READ encryptionAccountPickle
                    WRITE setEncryptionAccountPickle)
 public:
-    explicit AccountSettings(const QString& accountId, QObject* parent = nullptr)
-        : SettingsGroup("Accounts/"_L1 + escapedForSettings(accountId), parent)
-    {}
+    explicit AccountSettings(const QString& accountId, QObject* parent = nullptr);
 
     QString userId() const;
 
@@ -158,4 +130,24 @@ public:
     void setEncryptionAccountPickle(const QByteArray& encryptionAccountPickle);
     Q_INVOKABLE void clearEncryptionAccountPickle();
 };
+
+class QUOTIENT_API AccountSettingsGroup : public SettingsGroup {
+    Q_OBJECT
+public:
+    static auto name() { return u"Accounts"_s; }
+
+    explicit AccountSettingsGroup(QObject* parent = nullptr);
+
+    auto asRange() const
+    {
+        return std::views::transform(accountNames(),
+                                     [](const QString& mxid) { return AccountSettings(mxid); });
+    }
+
+    //! \brief Obtain the list of child groups from the current or, if missing, legacy settings
+    //! \note Slashes in account names will be automatically unescaped
+    //! \sa AccountSettings
+    Q_INVOKABLE QStringList accountNames() const;
+};
+
 } // namespace Quotient

--- a/autotests/testsettings.cpp
+++ b/autotests/testsettings.cpp
@@ -6,7 +6,7 @@
 #include <Quotient/settings.h>
 
 using namespace Qt::Literals;
-using Quotient::Settings, Quotient::SettingsGroup, Quotient::AccountSettings;
+using namespace Quotient;
 
 class TestSettings : public QObject {
     Q_OBJECT
@@ -20,7 +20,7 @@ private slots:
     void accountSettings();
 
 private:
-    static inline const auto AccountsGroupName = u"Accounts"_s;
+    static inline const auto AccountsGroupName = AccountSettingsGroup::name();
     QSettings qSettings{};
 };
 
@@ -44,9 +44,9 @@ void TestSettings::accountSettings()
     static const auto homeserverUrl = QUrl(u"https://example.org"_s);
     static const auto deviceName = u"SomeDevice"_s;
     QFETCH(QString, mxId);
-    const auto escapedMxId = Settings::escapedForSettings(mxId);
+    const auto escapedMxId = AccountSettings::toEncoded(mxId);
 
-    QVERIFY(SettingsGroup(AccountsGroupName).childGroups().empty()); // Pre-requisite
+    QVERIFY(AccountSettingsGroup{}.asRange().empty()); // Pre-requisite
     qSettings.beginGroup(AccountsGroupName);
     { // Test writing to account settings
         AccountSettings accSettings(mxId);
@@ -62,16 +62,18 @@ void TestSettings::accountSettings()
     // NB: QSettings::contains() doesn't work on groups, only on leaf keys; hence childGroups below
     auto childGroups = qSettings.childGroups();
     QVERIFY(childGroups.contains(escapedMxId));
-    QVERIFY(SettingsGroup(AccountsGroupName).childGroups().contains(mxId));
     { // Test reading what was previously written
-        SettingsGroup allAccountNames(AccountsGroupName);
-        QCOMPARE(allAccountNames.childGroups().size(), 1);
-        AccountSettings accSettings(allAccountNames.childGroups().back());
+        AccountSettingsGroup allAccounts{};
+        QCOMPARE(allAccounts.accountNames().size(), 1);
+        const auto allAccountsRange = allAccounts.asRange();
+        QCOMPARE(allAccountsRange.size(), 1);
+        QVERIFY(allAccounts.accountNames().contains(mxId));
+        const auto& accSettings = allAccountsRange.back();
         QCOMPARE(accSettings.userId(), mxId);
         QCOMPARE(accSettings.deviceName(), deviceName);
         QCOMPARE(accSettings.homeserver(), homeserverUrl);
     }
-    SettingsGroup(AccountsGroupName).remove(mxId); // Finally, test removal
+    AccountSettingsGroup{}.remove(mxId); // Finally, test removal
     qSettings.sync();
     childGroups = qSettings.childGroups();
     QVERIFY(!childGroups.contains(escapedMxId));


### PR DESCRIPTION
- `SettingsGroup` can be much simpler than it is now - one doesn't need to reconstruct the full path and do `beginGroup`/`endGroup` at every call, instead just do `beginGroup()` in the constructor. It's still kept as a class rather than converted to a factory, so that other classes could be derived from it.
- `AccountSettingsGroup` encapsulates the "Accounts/" settings group and the required slash decoding for its child groups.
- `Settings::childGroups(bool decodeSlashes)`, for those who need the functionality outside the accounts context.

See also #842.