### PR TITLE
Safer JobHandle

### DIFF
--- a/Quotient/avatar.cpp
+++ b/Quotient/avatar.cpp
@@ -39,8 +39,8 @@ public:
     mutable QSize largestRequestedSize{};
     enum ImageSource : quint8 { Unknown, Cache, Network, Invalid };
     mutable ImageSource imageSource = Invalid;
-    mutable JobHandle<MediaThumbnailJob> thumbnailRequest = nullptr;
-    mutable JobHandle<UploadContentJob> uploadRequest = nullptr;
+    mutable JobHandle<MediaThumbnailJob> thumbnailRequest{};
+    mutable JobHandle<UploadContentJob> uploadRequest{};
     mutable std::vector<get_callback_t> callbacks{};
 };
 

--- a/Quotient/connection.cpp
+++ b/Quotient/connection.cpp
@@ -680,7 +680,7 @@ QFuture<Room*> Connection::joinAndGetRoom(const QString& roomAlias, const QStrin
         .then([this](const QString& roomId) { return provideRoom(roomId); });
 }
 
-LeaveRoomJob* Connection::leaveRoom(Room* room)
+JobHandle<LeaveRoomJob> Connection::leaveRoom(Room* room)
 {
     const auto& roomId = room->id();
     const auto job = callApi<LeaveRoomJob>(roomId);
@@ -717,24 +717,22 @@ QUrl Connection::makeMediaUrl(QUrl mxcUrl) const
     return mxcUrl;
 }
 
-MediaThumbnailJob* Connection::getThumbnail(const QString& mediaId,
-                                            QSize requestedSize,
-                                            RunningPolicy policy)
+JobHandle<MediaThumbnailJob> Connection::getThumbnail(const QString& mediaId, QSize requestedSize,
+                                                      RunningPolicy policy)
 {
     auto idParts = splitMediaId(mediaId);
     return callApi<MediaThumbnailJob>(policy, idParts.front(), idParts.back(),
                                       requestedSize);
 }
 
-MediaThumbnailJob* Connection::getThumbnail(const QUrl& url, QSize requestedSize,
-                                            RunningPolicy policy)
+JobHandle<MediaThumbnailJob> Connection::getThumbnail(const QUrl& url, QSize requestedSize,
+                                                      RunningPolicy policy)
 {
     return getThumbnail(url.authority() + url.path(), requestedSize, policy);
 }
 
-MediaThumbnailJob* Connection::getThumbnail(const QUrl& url, int requestedWidth,
-                                            int requestedHeight,
-                                            RunningPolicy policy)
+JobHandle<MediaThumbnailJob> Connection::getThumbnail(const QUrl& url, int requestedWidth,
+                                                      int requestedHeight, RunningPolicy policy)
 {
     return getThumbnail(url, QSize(requestedWidth, requestedHeight), policy);
 }
@@ -752,7 +750,7 @@ JobHandle<UploadContentJob> Connection::uploadContent(QIODevice* contentSource,
         if (!contentSource->open(QIODevice::ReadOnly)) {
             qCWarning(MAIN) << "Couldn't open content source" << filename
                             << "for reading:" << contentSource->errorString();
-            return nullptr;
+            return {};
         }
     }
     return callApi<UploadContentJob>(contentSource, filename, contentType);
@@ -777,16 +775,16 @@ BaseJob* Connection::getContent(const QUrl& url)
     QT_IGNORE_DEPRECATIONS(return getContent(url.authority() + url.path());)
 }
 
-DownloadFileJob* Connection::downloadFile(const QUrl& url, const QString& localFilename)
+JobHandle<DownloadFileJob> Connection::downloadFile(const QUrl& url, const QString& localFilename)
 {
     auto mediaId = url.authority() + url.path();
     auto idParts = splitMediaId(mediaId);
     return callApi<DownloadFileJob>(idParts.front(), idParts.back(), localFilename);
 }
 
-DownloadFileJob* Connection::downloadFile(
-    const QUrl& url, const EncryptedFileMetadata& fileMetadata,
-    const QString& localFilename)
+JobHandle<DownloadFileJob> Connection::downloadFile(const QUrl& url,
+                                                    const EncryptedFileMetadata& fileMetadata,
+                                                    const QString& localFilename)
 {
     auto mediaId = url.authority() + url.path();
     auto idParts = splitMediaId(mediaId);
@@ -1591,14 +1589,13 @@ void Connection::setLazyLoading(bool newValue)
     }
 }
 
