### PR TITLE
Support room version 12

### DIFF
--- a/Quotient/connection.cpp
+++ b/Quotient/connection.cpp
@@ -681,6 +681,25 @@ QFuture<Room*> Connection::joinAndGetRoom(const QString& roomAlias, const QStrin
         .then([this](const QString& roomId) { return provideRoom(roomId); });
 }
 
+QFuture<Room *> Connection::waitForNewRoom(const QString &roomId)
+{
+    if (auto *newRoom = room(roomId))
+        return makeReadyValueFuture(newRoom);
+
+    QPromise<Room *> promise;
+    auto ft = promise.future();
+    connectUntil(this, &Connection::loadedRoomState, this,
+                 [roomId, p = std::move(promise)](Room *newRoom) mutable {
+        if (newRoom->id() == roomId) {
+            p.addResult(newRoom);
+            p.finish();
+            return true;
+        }
+        return false;
+    });
+    return ft;
+}
+
 JobHandle<LeaveRoomJob> Connection::leaveRoom(Room* room)
 {
     const auto& roomId = room->id();

--- a/Quotient/connection.cpp
+++ b/Quotient/connection.cpp
@@ -799,7 +799,24 @@ JobHandle<CreateRoomJob> Connection::createRoom(
     const QVector<CreateRoomJob::StateEvent>& initialState,
     const QVector<CreateRoomJob::Invite3pid>& invite3pids, const QJsonObject& creationContent)
 {
+    return createRoom(visibility, alias, name, topic, std::move(invites), presetName, roomVersion,
+                      isDirect, initialState, {}, invite3pids, creationContent);
+}
+
+JobHandle<CreateRoomJob> Connection::createRoom(
+    RoomVisibility visibility, const QString &alias, const QString &name, const QString &topic,
+    QStringList invites, const QString &presetName, const QString &roomVersion, bool isDirect,
+    const QVector<CreateRoomJob::StateEvent> &initialState, const QStringList &additionalCreators,
+    const QVector<Invite3pid> &invite3pids, QJsonObject creationContent)
+{
     invites.removeOne(userId()); // The creator is by definition in the room
+    if (!additionalCreators.empty()) {
+        auto creators = creationContent.take("additional_creators"_L1).toArray();
+        for (const auto &ac : additionalCreators)
+            if (!creators.contains(ac))
+                creators.append(ac);
+        creationContent.insert("additional_creators"_L1, creators);
+    }
     return callApi<CreateRoomJob>(visibility == PublishRoom ? u"public"_s : u"private"_s,
                                   alias, name, topic, invites, invite3pids, roomVersion,
                                   creationContent, initialState, presetName, isDirect)

--- a/Quotient/connection.h
+++ b/Quotient/connection.h
@@ -56,6 +56,8 @@ struct EncryptedFileMetadata;
 class QOlmAccount;
 class QOlmInboundGroupSession;
 
+using Invite3pid = CreateRoomJob::Invite3pid;
+
 using LoginFlow = GetLoginFlowsJob::LoginFlow;
 using LoginFlowType = QString;
 
@@ -749,6 +751,19 @@ public Q_SLOTS:
                const QVector<CreateRoomJob::StateEvent>& initialState = {},
                const QVector<CreateRoomJob::Invite3pid>& invite3pids = {},
                const QJsonObject& creationContent = {});
+
+    //! \brief Create a room with additional creators
+    //!
+    //! This is a temporary (until post-0.10) overload that accepts \p additionalCreators.
+    //! After 0.10 both overloads will merge into one again.
+    JobHandle<CreateRoomJob> createRoom(RoomVisibility visibility, const QString &alias,
+                                        const QString &name, const QString &topic,
+                                        QStringList invites, const QString &presetName,
+                                        const QString &roomVersion, bool isDirect,
+                                        const QVector<CreateRoomJob::StateEvent> &initialState,
+                                        const QStringList &additionalCreators,
+                                        const QVector<Invite3pid> &invite3pids = {},
+                                        QJsonObject creationContent = {});
 
     //! \brief Get a direct chat with a single user
     //!

--- a/Quotient/connection.h
+++ b/Quotient/connection.h
@@ -670,6 +670,8 @@ public:
     Q_INVOKABLE QFuture<Room*> joinAndGetRoom(const QString& roomAlias,
                                               const QStringList& serverNames = {});
 
+    Q_INVOKABLE QFuture<Room *> waitForNewRoom(const QString &roomId);
+
 public Q_SLOTS:
     //! \brief Log in using a username and password pair
     //!

--- a/Quotient/events/roomcreateevent.cpp
+++ b/Quotient/events/roomcreateevent.cpp
@@ -37,3 +37,8 @@ RoomType RoomCreateEvent::roomType() const
 {
     return contentPart<RoomType>("type"_L1);
 }
+
+QStringList RoomCreateEvent::additionalCreators() const
+{
+    return contentPart<QStringList>("additional_creators"_L1);
+}

--- a/Quotient/events/roomcreateevent.h
+++ b/Quotient/events/roomcreateevent.h
@@ -23,5 +23,6 @@ public:
     Predecessor predecessor() const;
     bool isUpgrade() const;
     RoomType roomType() const;
+    QStringList additionalCreators() const;
 };
 } // namespace Quotient

