### PR TITLE
Make guarding against event type clashes stricter

### DIFF
--- a/Quotient/events/event.cpp
+++ b/Quotient/events/event.cpp
@@ -4,7 +4,6 @@
 #include "event.h"
 
 #include "../logging_categories_p.h"
-#include "../ranges_extras.h"
 
 #include <QtCore/QJsonDocument>
 #include <QtCore/QStringBuilder>
@@ -15,31 +14,36 @@
 
 using namespace Quotient;
 
-void AbstractEventMetaType::addDerived(const AbstractEventMetaType* newType)
+AbstractEventMetaType::AbstractEventMetaType(const std::type_info &typeInfo, const char *className,
+                                             AbstractEventMetaType *nearestBase,
+                                             event_type_t matrixId)
+    : typeInfo(typeInfo), className(className), baseType(nearestBase), matrixId(matrixId)
 {
-    if (const auto existing =
-            std::ranges::find(_derivedTypes, newType->matrixId, &AbstractEventMetaType::matrixId);
-        existing != _derivedTypes.cend()) {
-        if (*existing == newType)
-            return;
-        // Two different metatype objects claim the same Matrix type id; this
-        // is not normal, so give as much information as possible to diagnose
-        if (QUO_ALARM_X(
-                (*existing)->className == newType->className,
-                QLatin1StringView(newType->className) % " claims '"_L1 % newType->matrixId
-                    % "' repeatedly;"
-                      " check that it's exported across translation units or shared objects"_L1))
-            return; // That situation is very wrong so maybe std::terminate() even?
+    if (nearestBase) {
+        if (const auto existing = std::ranges::find(nearestBase->derivedTypes(), matrixId,
+                                                    &AbstractEventMetaType::matrixId);
+            existing != nearestBase->derivedTypes().end()) // macOS still has no std::span::cend()
+        {
+            if (QUO_ALARM_X(*existing == this, "Attempt to re-register the same event class"))
+                return; // This is kinda fine but extremely fishy
 
-        qWarning(EVENTS).nospace() << newType->matrixId << " is already mapped to "
-                                   << (*existing)->className << " before " << newType->className
-                                   << "; unless the two have different isValid() conditions, the "
-                                      "latter class will never be used";
+            // Two different metatype objects claim the same Matrix type id; this
+            // is not normal, so give as much information as possible to diagnose
+            if (QUO_ALARM_X((*existing)->typeInfo == typeInfo,
+                            QLatin1StringView(className) % " claims '"_L1 % matrixId
+                                % "' repeatedly; check that the C++ symbol is properly exported"_L1))
+                return; // That situation is very wrong (see #413) so maybe std::terminate() even?
+
+            qWarning(EVENTS).nospace() << matrixId << " is already mapped to "
+                                       << (*existing)->className << " before " << className
+                                       << "; unless the two have different isValid() conditions, "
+                                          "the latter class will never be used";
+        }
+        nearestBase->_derivedTypes.emplace_back(this);
+        qDebug(EVENTS).nospace() << matrixId << " -> " << className << "; "
+                                 << nearestBase->_derivedTypes.size()
+                                 << " derived type(s) registered for " << nearestBase->className;
     }
-    _derivedTypes.emplace_back(newType);
-    qDebug(EVENTS).nospace() << newType->matrixId << " -> " << newType->className << "; "
-                             << _derivedTypes.size() << " derived type(s) registered for "
-                             << className;
 }
 
 Event::Event(const QJsonObject& json) : _json(json) {}

--- a/Quotient/events/event.h
+++ b/Quotient/events/event.h
@@ -43,29 +43,29 @@ class QUOTIENT_API AbstractEventMetaType {
 public:
     // The public fields here are const and are not to be changeable anyway.
     // NOLINTBEGIN(misc-non-private-member-variables-in-classes)
-    const char* const className; ///< C++ class name this metatype is for
-    const AbstractEventMetaType* const baseType;
+    const std::type_info &typeInfo;
+    const char *const className;
+    const AbstractEventMetaType *const baseType;
     const event_type_t matrixId;
     // NOLINTEND(misc-non-private-member-variables-in-classes)
 
-    explicit AbstractEventMetaType(const char* className,
-                                   AbstractEventMetaType* nearestBase = nullptr,
-                                   const char* matrixId = nullptr)
-        : className(className), baseType(nearestBase), matrixId(matrixId)
-    {
-        if (nearestBase)
-            nearestBase->addDerived(this);
-    }
-
-    void addDerived(const AbstractEventMetaType* newType);
     auto derivedTypes() const { return std::span(_derivedTypes); }
 
     virtual ~AbstractEventMetaType() = default;
+
+    friend bool operator==(const AbstractEventMetaType &lhs, const AbstractEventMetaType &rhs)
+    {
+        return lhs.typeInfo == rhs.typeInfo;
+    }
 
 protected:
     // Allow template specialisations to call into one another
     template <class EventT>
     friend class EventMetaType;
+
+    explicit AbstractEventMetaType(const std::type_info &typeInfo, const char *className,
+                                   AbstractEventMetaType *nearestBase = nullptr,
+                                   event_type_t matrixId = nullptr);
 
     // The returned value indicates whether a generic object has to be created
     // on the top level when `event` is empty, instead of returning nullptr
@@ -76,14 +76,6 @@ private:
     std::vector<const AbstractEventMetaType*> _derivedTypes{};
     Q_DISABLE_COPY_MOVE(AbstractEventMetaType)
 };
-
-// Any event metatype is unique (note Q_DISABLE_COPY_MOVE above) so can be
-// identified by its address
-inline bool operator==(const AbstractEventMetaType& lhs,
-                       const AbstractEventMetaType& rhs)
-{
-    return &lhs == &rhs;
-}
 
 //! \brief A family of event meta-types to load and match events
 //!
@@ -98,9 +90,17 @@ inline bool operator==(const AbstractEventMetaType& lhs,
 template <class EventT>
 class QUOTIENT_API EventMetaType : public AbstractEventMetaType {
     // Above: can't constrain EventT to be EventClass because it's incomplete
-    // at the point of EventMetaType<EventT> instantiation.
+    // at the point of EventMetaType<EventT> instantiation (see QUO_BASE_EVENT and QUO_EVENT)
 public:
-    using AbstractEventMetaType::AbstractEventMetaType;
+    explicit EventMetaType(AbstractEventMetaType *nearestBase = nullptr,
+                           const char* matrixTypeId = {})
+        // NB: typeid(T&) == typeid(T) but typeid(T&) can be used with an incomplete type
+        // NB2: it would be lovely to "just" use QMetaType::fromType<> instead of QtPrivate API
+        //      but QMetaType tries to instantiate constructor wrappers and it's not possible while
+        //      the type is incomplete
+        : AbstractEventMetaType(typeid(EventT &), QtPrivate::QMetaTypeForType<EventT>().getName(),
+                                nearestBase, event_type_t(matrixTypeId))
+    {}
 
     //! \brief Try to load an event from JSON, with dynamic type resolution
     //!
@@ -230,7 +230,7 @@ struct JsonConverter<event_ptr_tt<EventT>>
 
 class QUOTIENT_API Event {
 public:
-    static inline EventMetaType<Event> BaseMetaType { "Event" };
+    static inline EventMetaType<Event> BaseMetaType{};
     virtual const AbstractEventMetaType& metaType() const
     {
         return BaseMetaType;
@@ -405,17 +405,13 @@ public:
 //! initialised by parameters passed to the macro, and a metaType() override
 //! pointing to that BaseMetaType.
 //! \sa EventMetaType
-#define QUO_BASE_EVENT(CppType_, BaseCppType_, ...)                       \
-    friend class EventMetaType<CppType_>;                                 \
-    static inline EventMetaType<CppType_> BaseMetaType{                   \
-        #CppType_, &BaseCppType_::BaseMetaType __VA_OPT__(, ) __VA_ARGS__ \
-    };                                                                    \
-    static_assert(&CppType_::BaseMetaType == &BaseMetaType,               \
-                  #CppType_ " is wrong here - check for copy-pasta");     \
-    const AbstractEventMetaType& metaType() const override                \
-    {                                                                     \
-        return BaseMetaType;                                              \
-    }                                                                     \
+#define QUO_BASE_EVENT(CppType_, BaseCppType_, ...)                                      \
+    friend class EventMetaType<CppType_>;                                                \
+    static inline auto BaseMetaType =                                                    \
+        EventMetaType<CppType_>(&BaseCppType_::BaseMetaType __VA_OPT__(, ) __VA_ARGS__); \
+    static_assert(&CppType_::BaseMetaType == &BaseMetaType,                              \
+                  #CppType_ " is wrong here - check for copy-pasta");                    \
+    const AbstractEventMetaType &metaType() const override { return BaseMetaType; }      \
     // End of macro
 
 //! \brief Supply event metatype information in (specific) event types
@@ -433,18 +429,13 @@ public:
 //! parameters if you need to include the same event type in more than one
 //! event factory hierarchy (e.g., EncryptedEvent).
 //! \sa EventMetaType
-#define QUO_EVENT(CppType_, MatrixType_)                                 \
-    friend class EventMetaType<CppType_>;                                \
-    static inline const EventMetaType<CppType_> MetaType{ #CppType_,     \
-                                                          &BaseMetaType, \
-                                                          MatrixType_ }; \
-    static_assert(&CppType_::MetaType == &MetaType,                      \
-                  #CppType_ " is wrong here - check for copy-pasta");    \
-    static inline const auto& TypeId = MetaType.matrixId;                \
-    const AbstractEventMetaType& metaType() const override               \
-    {                                                                    \
-        return MetaType;                                                 \
-    }                                                                    \
+#define QUO_EVENT(CppType_, MatrixType_)                                                     \
+    friend class EventMetaType<CppType_>;                                                    \
+    static inline const auto MetaType = EventMetaType<CppType_>(&BaseMetaType, MatrixType_); \
+    static_assert(&CppType_::MetaType == &MetaType,                                          \
+                  #CppType_ " is wrong here - check for copy-pasta");                        \
+    static inline const auto &TypeId = MetaType.matrixId;                                    \
+    const AbstractEventMetaType &metaType() const override { return MetaType; }              \
     // End of macro
 
 #define QUO_CONTENT_GETTER_X(PartType_, PartName_, JsonKey_) \

--- a/Quotient/events/roomjoinrulesevent.h
+++ b/Quotient/events/roomjoinrulesevent.h
@@ -13,7 +13,7 @@ namespace EventContent {
 //! \brief Definition of an allow AllowCondition
 //!
 //! \sa https://spec.matrix.org/latest/client-server-api/#mroomjoin_ruless
-struct AllowCondition {
+struct QUOTIENT_API AllowCondition {
     QString roomId;
     QString type;
 };
@@ -30,7 +30,7 @@ struct AllowCondition {
 //! \brief The content of a join rule event
 //!
 //! \sa https://spec.matrix.org/latest/client-server-api/#mroomjoin_rules
-struct JoinRuleContent {
+struct QUOTIENT_API JoinRuleContent {
     JoinRule joinRule;
     QList<AllowCondition> allow;
 };
@@ -75,8 +75,8 @@ inline auto toJson(const EventContent::JoinRuleContent& c)
 //! \brief Class to define a join rule state event.
 //!
 //! \sa Quotient::StateEvent, https://spec.matrix.org/latest/client-server-api/#mroomjoin_rules
-class JoinRulesEvent : public KeylessStateEventBase<JoinRulesEvent,
-    EventContent::JoinRuleContent>
+class QUOTIENT_API JoinRulesEvent
+    : public KeylessStateEventBase<JoinRulesEvent, EventContent::JoinRuleContent>
 {
 public:
     QUO_EVENT(JoinRulesEvent, "m.room.join_rules")


### PR DESCRIPTION
After accidentally finding out that `JoinRulesEvent` wasn't marked with `QUOTIENT_API`, I went on to find out why - da117249df74834fc4dedcd2471b2846d9b5544e is the result of that quest. Basically, the current code (without this PR) prevents [split-brain](#413) but doesn't ensure that all translation units converge on one `EventMetaType` instance, ending up with `EventMetaType` clones created for the same type (seemingly harmless but still).

This PR doesn't do anything new when two _distinct_ types claim the same Matrix event type id; it's still a warning in the logs, with only the first registered type actually being used to create event objects.