### PR TITLE
Use smaller number when disabling timeouts for sync jobs

### DIFF
--- a/Quotient/jobs/syncjob.cpp
+++ b/Quotient/jobs/syncjob.cpp
@@ -23,7 +23,7 @@ SyncJob::SyncJob(const QString& since, const QString& filter, int timeout, const
         query.addQueryItem(u"timeout"_s, QString::number(timeout));
         backoffStrategy.jobTimeouts = { std::chrono::seconds(timeout / 1000 + 10) };
     } else
-        backoffStrategy.jobTimeouts = { std::chrono::seconds::max() };
+        backoffStrategy.jobTimeouts = { std::chrono::years { 1000 } }; // effectively disable the timeout
     setBackoffStrategy(std::move(backoffStrategy));
     addParam<IfNotEmpty>(query, u"since"_s, since);
     setRequestQuery(query);


### PR DESCRIPTION
This number is too big when we use it inside QObject::startTimer- for various reasons, such as when it internally converts it to nanoseconds and overflows it's integer type. This causes some consumers to emit the following log message:

QObject::startTimer: Timers cannot have negative intervals

To avoid this, we can choose a smaller value for the job timeout and still have the same result of effectively disabling the timeout.

Fixes #885