### PR TITLE
Fix readmarker crash

### DIFF
--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -840,7 +840,11 @@ Room::Changes Room::Private::setLocalLastReadReceipt(const rev_iter_t& newMarker
         return Change::None;
     Changes changes = Change::Other;
     if (!deferStatsUpdate) {
-        if (unreadStats.updateOnMarkerMove(q, q->findInTimeline(*prevEventId),
+        const auto prevMarker = q->findInTimeline(*prevEventId);
+        if (newMarker >= prevMarker) {
+            return Change::None;
+        }
+        if (unreadStats.updateOnMarkerMove(q, prevMarker,
                                            newMarker)) {
             qDebug(MESSAGES)
                 << "Updated unread event statistics in" << q->objectName()


### PR DESCRIPTION
The code assumes that the new marker is newer than the old marker, which isn't necessarily true, since we also overwrite it locally and the server might then send one that is older.

Fixes #867