### PR TITLE
Add QML module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,13 @@ jobs:
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
+    - name: Build and install ECM
+      run: |
+        cd ..
+        git clone https://invent.kde.org/frameworks/extra-cmake-modules.git
+        cmake -S extra-cmake-modules -B extra-cmake-modules/build $CMAKE_ARGS
+        cmake --build extra-cmake-modules/build --target install
+
     - name: Configure libQuotient
       run: |
         cmake -S $GITHUB_WORKSPACE -B $BUILD_PATH $CMAKE_ARGS -DQuotient_INSTALL_TESTS=ON

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ compile_commands.json
 # Created by doxygen
 html/
 latex/
+
+.qmlls.ini

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ string(JOIN ~ FULL_VERSION ${PROJECT_VERSION} ${PRE_STAGE})
 message(STATUS)
 message(STATUS "Configuring ${PROJECT_NAME} ${FULL_VERSION} ==>")
 
-find_package(ECM NO_MODULE)
+find_package(ECM REQUIRED NO_MODULE)
 if (ECM_FOUND)
     set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH})
     include(ECMEnableSanitizers)
@@ -90,7 +90,7 @@ set(${PROJECT_NAME}_INSTALL_INCLUDEDIR
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 
-find_package(${Qt} ${QtMinVersion} REQUIRED Core Network Gui Test Sql)
+find_package(${Qt} ${QtMinVersion} REQUIRED Core Network Gui Test Sql Qml)
 get_filename_component(Qt_Prefix "${${Qt}_DIR}/../../../.." ABSOLUTE)
 
 if(${Qt}Core_VERSION VERSION_GREATER_EQUAL 6.10)
@@ -257,6 +257,16 @@ target_sources(${QUOTIENT_LIB_NAME} PUBLIC FILE_SET HEADERS BASE_DIRS .
         libquotientemojis.qrc
 )
 
+include(ECMQmlModule)
+include(KDEInstallDirs)
+
+qt_extract_metatypes(${QUOTIENT_LIB_NAME})
+ecm_add_qml_module(${QUOTIENT_LIB_NAME}plugin URI io.github.quotient_im.libquotient GENERATE_PLUGIN_SOURCE DEPENDENCIES QtCore)
+target_include_directories(${QUOTIENT_LIB_NAME}plugin PRIVATE ${CMAKE_BINARY_DIR} ${CMAKE_SOURCE_DIR}/Quotient/e2ee)
+qt_generate_foreign_qml_types(${QUOTIENT_LIB_NAME} ${QUOTIENT_LIB_NAME}plugin)
+target_link_libraries(${QUOTIENT_LIB_NAME}plugin PRIVATE ${Qt}::Core ${Qt}::Qml ${QUOTIENT_LIB_NAME})
+ecm_finalize_qml_module(${QUOTIENT_LIB_NAME}plugin DESTINATION ${KDE_INSTALL_QMLDIR} EXPORT ${QUOTIENT_LIB_NAME}Targets)
+
 # Configure API files generation
 
 set(CSAPI_DIR csapi)
@@ -376,7 +386,7 @@ target_include_directories(${QUOTIENT_LIB_NAME} PUBLIC
 
 target_link_libraries(${QUOTIENT_LIB_NAME}
     PUBLIC ${Qt}::Core ${Qt}::Network ${Qt}::Gui qt${${Qt}Core_VERSION_MAJOR}keychain Olm::Olm ${Qt}::Sql
-    PRIVATE OpenSSL::Crypto ${Qt}::CorePrivate)
+    PRIVATE OpenSSL::Crypto ${Qt}::CorePrivate ${Qt}::QmlIntegration)
 
 configure_file(${PROJECT_NAME}.pc.in ${CMAKE_CURRENT_BINARY_DIR}/${QUOTIENT_LIB_NAME}.pc @ONLY NEWLINE_STYLE UNIX)
 

--- a/Quotient/connection.h
+++ b/Quotient/connection.h
@@ -24,6 +24,7 @@
 #include <QtCore/QObject>
 #include <QtCore/QSize>
 #include <QtCore/QUrl>
+#include <QtQmlIntegration/qqmlintegration.h>
 
 #include <functional>
 
@@ -102,8 +103,10 @@ using IgnoredUsersList = IgnoredUsersEvent::value_type;
 
 class QUOTIENT_API Connection : public QObject {
     Q_OBJECT
+    QML_ELEMENT
+    QML_UNCREATABLE("")
 
-    Q_PROPERTY(User* localUser READ user NOTIFY stateChanged)
+    Q_PROPERTY(Quotient::User* localUser READ user NOTIFY stateChanged)
     Q_PROPERTY(QString localUserId READ userId NOTIFY stateChanged)
     Q_PROPERTY(QString domain READ domain NOTIFY stateChanged STORED false)
     Q_PROPERTY(QString deviceId READ deviceId NOTIFY stateChanged)

--- a/Quotient/e2ee/sssshandler.h
+++ b/Quotient/e2ee/sssshandler.h
@@ -14,6 +14,7 @@ namespace Quotient {
 class QUOTIENT_API SSSSHandler : public QObject
 {
     Q_OBJECT
+    QML_ELEMENT
     Q_PROPERTY(Quotient::Connection* connection READ connection WRITE setConnection NOTIFY connectionChanged)
 
 public:

--- a/Quotient/eventstats.h
+++ b/Quotient/eventstats.h
@@ -18,6 +18,9 @@ namespace Quotient {
 //! \sa Room::unreadStats, Room::partiallyReadStats, Room::isEventNotable
 struct QUOTIENT_API EventStats {
     Q_GADGET
+    QML_NAMED_ELEMENT(eventStats)
+    QML_UNCREATABLE("")
+
     Q_PROPERTY(qsizetype notableCount MEMBER notableCount CONSTANT)
     Q_PROPERTY(qsizetype highlightCount MEMBER highlightCount CONSTANT)
     Q_PROPERTY(bool isEstimate MEMBER isEstimate CONSTANT)

--- a/Quotient/keyimport.h
+++ b/Quotient/keyimport.h
@@ -7,6 +7,7 @@
 #include "quotient_export.h"
 
 #include <QtCore/QObject>
+#include <QtQmlIntegration/qqmlintegration.h>
 
 class TestKeyImport;
 
@@ -21,6 +22,8 @@ namespace Quotient
 class QUOTIENT_API KeyImport : public QObject
 {
     Q_OBJECT
+    QML_ELEMENT
+    QML_SINGLETON
 
 public:
     enum Error {

--- a/Quotient/keyverificationsession.h
+++ b/Quotient/keyverificationsession.h
@@ -8,6 +8,7 @@
 
 #include <QtCore/QObject>
 #include <QtCore/QPointer>
+#include <QtQmlIntegration/qqmlintegration.h>
 
 struct OlmSAS;
 
@@ -34,6 +35,8 @@ public:
 class QUOTIENT_API KeyVerificationSession : public QObject
 {
     Q_OBJECT
+    QML_ELEMENT
+    QML_UNCREATABLE("")
 
 public:
     enum State {

--- a/Quotient/quotient_common.h
+++ b/Quotient/quotient_common.h
@@ -10,6 +10,7 @@
 
 #include <array>
 #include <span>
+#include <QtQmlIntegration/qqmlintegration.h>
 
 //! \brief Quotient replacement for the Q_FLAG/Q_DECLARE_FLAGS combination
 //!
@@ -44,6 +45,7 @@
 
 namespace Quotient {
 Q_NAMESPACE_EXPORT(QUOTIENT_API)
+QML_ELEMENT
 
 //! \brief Enabling structure for conversion between a given enum and JSON
 //!
@@ -199,7 +201,7 @@ constexpr inline auto MegolmV1AesSha2AlgoKey = "m.megolm.v1.aes-sha2"_L1;
 QUO_META_ENUM(EncryptionType, EncryptionType::Undefined, MegolmV1AesSha2AlgoKey)
 
 //! Enum representing the available room join rules
-enum JoinRule : uint16_t {
+enum JoinRule : uint32_t {
     Public,
     Knock,
     Invite,

--- a/Quotient/room.h
+++ b/Quotient/room.h
@@ -29,6 +29,7 @@
 
 #include <QtCore/QJsonObject>
 #include <QtGui/QImage>
+#include <QtQmlIntegration/qqmlintegration.h>
 
 #include <deque>
 #include <utility>
@@ -118,8 +119,11 @@ private:
 
 class QUOTIENT_API Room : public QObject {
     Q_OBJECT
-    Q_PROPERTY(Connection* connection READ connection CONSTANT)
-    Q_PROPERTY(RoomMember localMember READ localMember CONSTANT)
+    QML_ELEMENT
+    QML_UNCREATABLE("")
+
+    Q_PROPERTY(Quotient::Connection* connection READ connection CONSTANT)
+    Q_PROPERTY(Quotient::RoomMember localMember READ localMember CONSTANT)
     Q_PROPERTY(QString id READ id CONSTANT)
     Q_PROPERTY(QString version READ version NOTIFY baseStateLoaded)
     Q_PROPERTY(bool isUnstable READ isUnstable NOTIFY stabilityUpdated)
@@ -143,8 +147,8 @@ class QUOTIENT_API Room : public QObject {
     Q_PROPERTY(int joinedCount READ joinedCount NOTIFY memberListChanged)
     Q_PROPERTY(int invitedCount READ invitedCount NOTIFY memberListChanged)
     Q_PROPERTY(int totalMemberCount READ totalMemberCount NOTIFY memberListChanged)
-    Q_PROPERTY(QList<RoomMember> membersTyping READ membersTyping NOTIFY typingChanged)
-    Q_PROPERTY(QList<RoomMember> otherMembersTyping READ otherMembersTyping NOTIFY typingChanged)
+    Q_PROPERTY(QList<Quotient::RoomMember> membersTyping READ membersTyping NOTIFY typingChanged)
+    Q_PROPERTY(QList<Quotient::RoomMember> otherMembersTyping READ otherMembersTyping NOTIFY typingChanged)
     Q_PROPERTY(int localMemberEffectivePowerLevel READ memberEffectivePowerLevel NOTIFY changed)
 
     Q_PROPERTY(bool displayed READ displayed WRITE setDisplayed NOTIFY
@@ -159,14 +163,14 @@ class QUOTIENT_API Room : public QObject {
                    NOTIFY highlightCountChanged)
     Q_PROPERTY(qsizetype notificationCount READ notificationCount
                    NOTIFY notificationCountChanged)
-    Q_PROPERTY(EventStats partiallyReadStats READ partiallyReadStats NOTIFY partiallyReadStatsChanged)
-    Q_PROPERTY(EventStats unreadStats READ unreadStats NOTIFY unreadStatsChanged)
+    Q_PROPERTY(Quotient::EventStats partiallyReadStats READ partiallyReadStats NOTIFY partiallyReadStatsChanged)
+    Q_PROPERTY(Quotient::EventStats unreadStats READ unreadStats NOTIFY unreadStatsChanged)
     Q_PROPERTY(bool allHistoryLoaded READ allHistoryLoaded NOTIFY allHistoryLoadedChanged
                    STORED false)
     Q_PROPERTY(QStringList tagNames READ tagNames NOTIFY tagsChanged)
     Q_PROPERTY(bool isFavourite READ isFavourite NOTIFY tagsChanged STORED false)
     Q_PROPERTY(bool isLowPriority READ isLowPriority NOTIFY tagsChanged STORED false)
-    Q_PROPERTY(JoinRule joinRule READ joinRule WRITE setJoinRule NOTIFY joinRuleChanged)
+    Q_PROPERTY(Quotient::JoinRule joinRule READ joinRule WRITE setJoinRule NOTIFY joinRuleChanged)
     Q_PROPERTY(QList<QString> allowIds READ allowIds NOTIFY joinRuleChanged)
 
     Q_PROPERTY(GetRoomEventsJob* eventsHistoryJob READ eventsHistoryJob NOTIFY eventsHistoryJobChanged)

--- a/Quotient/roommember.h
+++ b/Quotient/roommember.h
@@ -8,6 +8,7 @@
 #include "avatar.h"
 
 #include <QtCore/QObject>
+#include <QtQmlIntegration/qqmlintegration.h>
 
 namespace Quotient {
 class Room;
@@ -31,6 +32,9 @@ class RoomMemberEvent;
 //! \sa User
 class QUOTIENT_API RoomMember {
     Q_GADGET
+    QML_NAMED_ELEMENT(roomMember)
+    QML_UNCREATABLE("")
+
     Q_PROPERTY(bool isEmpty READ isEmpty CONSTANT)
     Q_PROPERTY(QString id READ id CONSTANT)
     Q_PROPERTY(Uri uri READ uri CONSTANT)

--- a/Quotient/user.h
+++ b/Quotient/user.h
@@ -8,6 +8,7 @@
 #include "util.h"
 
 #include <QtCore/QObject>
+#include <QtQmlIntegration/qqmlintegration.h>
 
 namespace Quotient {
 class Connection;
@@ -24,6 +25,9 @@ class RoomMemberEvent;
 //! \sa Quotient::RoomMember
 class QUOTIENT_API User : public QObject {
     Q_OBJECT
+    QML_ELEMENT
+    QML_UNCREATABLE("")
+
     Q_PROPERTY(QString id READ id CONSTANT)
     Q_PROPERTY(bool isGuest READ isGuest CONSTANT)
     Q_PROPERTY(QString name READ name NOTIFY defaultNameChanged)

--- a/autotests/CMakeLists.txt
+++ b/autotests/CMakeLists.txt
@@ -37,3 +37,5 @@ quotient_add_test(NAME testcrosssigning)
 quotient_add_test(NAME testkeyimport)
 quotient_add_test(NAME testsettings)
 quotient_add_test(NAME testthread)
+
+add_test(NAME testqmltypes COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/testqmltypes.sh ${KDE_INSTALL_FULL_LIBDIR}/qml/io/github/quotient_im/libquotient)

--- a/autotests/testqmltypes.sh
+++ b/autotests/testqmltypes.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2025 Tobias Fella <tobias.fella@kde.org>
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+file="$1/QuotientQt6plugin.qmltypes"
+
+if [ ! -f "$file" ]; then
+    echo "File $file does not exist"
+    exit 1
+fi
+
+lines=$(wc -l < "$file")
+if [ "$lines" -gt 100 ]; then
+    exit 0
+else
+    exit 1
+fi
+


### PR DESCRIPTION
This is required for some tooling - qmlls, qmllint, etc. - to work correctly. It also improves qml compilation in the clients