### PR TITLE
Merge notable count from the server during sync

### DIFF
--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -1915,6 +1915,11 @@ Room::Changes Room::Private::updateStatsFromSyncData(const SyncRoomData& data, b
                           << "to" << serverHighlightCount;
         changes |= Change::Highlights;
     }
+    if (merge(unreadStats.notableCount, data.unreadCount)) {
+        qCDebug(MESSAGES) << "Updated notable number in" << q->objectName()
+                          << "to" << unreadStats.notableCount;
+        changes |= Change::PartiallyReadStats;
+    }
     return changes;
 }
 


### PR DESCRIPTION
This fixes a bug in the following case:
* The user has disabled notifications for messages in their push rules.
* There is no room-specific override for notifications in the push rules.

In libQuotient applications - despite being asked to not to - will still add new unread messages to the notable count. This does not happen in other clients, e.g. Element. So now the notable count is used from the server which is correct as it takes into account the push configured by the user.