--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -1308,35 +1308,45 @@ qsizetype Room::highlightCount() const { return d->serverHighlightCount; }
 
 void Room::switchVersion(QString newVersion) { this->upgrade(newVersion); }
 
-namespace Matrix_v16 {
-// The CS API backend in libQuotient does not support additionalCreators yet, instead we build on
-// the old UpgradeRoomJob code but write our own request body.
-class UpgradeRoomJob : public Quotient::UpgradeRoomJob
-{
-public:
-    UpgradeRoomJob(const QString &roomId, const QString &version,
-                   const QStringList &additionalCreators)
-        : Quotient::UpgradeRoomJob(roomId, {})
-    {
-        setRequestData(QJsonObject{{"new_version"_L1, toJson(version)},
-                                   {"additional_creators"_L1, toJson(additionalCreators)}});
-    }
-};
+namespace CSAPI {
+inline namespace v16 {
+    // The CS API backend in libQuotient does not support additionalCreators yet, instead we build
+    // on the old UpgradeRoomJob code but write our own request body.
+    class UpgradeRoomJob : public Quotient::UpgradeRoomJob {
+    public:
+        UpgradeRoomJob(const QString& roomId, const QString& version,
+                       const QStringList& additionalCreators)
+            : Quotient::UpgradeRoomJob(roomId, {})
+        {
+            setRequestData(QJsonObject{ { "new_version"_L1, toJson(version) },
+                                        { "additional_creators"_L1, toJson(additionalCreators) } });
+        }
+    };
+}
 }
 
-QFuture<Room *> Room::upgrade(QString newVersion, const QStringList &additionalCreators)
+QFuture<Expected<Room*, BaseJob::Status>> Room::upgrade(QString newVersion,
+                                                        const QStringList& additionalCreators)
 {
     if (!successorId().isEmpty()) {
         Q_ASSERT(!successorId().isEmpty());
         emit upgradeFailed(tr("The room is already upgraded"));
     }
+    using future_t = Expected<Room*, BaseJob::Status>;
     return connection()
-        ->callApi<Matrix_v16::UpgradeRoomJob>(id(), newVersion, additionalCreators)
-        .then(std::bind_front(&Connection::waitForNewRoom, connection()),
-              [this](const auto *sameJob) {
-        emit upgradeFailed(sameJob ? sameJob->errorString() : tr("Couldn't initiate upgrade"));
-        return QFuture<Room *>{};
-    }).unwrap();
+        ->callApi<CSAPI::v16::UpgradeRoomJob>(id(), newVersion, additionalCreators)
+        .then(
+            connection(),
+            [this](const QString& newRoomId) {
+                return connection()->waitForNewRoom(newRoomId).then(
+                    [](Room* r) { return future_t(r); });
+            },
+            [this](const BaseJob* sameJob) {
+                auto&& status = sameJob->status();
+                emit upgradeFailed(status.message);
+                return makeReadyValueFuture<future_t>(std::move(status));
+            })
+        .unwrap();
 }
 
 bool Room::hasAccountData(const QString& type) const

--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -342,6 +342,28 @@ public:
 
     bool isLocalMember(const QString& memberId) const { return memberId == connection->userId(); }
 
+    //! \brief Check whether room (co-)creators have infinite power
+    //!
+    //! Since version 12, room (co-)creators have immutable infinite power. Coincidentally,
+    //! room ids as hashes have been introduced in the same version; so we use this instead of
+    //! checking the version number which, for unstable versions, may not necessarily start with 12
+    //! (or a larger number), neither even contain it.
+    bool creatorsHaveInfinitePower() const { return !id.contains(u':'); }
+
+    //! \brief Check whether the user is a/the room creator and has infinite power
+    //! \return `true` if creatorsHaveInfinitePower() returns `true` for this room version and
+    //!         \p mxId is either equal to the sender of the room creation event or is among
+    //!         additional_creators listed in that event; `false` otherwise
+    bool isAlmightyCreator(const UserId &mxId) const
+    {
+        return creatorsHaveInfinitePower() && q->creatorIds().contains(mxId);
+    }
+
+    int defaultCreatorPowerLevel() const
+    {
+        return creatorsHaveInfinitePower() ? std::numeric_limits<int>::max() : 100;
+    }
+
     std::unordered_map<QByteArray, QOlmInboundGroupSession> groupSessions;
     std::optional<QOlmOutboundGroupSession> currentOutboundMegolmSession = {};
 
@@ -658,6 +680,18 @@ RoomMember Room::member(const QString& userId) const
         return {};
     }
     return RoomMember(this, currentState().get<RoomMemberEvent>(userId));
