### PR TITLE
Support listening to and ignoring SSL errors for MxcReply

### DIFF
--- a/Quotient/mxcreply.cpp
+++ b/Quotient/mxcreply.cpp
@@ -43,6 +43,7 @@ MxcReply::MxcReply(QNetworkReply* reply,
         setOpenMode(ReadOnly);
         emit finished();
     });
+    connect(d->m_reply, &QNetworkReply::sslErrors, this, &MxcReply::sslErrors);
 }
 
 MxcReply::MxcReply()
@@ -67,6 +68,11 @@ qint64 MxcReply::readData(char *data, qint64 maxlen)
         return d->m_device->read(data, maxlen);
     }
     return -1;
+}
+
+void MxcReply::ignoreSslErrorsImplementation(const QList<QSslError> &ssl_errors)
+{
+    d->m_reply->ignoreSslErrors(ssl_errors);
 }
 
 void MxcReply::abort()

--- a/Quotient/mxcreply.h
+++ b/Quotient/mxcreply.h
@@ -25,6 +25,7 @@ public Q_SLOTS:
 
 protected:
     qint64 readData(char* data, qint64 maxlen) override;
+    void ignoreSslErrorsImplementation(const QList<QSslError> &) override;
 
 private:
     class Private;


### PR DESCRIPTION
Because of the odd reply-in-reply business happening with how mxc URIs work, it's not possible for an application - say, NeoChat's tests - to unilaterally get SSL errors and ignore them. This wasn't a problem for non-MXC URIs because they don't use MxcReply.