### PR TITLE
Add cmake option for enabling sanitizers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,12 @@ string(JOIN ~ FULL_VERSION ${PROJECT_VERSION} ${PRE_STAGE})
 message(STATUS)
 message(STATUS "Configuring ${PROJECT_NAME} ${FULL_VERSION} ==>")
 
+find_package(ECM NO_MODULE)
+if (ECM_FOUND)
+    set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH})
+    include(ECMEnableSanitizers)
+endif()
+
 include(FeatureSummary)
 include(CTest)
 


### PR DESCRIPTION
This adds the -DECM_ENABLE_SANITIZERS option; to enable sanitizers, run `cmake [...] -DECM_ENABLE_SANITIZERS="address;undefined" [...]`. The code is a copy from extra-cmake-modules.

I have created this patch locally ~once a month since 2020 and got tired of doing that :)