### PR TITLE
Fix downloading to temporary file

### DIFF
--- a/Quotient/jobs/downloadfilejob.cpp
+++ b/Quotient/jobs/downloadfilejob.cpp
@@ -158,7 +158,7 @@ BaseJob::Status DownloadFileJob::prepareResult()
     } else {
         if (d->encryptedFileMetadata.has_value()) {
             std::unique_ptr<QFile> tempTempFile = std::make_unique<QTemporaryFile>();
-            if (!tempTempFile->isWritable()) {
+            if (!tempTempFile->open(QFile::WriteOnly)) {
                 qCWarning(JOBS) << "Failed to open temporary file for decryption"
                                 << tempTempFile->errorString();
                 return { FileError, "Couldn't open temporary file for decryption"_L1 };


### PR DESCRIPTION
Regression from c1ef9310b30b1fefa789756cdaafb12d6cbcb187, which removed actually opening the temporary file we are about to write to.