-BaseJob* Connection::run(BaseJob* job, RunningPolicy runningPolicy)
+void Connection::run(BaseJob* job, RunningPolicy runningPolicy)
 {
     // Reparent to protect from #397, #398 and to prevent BaseJob* from being
     // garbage-collected if made by or returned to QML/JavaScript.
     job->setParent(this);
     connect(job, &BaseJob::failure, this, &Connection::requestFailed);
     job->initiate(d->data.get(), runningPolicy & BackgroundRequest);
-    return job;
 }
 
 void Connection::getTurnServers()

--- a/Quotient/connection.h
+++ b/Quotient/connection.h
@@ -515,21 +515,26 @@ public:
     bool lazyLoading() const;
     void setLazyLoading(bool newValue);
 
-    //! Start a pre-created job object on this connection
-    Q_INVOKABLE BaseJob* run(BaseJob* job, RunningPolicy runningPolicy = ForegroundRequest);
-
-    //! \brief Start a pre-created job on this connection and get a job handle to it
+    //! \brief Start a pre-made job object on this connection
     //!
-    //! This is a template overload for run(BaseJob*, RunningPolicy) - if you call run() on any
-    //! derived job (99% of the cases when you're going to call it), this overload will be chosen
-    //! as a more type-safe and feature-rich version. It's not Q_INVOKABLE though.
+    //! Use this overload in case when you don't want to, or cannot, use JobHandle. Internally,
+    //! this is also the function all other template wrappers ultimately call to do the real work.
+    Q_INVOKABLE void run(Quotient::BaseJob* job,
+                         Quotient::RunningPolicy runningPolicy = Quotient::ForegroundRequest);
+
+    //! \brief Start a pre-created job on this connection
+    //!
+    //! Use this overload if you have a job object pre-made with JobHandle<>::createFrom() when
+    //! you need to actually start (or rather, queue) the network request. It is strongly
+    //! recommended to use the job handle returned by run() instead of the original, as run() may
+    //! (in the future) attach continuations to the future interface of the handle.
+    //! \sa JobHandle::createFrom
     template <std::derived_from<BaseJob> JobT>
         requires (!std::same_as<JobT, BaseJob>)
-    JobHandle<JobT> run(JobT* job, RunningPolicy runningPolicy = ForegroundRequest)
+    JobHandle<JobT> run(JobHandle<JobT>&& job, RunningPolicy runningPolicy = ForegroundRequest)
     {
-        JobHandle jh { job };
-        run(static_cast<BaseJob*>(job), runningPolicy);
-        return jh;
+        run(job.get(), runningPolicy);
+        return std::move(job);
     }
 
     //! \brief Start a job of a given type with specified arguments and policy
@@ -546,7 +551,7 @@ public:
     template <typename JobT, typename... JobArgTs>
     JobHandle<JobT> callApi(RunningPolicy runningPolicy, JobArgTs&&... jobArgs)
     {
-        return run(new JobT(std::forward<JobArgTs>(jobArgs)...), runningPolicy);
+        return run(JobHandle<JobT>::createFrom(std::forward<JobArgTs>(jobArgs)...), runningPolicy);
     }
 
     //! \brief Start a job of a specified type with specified arguments
@@ -710,14 +715,13 @@ public Q_SLOTS:
 
     void stopSync();
 
