### PR TITLE
Fix dangling reference in JobHandle

### DIFF
--- a/Quotient/connectionencryptiondata_p.cpp
+++ b/Quotient/connectionencryptiondata_p.cpp
@@ -953,15 +953,11 @@ void ConnectionEncryptionData::sendSessionKeyToDevices(
     const QString& roomId, const QOlmOutboundGroupSession& outboundSession,
     const QMultiHash<QString, QString>& devices)
 {
-    const auto& sessionId = outboundSession.sessionId();
-    const auto& sessionKey = outboundSession.sessionKey();
-    const auto& index = outboundSession.sessionMessageIndex();
-
-    const auto closure = [this, roomId, sessionId, sessionKey, index, devices] {
-        doSendSessionKeyToDevices(roomId, sessionId, sessionKey, index, devices);
-    };
+    auto closure = std::bind_front(&ConnectionEncryptionData::doSendSessionKeyToDevices, this,
+                                   roomId, outboundSession.sessionId(), outboundSession.sessionKey(),
+                                   outboundSession.sessionMessageIndex(), devices);
     if (currentQueryKeysJob != nullptr) {
-        currentQueryKeysJob = currentQueryKeysJob.onResult(q, closure);
+        currentQueryKeysJob = currentQueryKeysJob.onResult(q, std::move(closure));
     } else
         closure();
 }

--- a/Quotient/jobs/jobhandle.h
+++ b/Quotient/jobs/jobhandle.h
@@ -213,6 +213,7 @@ public:
 private:
     //! A function object that can be passed to QFuture::then and QFuture::onCanceled
     template <typename FnT>
+        requires (!std::is_reference_v<FnT>)
     struct BoundFn {
         auto operator()() { return callFn<false>(nullptr); } // For QFuture::onCanceled
         auto operator()(future_value_type job) { return callFn(job); } // For QFuture::then
@@ -247,6 +248,9 @@ private:
 
     template <typename FnT>
     BoundFn(FnT&&) -> BoundFn<FnT>;
+
+    template <typename FnT>
+    BoundFn(const FnT &) -> BoundFn<FnT>;
 
     template <typename FnT, typename ConfigT = Skip>
     static auto bindToContext(FnT&& fn, ConfigT config = {})


### PR DESCRIPTION
The actual fix is in the second commit; the first commit is sufficient as a workaround in the stable branch though.

Fixes #910.