### PR TITLE
CI: Switch to ubuntu-24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,16 +18,16 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        os: [ ubuntu-22.04 ]
+        os: [ ubuntu-24.04 ]
         qt-version: [ '6.4' ]
         override-compiler: [ '', GCC ] # Defaults: MSVC on Windows, Clang elsewhere
         include: # Attach API updating and static analysis to specific jobs
-        - os: ubuntu-22.04
-          qt-version: '6.4' # That's what is in Ubuntu 22.04
+        - os: ubuntu-24.04
+          qt-version: '6.4'
           override-compiler: GCC
           update-api: update-api
           static-analysis: sonar # NB: to use sonar with Clang, replace gcov usage with lcov
-        - os: ubuntu-22.04
+        - os: ubuntu-24.04
           qt-version: '6.4'
           override-compiler: ''
           static-analysis: codeql
@@ -38,7 +38,7 @@ jobs:
 
     env:
       GCC_VERSION: -13
-      CLANG_VERSION: -17
+      CLANG_VERSION: -18
 
     steps:
     - uses: actions/checkout@v4
@@ -49,24 +49,20 @@ jobs:
     - name: Install dependencies (Linux)
       if: startsWith(matrix.os, 'ubuntu')
       run: |
-        COMMON_PKGS="libolm-dev ninja-build gnome-keyring g++$GCC_VERSION clang$CLANG_VERSION"
-        # See https://github.com/actions/runner-images/issues/9679
-        sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-        # Add LLVM repo for newer Clang
-        wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
-        sudo add-apt-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy$CLANG_VERSION main" -y
         sudo apt-get -qq update
-        sudo apt-get -qq install $COMMON_PKGS
+        sudo apt-get -q install \
+            ninja-build g++$GCC_VERSION clang$CLANG_VERSION libsecret-1-dev libolm-dev \
+            qt6-base-dev qt6-base-private-dev gnome-keyring
         gnome-keyring-daemon -d --unlock <<<'' # Create a login keyring with no password
 
     - name: Install dependencies (non-Linux)
+      if: "!startsWith(matrix.os, 'ubuntu')"
       uses: jurplel/install-qt-action@v4.1.1
       with:
         version: '${{ matrix.qt-version }}.*'
         cache: true
         cache-key-prefix: Qt
-        tools: "${{ !startsWith(matrix.os, 'ubuntu') && 'tools_ninja ' || '' }}\
-                ${{ startsWith(matrix.os, 'windows') && 'tools_opensslv3_x64' || '' }}"
+        tools: "tools_ninja ${{ startsWith(matrix.os, 'windows') && 'tools_opensslv3_x64' || '' }}"
 
     - name: Setup build environment
       run: |
@@ -138,7 +134,7 @@ jobs:
       run: |
         cd ..
         git clone -b 0.15.0 https://github.com/frankosterfeld/qtkeychain.git
-        cmake -S qtkeychain -B qtkeychain/build -DBUILD_WITH_QT6=ON $CMAKE_ARGS
+        cmake -S qtkeychain -B qtkeychain/build -DBUILD_WITH_QT6=ON -DBUILD_TRANSLATIONS=OFF $CMAKE_ARGS
         cmake --build qtkeychain/build --target install
 
     - name: Build and install Olm


### PR DESCRIPTION
An excuse is .clang-format requiring ClangFormat 18 but really an upgrade is overdue by now.