-    virtual MediaThumbnailJob*
-    getThumbnail(const QString& mediaId, QSize requestedSize,
-                 RunningPolicy policy = BackgroundRequest);
-    MediaThumbnailJob* getThumbnail(const QUrl& url, QSize requestedSize,
-                                    RunningPolicy policy = BackgroundRequest);
-    MediaThumbnailJob* getThumbnail(const QUrl& url, int requestedWidth,
-                                    int requestedHeight,
-                                    RunningPolicy policy = BackgroundRequest);
+    virtual JobHandle<MediaThumbnailJob> getThumbnail(const QString& mediaId, QSize requestedSize,
+                                                      RunningPolicy policy = BackgroundRequest);
+    JobHandle<MediaThumbnailJob> getThumbnail(const QUrl& url, QSize requestedSize,
+                                              RunningPolicy policy = BackgroundRequest);
+    JobHandle<MediaThumbnailJob> getThumbnail(const QUrl& url, int requestedWidth,
+                                              int requestedHeight,
+                                              RunningPolicy policy = BackgroundRequest);
 
     // QIODevice* should already be open
     JobHandle<UploadContentJob> uploadContent(QIODevice* contentSource, const QString& filename = {},
@@ -728,11 +732,11 @@ public Q_SLOTS:
     [[deprecated("Use downloadFile() instead")]] BaseJob* getContent(const QUrl& url);
 
     // If localFilename is empty, a temporary file will be created
-    DownloadFileJob* downloadFile(const QUrl& url, const QString& localFilename = {});
+    JobHandle<DownloadFileJob> downloadFile(const QUrl& url, const QString& localFilename = {});
 
-    DownloadFileJob* downloadFile(const QUrl& url,
-                                  const EncryptedFileMetadata& fileMetadata,
-                                  const QString& localFilename = {});
+    JobHandle<DownloadFileJob> downloadFile(const QUrl& url,
+                                            const EncryptedFileMetadata& fileMetadata,
+                                            const QString& localFilename = {});
 
     //! \brief Create a room (generic method)
     //!
@@ -775,7 +779,7 @@ public Q_SLOTS:
     SendMessageJob* sendMessage(const QString& roomId, const RoomEvent& event);
 
     //! \deprecated Do not use this directly, use Room::leaveRoom() instead
-    virtual LeaveRoomJob* leaveRoom(Room* room);
+    virtual JobHandle<LeaveRoomJob> leaveRoom(Room* room);
 
     Quotient::KeyVerificationSession* startKeyVerificationSession(const QString& userId,
                                                                   const QString& deviceId);

--- a/Quotient/connection_p.h
+++ b/Quotient/connection_p.h
@@ -63,12 +63,12 @@ public:
     bool encryptDirectChats = directChatEncryptionDefault;
     std::unique_ptr<_impl::ConnectionEncryptionData> encryptionData;
 
-    JobHandle<GetWellknownJob> resolverJob = nullptr;
-    JobHandle<GetLoginFlowsJob> loginFlowsJob = nullptr;
+    JobHandle<GetWellknownJob> resolverJob{};
+    JobHandle<GetLoginFlowsJob> loginFlowsJob{};
 
     SyncJob* syncJob = nullptr;
     bool lastSyncSuccessful = true;
-    JobHandle<LogoutJob> logoutJob = nullptr;
+    JobHandle<LogoutJob> logoutJob{};
 
     bool cacheState = true;
     bool cacheToBinary =

--- a/Quotient/e2ee/qolmaccount.cpp
+++ b/Quotient/e2ee/qolmaccount.cpp
@@ -222,10 +222,10 @@ DeviceKeys QOlmAccount::deviceKeys() const
     };
 }
 
-UploadKeysJob* QOlmAccount::createUploadKeyRequest(
+JobHandle<UploadKeysJob> QOlmAccount::createUploadKeyRequest(
     const UnsignedOneTimeKeys& oneTimeKeys) const
 {
-    return new UploadKeysJob(deviceKeys(), signOneTimeKeys(oneTimeKeys));
+    return JobHandle<UploadKeysJob>::createFrom(deviceKeys(), signOneTimeKeys(oneTimeKeys));
 }
 
 QOlmExpected<QOlmSession> QOlmAccount::createInboundSession(

--- a/Quotient/e2ee/qolmaccount.h
+++ b/Quotient/e2ee/qolmaccount.h
@@ -10,6 +10,8 @@
 
 #include <Quotient/csapi/keys.h>
 
+#include "../jobs/jobhandle.h"
+
 #include <QtCore/QObject>
 
 struct OlmAccount;
@@ -66,7 +68,7 @@ public:
     //! Sign all one time keys.
     OneTimeKeys signOneTimeKeys(const UnsignedOneTimeKeys &keys) const;
 
-    UploadKeysJob* createUploadKeyRequest(const UnsignedOneTimeKeys& oneTimeKeys) const;
+    JobHandle<UploadKeysJob> createUploadKeyRequest(const UnsignedOneTimeKeys& oneTimeKeys) const;
 
     DeviceKeys deviceKeys() const;
 

--- a/Quotient/jobs/basejob.cpp
+++ b/Quotient/jobs/basejob.cpp
@@ -125,6 +125,7 @@ public:
     QPointer<QNetworkReply> reply;
 
     QPromise<void> promise{};
+    bool futureGenerated = false;
 
     Status status = Unprepared;
     QByteArray rawResponse;
@@ -818,7 +819,7 @@ void BaseJob::abandon()
         d->reply->disconnect(this);
     emit finished(this);
     if (QLibraryInfo::version() < QVersionNumber(6, 5))
-        future().cancel(); // Qt 6.4 didn't do it on the promise destruction, see QTBUG-103992
+        d->promise.future().cancel(); // Cover for QTBUG-103992
 
     deleteLater(); // The promise will cancel itself on deletion
 }
@@ -834,4 +835,12 @@ void BaseJob::setLoggingCategory(QMessageLogger::CategoryFunction lcf)
     d->logCat = lcf;
 }
 
