### PR TITLE
Fix qt warning about too high timer intervals

### DIFF
--- a/Quotient/jobs/syncjob.cpp
+++ b/Quotient/jobs/syncjob.cpp
@@ -23,7 +23,7 @@ SyncJob::SyncJob(const QString& since, const QString& filter, int timeout, const
         query.addQueryItem(u"timeout"_s, QString::number(timeout));
         backoffStrategy.jobTimeouts = { std::chrono::seconds(timeout / 1000 + 10) };
     } else
-        backoffStrategy.jobTimeouts = { std::chrono::years { 1000 } }; // effectively disable the timeout
+        backoffStrategy.jobTimeouts = { std::chrono::weeks { 3 } }; // effectively disable the timeout
     setBackoffStrategy(std::move(backoffStrategy));
     addParam<IfNotEmpty>(query, u"since"_s, since);
     setRequestQuery(query);


### PR DESCRIPTION
Qt warns that it can't set timers for 1000 years and that they will be clamped to "about 24 days". For simplicity, set the to three weeks, which is close enough to the maximum and simple enough to write; the exact value doesn't matter to us anyway.