### PR TITLE
DownloadFileJob: Use ".part" for download file

### DIFF
--- a/Quotient/jobs/downloadfilejob.cpp
+++ b/Quotient/jobs/downloadfilejob.cpp
@@ -25,7 +25,7 @@ public:
         , mediaId(std::move(mediaId))
         , targetFile(!localFilename.isEmpty() ? std::make_unique<QFile>(localFilename) : nullptr)
         , tempFile(!localFilename.isEmpty()
-                       ? std::make_unique<QFile>(targetFile->fileName() + ".qtntdownload"_L1)
+                       ? std::make_unique<QFile>(targetFile->fileName() + ".part"_L1)
                        : std::make_unique<QTemporaryFile>())
     {}
 


### PR DESCRIPTION
Makes the file of application/x-partial-download type which is a known MIME type for partial downloads and incomplete files.

---

KDE Plasma for example advises the user to not touch the file:

> This file is incomplete and should not be opened.
> Check your open applications and the notification area for any pending tasks or download