### PR TITLE
static.yml: bump versions of used actions

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -25,17 +25,17 @@ jobs:
       - name: Install doxygen
         run: sudo apt-get -qq install doxygen graphviz
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Update submodules
         run: git submodule update --init
       - name: Build docs
         run: doxygen
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: 'html'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
The actions didn't age well, turns out - lots of updates happened over the last year, and now GitHub started force-failing some old versions to push upgrading. Which is what this does.