### PR TITLE
Use network error message if an API error isn't available in MxcReply

### DIFF
--- a/Quotient/mxcreply.cpp
+++ b/Quotient/mxcreply.cpp
@@ -26,7 +26,14 @@ MxcReply::MxcReply(QNetworkReply* reply,
 
         if (d->m_reply->error() != NoError) {
             const QJsonDocument doc = QJsonDocument::fromJson(d->m_reply->readAll());
-            setErrorString(QStringLiteral("%1 (%2)").arg(doc["error"_L1].toString(), d->m_reply->url().toString()));
+            QString errorString;
+            if (doc.object().contains("error"_L1)) {
+                errorString = doc["error"_L1].toString();
+            } else {
+                errorString = d->m_reply->errorString();
+            }
+            setErrorString(QStringLiteral("%1 (%2)").arg(errorString,
+                                                         d->m_reply->url().toString()));
         } else if (fileMetadata.isValid()) {
             auto buffer = new QBuffer(this);
             buffer->setData(decryptFile(d->m_reply->readAll(), fileMetadata));


### PR DESCRIPTION
Sometimes you really do get normal network errors when pulling from mxc URLs. So it make it less confusing (e.g. it prints out an empty error message in a log) use the network error message as a fallback if none is provided by the API.