### PR TITLE
Fix CI breakage induced by GitHub + minor/non-code changes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -53,13 +53,13 @@ AttributeMacros:
 #BitFieldColonSpacing: Both
 BraceWrapping:
 #  AfterCaseLabel:  false
-#  AfterClass:      false
+  AfterClass:      true
 #  AfterControlStatement: Never
 #  AfterEnum:       false
 #  AfterExternBlock: false
   AfterFunction:   true
 #  AfterNamespace:  false
-#  AfterStruct:     false
+  AfterStruct:     true
 #  AfterUnion:      false
 #  BeforeCatch:     false
 #  BeforeElse:      false
@@ -161,7 +161,7 @@ PenaltyBreakString: 200
 PenaltyExcessCharacter: 40
 #PenaltyIndentedWhitespace: 0
 PenaltyReturnTypeOnItsOwnLine: 200
-#PointerAlignment: Left
+PointerAlignment: Right
 #PPIndentWidth: -1
 #QualifierAlignment: Leave # Anything else is dangerous, see ClangFormat docs
 #QualifierOrder: ['friend', 'static', 'inline', 'constexpr', 'const', 'volatile', 'type'] # Unknown key error, despite the documentation...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,11 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Install cmake
+      uses: jwlawson/actions-setup-cmake@v2
+      with:
+        cmake-version: '3.x'
+
     # Install on Linux via apt to get everything necessary in one go
     - name: Install dependencies (Linux)
       if: startsWith(matrix.os, 'ubuntu')

--- a/Quotient/quotient_export.h
+++ b/Quotient/quotient_export.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <QtCore/qglobal.h>
+#include <QtCore/qcompilerdetection.h>
 
 #ifdef QUOTIENT_STATIC
     #define QUOTIENT_API

--- a/README.md
+++ b/README.md
@@ -39,21 +39,22 @@ To use libQuotient (i.e. build or run applications with it), you'll need:
 
 - A recent Linux, macOS or Windows system (desktop versions are known to work, and there's also
   limited positive experience with Android)
-  - Recent enough Linux examples: Debian Trixie; Fedora 39; openSUSE Leap 15.6; Ubuntu 24.04 LTS
+  - Recent enough Linux examples: Debian Trixie; Fedora 40; Ubuntu 24.04 LTS
 - Qt 6.4 or newer - either Open Source or Commercial
 - QtKeychain (https://github.com/frankosterfeld/qtkeychain) - 0.12 or newer is recommended;
-  the build configuration of QtKeychain must use the same Qt major version, that is Qt 6.
+  the build configuration of QtKeychain must use the same Qt major version, i.e. Qt 6.
 
 To build applications with libQuotient, you'll also need:
 
 - CMake 3.26 or newer
-- A C++ toolchain that supports at least some subset of C++20 (concepts, in particular):
-  - GCC 13 (Windows, Linux, macOS), Clang 16 (Linux), Apple Clang 15 (macOS 14+)
-    and Visual Studio 2022 (Windows) are the oldest officially supported
+- A C++ toolchain that has reasonably complete C++20 support and some C++23 elements
+  (`std::expected`, in particular)
+  - GCC 13 (Windows, Linux, macOS), Clang 18 (Linux), Apple Clang 15 (macOS 14+)
+    and Visual Studio 2022 17.6 (Windows) are the oldest officially supported
 - libolm 3.2.5 or newer (the latest 3.x strongly recommended)
-- OpenSSL 3.x (1.1.x may still work but is strongly recommended against)
+- OpenSSL 3.x (1.1.x may still work but is strongly discouraged)
 - Any build system that works with CMake should be fine; known to work are GNU Make and
-  ninja (recommended) on any platform; NMake and jom on Windows
+  ninja (recommended) on any platform; NMake and jom on Windows should also work
 
 The requirements to build libQuotient itself are basically the same except that you should install
 development libraries for the dependencies listed above.


### PR DESCRIPTION
For details of the breakage, see https://github.com/actions/runner-images/issues/11926