### PR TITLE
Move reply-related functions to RoomEvent

### DIFF
--- a/Quotient/events/roomevent.cpp
+++ b/Quotient/events/roomevent.cpp
@@ -115,3 +115,30 @@ bool Quotient::isStateEvent(const QString& eventTypeId)
 {
     return containsEventType(StateEvent::BaseMetaType.derivedTypes(), eventTypeId);
 }
+
+bool RoomEvent::isReply(bool includeFallbacks) const
+{
+    const auto relation = relatesTo();
+    return relation.has_value() &&
+    (relation.value().type == EventRelation::ReplyType ||
+    (relation.value().type == EventRelation::ThreadType &&
+    (relation.value().isFallingBack == false || includeFallbacks)));
+}
+
+QString RoomEvent::replyEventId(bool includeFallbacks) const
+{
+    if (const auto relation = relatesTo()) {
+        if (relation.value().type == EventRelation::ReplyType) {
+            return relation.value().eventId;
+        } else if (relation.value().type == EventRelation::ThreadType &&
+            (relation.value().isFallingBack == false || includeFallbacks)) {
+            return relation.value().inThreadReplyEventId;
+            }
+    }
+    return {};
+}
+
+std::optional<EventRelation> RoomEvent::relatesTo() const
+{
+    return contentPart<std::optional<EventRelation>>(RelatesToKey);
+}

--- a/Quotient/events/roomevent.h
+++ b/Quotient/events/roomevent.h
@@ -5,6 +5,8 @@
 
 #include "event.h"
 
+#include "eventrelation.h"
+
 #include <QtCore/QDateTime>
 
 namespace Quotient {
@@ -77,6 +79,34 @@ public:
     void setOriginalEvent(event_ptr_tt<EncryptedEvent>&& originalEvent);
     const EncryptedEvent* originalEvent() const { return _originalEvent.get(); }
     const QJsonObject encryptedJson() const;
+
+    //! \brief Determine whether the event is a reply to another message.
+    //!
+    //! \param includeFallbacks include thread fallback replies for non-threaded clients.
+    //!
+    //! \return true if this event is a reply, i.e. it has `"m.in_reply_to"`
+    //!         event ID and is not a thread fallback (except where \p includeFallbacks is true);
+    //!         false otherwise.
+    //!
+    //! \note It's possible to reply to another message in a thread so this function
+    //!       will return true for a `"rel_type"` of `"m.thread"` if `"is_falling_back"`
+    //!       is false.
+    bool isReply(bool includeFallbacks = false) const;
+
+    //! \brief The ID for the event being replied to.
+    //!
+    //! \param includeFallbacks include thread fallback replies for non-threaded clients.
+    //!
+    //!
+    //! \return The event ID for a reply, this includes threaded replies where `"rel_type"`
+    //!         is `"m.thread"` and `"is_falling_back"` is false (except where \p includeFallbacks is true).
+    QString replyEventId(bool includeFallbacks = false) const;
+
+    //! \brief The EventRelation for this event.
+    //!
+    //! \return an EventRelation object which can be checked for type if it exists,
+    //!         std::nullopt otherwise.
+    std::optional<EventRelation> relatesTo() const;
 
 protected:
     explicit RoomEvent(const QJsonObject& json);

--- a/Quotient/events/roommessageevent.cpp
+++ b/Quotient/events/roommessageevent.cpp
@@ -249,11 +249,6 @@ bool RoomMessageEvent::has<LocationContent>() const
     return rawMsgtype() == LocationTypeId;
 }
 
-std::optional<EventRelation> RoomMessageEvent::relatesTo() const
-{
-    return contentPart<std::optional<EventRelation>>(RelatesToKey);
-}
-
 QString RoomMessageEvent::upstreamEventId() const
 {
     const auto relation = relatesTo();
@@ -278,28 +273,6 @@ QString RoomMessageEvent::replacedBy() const
 {
     return unsignedPart<QJsonObject>("m.relations"_L1)[EventRelation::ReplacementType][EventIdKey]
         .toString();
-}
-
-bool RoomMessageEvent::isReply(bool includeFallbacks) const
-{
-    const auto relation = relatesTo();
-    return relation.has_value() &&
-            (relation.value().type == EventRelation::ReplyType ||
-            (relation.value().type == EventRelation::ThreadType &&
-            (relation.value().isFallingBack == false || includeFallbacks)));
-}
-
-QString RoomMessageEvent::replyEventId(bool includeFallbacks) const
-{
-    if (const auto relation = relatesTo()) {
-        if (relation.value().type == EventRelation::ReplyType) {
-            return relation.value().eventId;
-        } else if (relation.value().type == EventRelation::ThreadType &&
-                (relation.value().isFallingBack == false || includeFallbacks)) {
-            return relation.value().inThreadReplyEventId;
-        }
-    }
-    return {};
 }
 
 bool RoomMessageEvent::isThreaded() const

--- a/Quotient/events/roommessageevent.h
+++ b/Quotient/events/roommessageevent.h
@@ -6,7 +6,6 @@
 #pragma once
 
 #include "eventcontent.h"
-#include "eventrelation.h"
 #include "roomevent.h"
 
 class QFileInfo;
@@ -94,12 +93,6 @@ public:
     //! Retrieve a thumbnail from the message event
     EventContent::Thumbnail getThumbnail() const;
 
-    //! \brief The EventRelation for this event.
-    //!
-    //! \return an EventRelation object which can be checked for type if it exists,
-    //!         std::nullopt otherwise.
-    std::optional<EventRelation> relatesTo() const;
-
     //! \brief The upstream event ID for the relation.
     //!
     //! \warning If your client is not thread aware use replyEventId() as this will
@@ -121,28 +114,6 @@ public:
     bool isReplaced() const;
 
     QString replacedBy() const;
-
-    //! \brief Determine whether the event is a reply to another message.
-    //!
-    //! \param includeFallbacks include thread fallback replies for non-threaded clients.
-    //!
-    //! \return true if this event is a reply, i.e. it has `"m.in_reply_to"`
-    //!         event ID and is not a thread fallback (except where \p includeFallbacks is true);
-    //!         false otherwise.
-    //!
-    //! \note It's possible to reply to another message in a thread so this function
-    //!       will return true for a `"rel_type"` of `"m.thread"` if `"is_falling_back"`
-    //!       is false.
-    bool isReply(bool includeFallbacks = false) const;
-
-    //! \brief The ID for the event being replied to.
-    //!
-    //! \param includeFallbacks include thread fallback replies for non-threaded clients.
-    //!
-    //!
-    //! \return The event ID for a reply, this includes threaded replies where `"rel_type"`
-    //!         is `"m.thread"` and `"is_falling_back"` is false (except where \p includeFallbacks is true).
-    QString replyEventId(bool includeFallbacks = false)const;
 
     //! \brief Determine whether the event is part of a thread.
     //!


### PR DESCRIPTION
Current matrix versions allow having replies to all room events, not just message events