### PR TITLE
Allow handling key verification start events from other devices

### DIFF
--- a/Quotient/keyverificationsession.cpp
+++ b/Quotient/keyverificationsession.cpp
@@ -449,9 +449,7 @@ void KeyVerificationSession::handleReady(const KeyVerificationReadyEvent& event)
 void KeyVerificationSession::handleStart(const KeyVerificationStartEvent& event)
 {
     if (startSentByUs) {
-        if (m_remoteUserId > m_connection->userId()
-            || (m_remoteUserId == m_connection->userId()
-                && m_remoteDeviceId > m_connection->deviceId())) {
+        if (m_remoteUserId > m_connection->userId()) {
             return;
         }
         startSentByUs = false;


### PR DESCRIPTION
See this NeoChat bug (https://bugs.kde.org/show_bug.cgi?id=508483) where a user encounters a strange situation where handling a device verification through NeoChat ended up in a "stalemate". The KeyVerificationSession is in the WAITINGFORACCEPT state, but neither client (in this case, Element Web) actually starts the session.

However, Element prompts the user to begin emoji verification and can send us a m.key.verification.start to get us unstuck. But we end up throwing this anyway - making the situation worse, because we don't consider these events when it didn't come from our device. In reality this is completely kosher, as the verification will succeed and the spec even mentions that either device can send this event. So libQuotient was being unnecessarily stringent here:

> Also note that, although in this example, Bob’s device sends the
> m.key.verification.start, Alice’s device could also send that message.
(From 10.12.2.1. Key verification framework)

The only way I found to test this in the real world is to keep sending device verification requests from Element Web until you hit this bug, but it is fairly reproducible.