### PR TITLE
Emit finished() and delete remotely cancelled verification session

### DIFF
--- a/Quotient/keyverificationsession.cpp
+++ b/Quotient/keyverificationsession.cpp
@@ -130,11 +130,9 @@ void KeyVerificationSession::setupTimeout(milliseconds timeout)
 
 void KeyVerificationSession::handleEvent(const KeyVerificationEvent& baseEvent)
 {
-    if (!switchOnType(
-            baseEvent,
+    if (!baseEvent.switchOnType( // true if state transition is correct; false otherwise
             [this](const KeyVerificationCancelEvent& event) {
-                setError(stringToError(event.code()));
-                setState(CANCELED);
+                handleCancel(stringToError(event.code()));
                 return true;
             },
             [this](const KeyVerificationStartEvent& event) {
@@ -162,13 +160,13 @@ void KeyVerificationSession::handleEvent(const KeyVerificationEvent& baseEvent)
                 }
                 if (m_commonMacCodes.isEmpty()) {
                     cancelVerification(UNKNOWN_METHOD);
-                    return false;
+                    return true;
                 }
                 m_commitment = event.commitment().toLatin1();
                 if (!QByteArray::fromBase64Encoding(m_commitment,
                                                     QByteArray::AbortOnBase64DecodingErrors)) {
                     cancelVerification(INVALID_MESSAGE);
-                    return false;
+                    return true;
                 }
                 sendKey();
                 setState(WAITINGFORKEY);
@@ -361,15 +359,13 @@ void KeyVerificationSession::sendKey()
                                m_encrypted);
 }
 
-
 void KeyVerificationSession::cancelVerification(Error error)
 {
-    sendEvent(m_remoteUserId, m_remoteDeviceId, KeyVerificationCancelEvent(m_transactionId,
-                                                          errorToString(error)), m_encrypted);
-    setState(CANCELED);
-    setError(error);
-    emit finished();
-    deleteLater();
+    if (QUO_ALARM(state() == CANCELED))
+        return; // Make sure not to overwrite previous error
+    sendEvent(m_remoteUserId, m_remoteDeviceId,
+              KeyVerificationCancelEvent(m_transactionId, errorToString(error)), m_encrypted);
+    handleCancel(error);
 }
 
 void KeyVerificationSession::sendReady()
@@ -497,6 +493,14 @@ void KeyVerificationSession::handleMac(const KeyVerificationMacEvent& event)
     if (m_verified) {
         trustKeys();
     }
+}
+
+void KeyVerificationSession::handleCancel(Error error)
+{
+    setState(CANCELED);
+    setError(error);
+    emit finished();
+    deleteLater();
 }
 
 void KeyVerificationSession::trustKeys()

--- a/Quotient/keyverificationsession.h
+++ b/Quotient/keyverificationsession.h
@@ -170,6 +170,7 @@ private:
     void handleStart(const KeyVerificationStartEvent& event);
     void handleKey(const KeyVerificationKeyEvent& event);
     void handleMac(const KeyVerificationMacEvent& event);
+    void handleCancel(Error error);
     void setupTimeout(std::chrono::milliseconds timeout);
     void setState(State state);
     void setError(Error error);


### PR DESCRIPTION
Prevents a potential verification session leak but may break clients if they relied on the remotely cancelled session to still be around and not emit `finished()` - to me that feels like a misuse, so I'm sending this to 0.9.x even though this change may break this misuse.

Commit message with details:
KeyVerificationSession emits finished() and self-deletes on any wrong situation but only changes state if a remote device simply cancels the verification, as if it were not an endgame. This commit pulls the common code from cancelVerification() into handleCancel() and calls that new function when KeyVerificationCancelEvent is received. It also makes sure now not to call cancelVerification() twice with different error codes.