### PR TITLE
Connection::getDeviceVerificationState()

### DIFF
--- a/Quotient/connection.cpp
+++ b/Quotient/connection.cpp
@@ -1904,6 +1904,21 @@ bool Connection::isKnownE2eeCapableDevice(const QString& userId, const QString& 
     return query.next();
 }
 
+Connection::VerificationState Connection::getDeviceVerificationState(const QString& userId,
+                                                                     const QString& deviceId) const
+{
+    auto query = database()->prepareQuery(
+        "SELECT verified, selfVerified FROM tracked_devices WHERE deviceId=:deviceId AND matrixId=:matrixId;"_L1);
+    query.bindValue(":deviceId"_L1, deviceId);
+    query.bindValue(":matrixId"_L1, userId);
+    database()->execute(query);
+    return query.next() ? query.value("verified"_L1).toBool() ? Verified
+                          : isUserVerified(userId) && query.value("selfVerified"_L1).toBool()
+                              ? SelfVerified
+                              : Unverified
+                        : NoE2EE;
+}
+
 bool Connection::hasConflictingDeviceIdsAndCrossSigningKeys(const QString& userId)
 {
     if (d->encryptionData) {

--- a/Quotient/connection.h
+++ b/Quotient/connection.h
@@ -373,6 +373,7 @@ public:
     //! Returns true if this megolm session comes from a verified device
     bool isVerifiedSession(const QByteArray& megolmSessionId) const;
 
+#if Quotient_VERSION_MAJOR == 0 && Quotient_VERSION_MINOR <= 10
     //! Returns whether the device is verified
     bool isVerifiedDevice(const QString& userId, const QString& deviceId) const;
 
@@ -381,7 +382,17 @@ public:
     //! This might give unexpected results for users we're not tracking,
     //! i.e., users that we don't share an encrypted room with
     bool isKnownE2eeCapableDevice(const QString& userId, const QString& deviceId) const;
+#endif
 
+    enum VerificationState : uint8_t { NoE2EE = 0, Unverified, SelfVerified, Verified };
+    Q_ENUM(VerificationState)
+
+    //! \brief Returns whether the device is E2EE-capable and verified/self-verified
+    //!
+    //! \note This may give unexpected results for users not tracked in this account,
+    //!       e.g. users that have no common encrypted room with the current account
+    VerificationState getDeviceVerificationState(const QString& userId,
+                                                 const QString& deviceId) const;
 
     void sendSessionKeyToDevices(const QString& roomId,
                                  const QOlmOutboundGroupSession& outboundSession,


### PR DESCRIPTION
As a replacement for Connection::isVerifiedDevice() and Connection::isKnownE2eeCapableDevice() - both of these seem to be called in the same context, ending up with two identical queries to the database instead of one.