+}
+
+QStringList Room::creatorIds() const
+{
+    if (auto createEvent = creation())
+#if defined(__cpp_lib_ranges_concat) && __cpp_lib_ranges_concat >= 202'403L
+        return rangeTo<QStringList>(std::views::concat(std::views::single(createEvent->senderId()),
+                                                       createEvent->additionalCreators()));
+#else
+        return QStringList{createEvent->senderId()} + createEvent->additionalCreators();
+#endif
+    return {};
 }
 
 QList<RoomMember> Room::joinedMembers() const
@@ -1034,6 +1068,9 @@ bool Room::canSwitchVersions() const
     if (!successorId().isEmpty())
         return false; // No one can upgrade a room that's already upgraded
 
+    if (d->isAlmightyCreator(connection()->userId()))
+        return true;
+
     if (const auto* plEvt = currentState().get<RoomPowerLevelsEvent>()) {
         const auto currentUserLevel =
             plEvt->powerLevelForUser(localMember().id());
@@ -1269,15 +1306,49 @@ qsizetype Room::notificationCount() const
 
 qsizetype Room::highlightCount() const { return d->serverHighlightCount; }
 
-void Room::switchVersion(QString newVersion)
+void Room::switchVersion(QString newVersion) { this->upgrade(newVersion); }
+
+namespace Matrix_v16 {
+// The CS API backend in libQuotient does not support additionalCreators yet, instead we build on
+// the old UpgradeRoomJob code but write our own request body.
+class UpgradeRoomJob : public Quotient::UpgradeRoomJob
+{
+public:
+    UpgradeRoomJob(const QString &roomId, const QString &version,
+                   const QStringList &additionalCreators)
+        : Quotient::UpgradeRoomJob(roomId, {})
+    {
+        setRequestData(QJsonObject{{"new_version"_L1, toJson(version)},
+                                   {"additional_creators"_L1, toJson(additionalCreators)}});
+    }
+};
+}
+
+QFuture<Room *> Room::upgrade(QString newVersion, const QStringList &additionalCreators)
 {
     if (!successorId().isEmpty()) {
         Q_ASSERT(!successorId().isEmpty());
         emit upgradeFailed(tr("The room is already upgraded"));
     }
-    connection()->callApi<UpgradeRoomJob>(id(), newVersion).onFailure([this](const auto* job) {
-        emit upgradeFailed(job ? job->errorString() : tr("Couldn't initiate upgrade"));
-    });
+    return connection()
+        ->callApi<Matrix_v16::UpgradeRoomJob>(id(), newVersion, additionalCreators)
+        .then([this](const QString &replacementRoom) {
+        QPromise<Room *> promise;
+        auto ft = promise.future();
+        connectUntil(connection(), &Connection::syncDone, this,
+                     [this, replacementRoom, p = std::move(promise)]() mutable {
+            if (auto *r = connection()->room(replacementRoom)) {
+                p.addResult(r);
+                p.finish();
+                return true;
+            }
+            return false;
+        });
+        return ft;
+    }, [this](const auto *sameJob) {
+        emit upgradeFailed(sameJob ? sameJob->errorString() : tr("Couldn't initiate upgrade"));
+        return QFuture<Room *>{};
+    }).unwrap();
 }
 
 bool Room::hasAccountData(const QString& type) const
@@ -1571,8 +1642,10 @@ void Room::setJoinRule(JoinRule newRule, const QList<QString>& allowedRooms)
 
 int Room::memberEffectivePowerLevel(const UserId& memberId) const
 {
-    return currentState().get<RoomPowerLevelsEvent>()->powerLevelForUser(
-        memberId.isEmpty() ? connection()->userId() : memberId);
+    auto actualMemberId = memberId.isEmpty() ? connection()->userId() : memberId;
+    return d->isAlmightyCreator(actualMemberId)
+               ? std::numeric_limits<int>::max()
+               : currentState().get<RoomPowerLevelsEvent>()->powerLevelForUser(actualMemberId);
 }
 
 int Room::powerLevelFor(const QString& eventTypeId, bool forceStateEvent) const
@@ -1950,14 +2023,16 @@ void Room::updateData(SyncRoomData&& data, bool fromCache)
         if (createEventPreviouslyMissing && creation()
             && currentState().get<RoomPowerLevelsEvent>() == d->defaultPowerLevels.get()) {
             // Handle a special case when RoomCreateEvent just arrived but RoomPowerLevelsEvent
-            // did not. Usually that means that a power levels event is not in the room at all,
-            // which is a somewhat extreme but still valid situation. In such a case the spec says
-            // to rely on the default power levels save for the room creator who is effectively
-            // allowed to do everything.
+            // did not. Usually that means that a power levels event is not in the room at all;
+            // in older room versions this is a somewhat extreme but still valid situation; since
+            // room version 12, this is (almost) normal for rooms that only contain the creators
+            // (e.g. private 1:1 chats). In such a case the spec says to rely on the default power
+            // levels save for the room creator who is allowed to do everything.
             // The entire defaultPowerLevels event gets replaced in order to maintain its constness
             // everywhere else.
-            d->defaultPowerLevels = std::make_unique<const RoomPowerLevelsEvent>(
-                PowerLevelsEventContent{ .users = { { creation()->senderId(), 100 } } });
+            d->defaultPowerLevels =
+                std::make_unique<const RoomPowerLevelsEvent>(PowerLevelsEventContent{
+                    .users = {{creation()->senderId(), d->defaultCreatorPowerLevel()}}});
             d->currentState[{ RoomPowerLevelsEvent::TypeId, {} }] = d->defaultPowerLevels.get();
         }
 

--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -1332,20 +1332,8 @@ QFuture<Room *> Room::upgrade(QString newVersion, const QStringList &additionalC
     }
     return connection()
         ->callApi<Matrix_v16::UpgradeRoomJob>(id(), newVersion, additionalCreators)
-        .then([this](const QString &replacementRoom) {
-        QPromise<Room *> promise;
-        auto ft = promise.future();
-        connectUntil(connection(), &Connection::syncDone, this,
-                     [this, replacementRoom, p = std::move(promise)]() mutable {
-            if (auto *r = connection()->room(replacementRoom)) {
-                p.addResult(r);
-                p.finish();
-                return true;
-            }
-            return false;
-        });
-        return ft;
-    }, [this](const auto *sameJob) {
+        .then(std::bind_front(&Connection::waitForNewRoom, connection()),
+              [this](const auto *sameJob) {
         emit upgradeFailed(sameJob ? sameJob->errorString() : tr("Couldn't initiate upgrade"));
         return QFuture<Room *>{};
     }).unwrap();
@@ -3306,18 +3294,8 @@ Room::Change Room::Private::processStateEvent(const RoomEvent& curEvent,
             return Change::Other;
         },
         [this](const RoomTombstoneEvent& evt) {
-            const auto successorId = evt.successorRoomId();
-            if (auto* successor = connection->room(successorId))
-                emit q->upgraded(evt.serverMessage(), successor);
-            else
-                connectUntil(connection, &Connection::loadedRoomState, q,
-                    [this,successorId,serverMsg=evt.serverMessage()]
-                    (Room* newRoom) {
-                        if (newRoom->id() != successorId)
-                            return false;
-                        emit q->upgraded(serverMsg, newRoom);
-                        return true;
-                    });
+            connection->waitForNewRoom(evt.successorRoomId())
+                .then(std::bind_front(/* emit */ &Room::upgraded, q, evt.serverMessage()));
 
             return Change::Other;
         },

--- a/Quotient/room.h
+++ b/Quotient/room.h
@@ -327,6 +327,13 @@ public:
     //! Get a list of all member Matrix IDs known to the room.
     QStringList memberIds() const;
 
+    //! \brief Get Matrix IDs for room creator(s)
+    //!
+    //! As long as the create event for the room is known, the returned list will start with
+    //! MXID of the room creation event sender. For room versions 12 and newer, the returned list
+    //! will further include additional creators if there are any.
+    QStringList creatorIds() const;
+
     //! Whether the name for the given member should be disambiguated
     bool needsDisambiguation(const QString& userId) const;
 
@@ -718,13 +725,14 @@ public:
     //! \note This is a generic method that only gets the power level to send events with a given
     //!       type. Some operations have additional restrictions or enablers though: e.g.,
     //!       room member changes (kicks, invites) have special power levels; on the other hand,
-    //!       redactions of one's own messages are allowed regardless of the power level. To check
-    //!       effective ability to perform an operation, use Room's can*() methods instead of
-    //!       comparing the power levels (those are also slightly more efficient).
+    //!       redactions of one's own messages are allowed regardless of the power level.
+    //!       The library has no method to check effective ability to perform an operation as yet;
+    //!       you have to either blindly make a call to the homeserver or implement the logic
+    //!       described in the Federation API and respective room versions, in the client code.
     //! \note Unlike the template version below, this method determines at runtime whether an event
     //!       type is that of a state event, assuming unknown event types to be non-state; pass
     //!       `true` as the second parameter to override that.
-    //! \sa canSend, canRedact, canSwitchVersions
+    //! \sa canSwitchVersions
     Q_INVOKABLE int powerLevelFor(const QString& eventTypeId, bool forceStateEvent = false) const;
 
     //! \brief Get the power level required to send events of the given type
@@ -806,6 +814,15 @@ public:
 
     QJsonArray exportMegolmSessions();
 
+    //! \brief Upgrade the room to \p newVersion
+    //!
+    //! Triggers an upgrade process that puts the tombstone event on the current room and creates
+    //! a new room of the specified version. It is possible to specify \p additionalCreators for
+    //! room versions that support those (unfortunately it is only possible to find out whether
+    //! a given room version supports additional creators by attempting to upgrade a room).
+    //! \return a future eventually holding a new room once it arrives via sync
+    QFuture<Room *> upgrade(QString newVersion, const QStringList &additionalCreators = {});
+
 public Q_SLOTS:
     /** Check whether the room should be upgraded */
     void checkVersion();
@@ -850,7 +867,8 @@ public Q_SLOTS:
     //! Put the fully-read marker at the latest message in the room
     void markAllMessagesAsRead();
 
-    /// Switch the room's version (aka upgrade)
+    //! Switch the room's version (aka upgrade)
+    [[deprecated("Use upgrade() instead")]]
     void switchVersion(QString newVersion);
 
     void inviteCall(const QString& callId, const int lifetime,

--- a/Quotient/room.h
+++ b/Quotient/room.h
@@ -821,7 +821,8 @@ public:
     //! room versions that support those (unfortunately it is only possible to find out whether
     //! a given room version supports additional creators by attempting to upgrade a room).
     //! \return a future eventually holding a new room once it arrives via sync
-    QFuture<Room *> upgrade(QString newVersion, const QStringList &additionalCreators = {});
+    QFuture<Expected<Room*, BaseJob::Status>> upgrade(QString newVersion,
+                                                      const QStringList& additionalCreators = {});
 
 public Q_SLOTS:
     /** Check whether the room should be upgraded */


### PR DESCRIPTION
The implementation is pretty basic and makes a shortcut in CS API backend, so that it can be easily applied to 0.9.x branch too. The impact on clients should be relatively minimal: `Room::memberEffectivePowerLevel()` will return `std::numeric_lmits<int>::max()` for room (co-)creators in new room versions, making it business as usual for (most) intents and purposes. Introducing additional creators in the user interface is, of course, on clients: namely, the room creation dialog and room upgrade dialog should be extended for that purpose.