### PR TITLE
Fix dangling reference in JobHandle - 0.9

### DIFF
--- a/Quotient/connectionencryptiondata_p.cpp
+++ b/Quotient/connectionencryptiondata_p.cpp
@@ -955,15 +955,11 @@ void ConnectionEncryptionData::sendSessionKeyToDevices(
     const QString& roomId, const QOlmOutboundGroupSession& outboundSession,
     const QMultiHash<QString, QString>& devices)
 {
-    const auto& sessionId = outboundSession.sessionId();
-    const auto& sessionKey = outboundSession.sessionKey();
-    const auto& index = outboundSession.sessionMessageIndex();
-
-    const auto closure = [this, roomId, sessionId, sessionKey, index, devices] {
-        doSendSessionKeyToDevices(roomId, sessionId, sessionKey, index, devices);
-    };
+    auto closure = std::bind_front(&ConnectionEncryptionData::doSendSessionKeyToDevices, this,
+                                   roomId, outboundSession.sessionId(), outboundSession.sessionKey(),
+                                   outboundSession.sessionMessageIndex(), devices);
     if (currentQueryKeysJob != nullptr) {
-        currentQueryKeysJob = currentQueryKeysJob.onResult(q, closure);
+        currentQueryKeysJob = currentQueryKeysJob.onResult(q, std::move(closure));
     } else
         closure();
 }

--- a/Quotient/jobs/jobhandle.h
+++ b/Quotient/jobs/jobhandle.h
@@ -209,6 +209,7 @@ public:
 private:
     //! A function object that can be passed to QFuture::then and QFuture::onCanceled
     template <typename FnT>
+        requires (!std::is_reference_v<FnT>)
     struct BoundFn {
         auto operator()() { return callFn<false>(nullptr); } // For QFuture::onCanceled
         auto operator()(future_value_type job) { return callFn(job); } // For QFuture::then
@@ -243,6 +244,9 @@ private:
 
     template <typename FnT>
     BoundFn(FnT&&) -> BoundFn<FnT>;
+
+    template <typename FnT>
+    BoundFn(const FnT &) -> BoundFn<FnT>;
 
     template <typename FnT, typename ConfigT = Skip>
     static auto bindToContext(FnT&& fn, ConfigT config = {})


### PR DESCRIPTION
Although formally the second commit changes the API so you have to rebuild anything that uses the library, the alternative is to make sure client code doesn't use lvalue closures. In the best case it's a noop in both approaches, in the worst case it's either rebuilding or changing the client code; the former is less disruptive.