### PR TITLE
Remove problematic transaction in Database::setMasterKeyVerified

### DIFF
--- a/Quotient/database.cpp
+++ b/Quotient/database.cpp
@@ -629,9 +629,7 @@ void Database::setMasterKeyVerified(const QString& masterKey)
 {
     auto query = prepareQuery(u"UPDATE master_keys SET verified=true WHERE key=:key;"_s);
     query.bindValue(u":key"_s, masterKey);
-    transaction();
     execute(query);
-    commit();
 }
 
 QString Database::userSigningPublicKey()


### PR DESCRIPTION
This was causing issues inside of ConnectionEncryptionData::handleQueryKeys and how I redone the transactions. (Because handleQueryKeys starts one big transaction inside of it's function body.)

If you try to start another transaction while one is already begun, it will error out and fall back to flushing each operation to disk - that's slow, of course. This is especially relevant because the setMasterKeyVerified call happens before saveDevicesList - one of the slowest functions for us.

Fixing this is simple though, we can remove this problematic nested transaction in setMasterKeyVerified. I'm not even sure what this does in the first place, because it's only committing one UPDATE operation.