-QFuture<void> BaseJob::future() { return d->promise.future(); }
+QFuture<void> BaseJob::future()
+{
+    if (d->futureGenerated)
+        qWarning(JOBS) << "Attempt to get the second future from" << objectName()
+                       << "- a continuation on the previous future may be overwritten";
+
+    d->futureGenerated = true;
+    return d->promise.future();
+}

--- a/Quotient/jobs/jobhandle.h
+++ b/Quotient/jobs/jobhandle.h
@@ -85,13 +85,16 @@ private:
         : pointer_type(job), future_type(std::move(futureToWrap))
     {}
 
-    static future_type setupFuture(JobT* job)
-    {
-        return job ? job->future().then([job] { return future_value_type{ job }; }) : future_type{};
-    }
-
 public:
-    Q_IMPLICIT JobHandle(JobT* job = nullptr) : JobHandle(job, setupFuture(job)) {}
+    JobHandle() = default; //!< Creates a "null QPointer, cancelled QFuture" job handle
+
+    //! Create a new job and get a JobHandle for it
+    template <typename... JobArgTs>
+    static JobHandle createFrom(JobArgTs&&... jobArgs)
+    {
+        auto pJob = new JobT(std::forward<JobArgTs>(jobArgs)...);
+        return { pJob, pJob->future().then([pJob] { return future_value_type{ pJob }; }) };
+    }
 
     //! \brief Attach a continuation to a successful or unsuccessful completion of the future
     //!
@@ -310,8 +313,8 @@ private:
         // exist when the continuation is constructed, and only later it would change its value
         // to something useful. Unless the client code stored the original JobHandle, it would
         // lose that change and only store nullptr; and if it stores a JobHandle then it can just
-        // use the QFuture interface instead. Therefore a pure QFuture is returned instead, that
-        // settles when the underlying job finishes or gets cancelled.
+        // use the QFuture interface instead. The returned QFuture settles when the underlying job
+        // finishes or gets cancelled.
         QFutureInterface<typename JobHandle<NewJobT>::future_value_type> newPromise(
             QFutureInterfaceBase::State::Pending);
         ft.then([newPromise](JobHandle<NewJobT> nestedHandle) mutable {

--- a/Quotient/jobs/jobhandle.h
+++ b/Quotient/jobs/jobhandle.h
@@ -3,6 +3,7 @@
 #include "basejob.h"
 
 #include <QtCore/QFuture>
+#include <QtCore/QPointer>
 
 namespace Quotient {
 


### PR DESCRIPTION
After stumbling over continuation overwriting yet another time, I decided to remove what I always suspected to be a bit of footgun - `JobHandle` constructor from raw job pointers. That constructor relies on `BaseJob::future()` that returns `QFuture` referring to the same underlying promise backend every time; so fundamentally, it is not meant to be called more than once on the same job object (aside from the cancellation case). This PR adds a warning about repeated calls to `BaseJob::future()` and replaces the problematic constructor with a factory method that acts as an equivalent of `std::make_unique` but for `JobHandle`. That causes a few changes in code that uses it; in particular, more job wrapping methods now return `JobHandle` instead of a raw pointer. And since `JobHandle` can still be converted to a raw pointer, these changes should be mostly API-compatible.