### PR TITLE
Unstable event types

### DIFF
--- a/Quotient/connection.h
+++ b/Quotient/connection.h
@@ -180,8 +180,10 @@ public:
     template <EventClass EventT>
     const EventT* accountData() const
     {
-        // 0.9: use the default argument and fold into the next overload
-        return eventCast<EventT>(accountData(EventT::TypeId));
+        for (auto typeId : EventT::MetaType.matrixIds)
+            if (const auto &evtPtr = accountData(typeId))
+                return eventCast<EventT>(evtPtr);
+        return nullptr;
     }
 
     template <EventClass EventT>

--- a/Quotient/events/callevents.h
+++ b/Quotient/events/callevents.h
@@ -9,7 +9,7 @@ namespace Quotient {
 
 class QUOTIENT_API CallEvent : public RoomEvent {
 public:
-    QUO_BASE_EVENT(CallEvent, RoomEvent, "m.call.*")
+    QUO_BASE_EVENT(CallEvent, RoomEvent)
 
     QUO_CONTENT_GETTER(QString, callId)
     QUO_CONTENT_GETTER(int, version)

--- a/Quotient/events/event.cpp
+++ b/Quotient/events/event.cpp
@@ -60,22 +60,22 @@ AbstractEventMetaType::AbstractEventMetaType(const std::type_info &typeInfo, con
 {
     QUO_CHECK(!matrixIds.front().isEmpty());
     if (nearestBase) {
-        if (const auto overlap =
+        if (const auto [priorMetaType, overlappingId] =
                 findFirstOverlap(nearestBase->derivedTypes(),
                                  filter_view(matrixIds, std::not_fn(&QLatin1String::isEmpty)));
-            overlap.first) {
-            if (QUO_ALARM_X(overlap.first == this, "Attempt to re-register the same event class"))
+            priorMetaType) {
+            if (QUO_ALARM_X(priorMetaType == this, "Attempt to re-register the same event class"))
                 return; // This is kinda fine but extremely fishy
 
             // Two different metatype objects claim the same Matrix type id; this
             // is not normal, so give as much information as possible to diagnose
-            if (QUO_ALARM_X(overlap.first->typeInfo == typeInfo,
-                            QLatin1StringView(className) % " claims '"_L1 % overlap.second
+            if (QUO_ALARM_X(priorMetaType->typeInfo == typeInfo,
+                            QLatin1StringView(className) % " claims '"_L1 % overlappingId
                                 % "' repeatedly; check that the C++ symbol is properly exported"_L1))
                 return; // That situation is very wrong (see #413) so maybe std::terminate() even?
 
-            qWarning(EVENTS).nospace() << overlap.second << " is already mapped to "
-                                       << overlap.first->className << " before " << className
+            qWarning(EVENTS).nospace() << overlappingId << " is already mapped to "
+                                       << priorMetaType->className << " before " << className
                                        << "; unless the two have different isValid() conditions, "
                                           "the latter class will never be used";
         }

--- a/Quotient/events/event.cpp
+++ b/Quotient/events/event.cpp
@@ -10,35 +10,52 @@
 
 using namespace Quotient;
 
+namespace {
+std::pair<const AbstractEventMetaType *, event_type_t> findFirstOverlap(
+    std::span<const AbstractEventMetaType *const> metaTypes,
+    std::span<event_type_t const> matrixTypeIds)
+{
+    using namespace std::ranges;
+    for (const auto *metaType : metaTypes)
+        if (const auto overlappingIdIt = find_first_of(matrixTypeIds, metaType->matrixIds);
+            overlappingIdIt != end(matrixTypeIds))
+            return {metaType, *overlappingIdIt};
+    return {};
+}
+}
+
 AbstractEventMetaType::AbstractEventMetaType(const std::type_info &typeInfo, const char *className,
                                              AbstractEventMetaType *nearestBase,
-                                             event_type_t matrixId)
-    : typeInfo(typeInfo), className(className), baseType(nearestBase), matrixId(matrixId)
+                                             std::vector<event_type_t> matrixTypeIds)
+    : typeInfo(typeInfo)
+    , className(className)
+    , baseType(nearestBase)
+    , matrixIds(std::move(matrixTypeIds))
 {
     if (nearestBase) {
-        if (const auto existing = std::ranges::find(nearestBase->derivedTypes(), matrixId,
-                                                    &AbstractEventMetaType::matrixId);
-            existing != nearestBase->derivedTypes().end()) // macOS still has no std::span::cend()
+        if (const auto overlap = findFirstOverlap(nearestBase->derivedTypes(), matrixIds);
+            overlap.first)
         {
-            if (QUO_ALARM_X(*existing == this, "Attempt to re-register the same event class"))
+            if (QUO_ALARM_X(overlap.first == this, "Attempt to re-register the same event class"))
                 return; // This is kinda fine but extremely fishy
 
             // Two different metatype objects claim the same Matrix type id; this
             // is not normal, so give as much information as possible to diagnose
-            if (QUO_ALARM_X((*existing)->typeInfo == typeInfo,
-                            QLatin1StringView(className) % " claims '"_L1 % matrixId
+            if (QUO_ALARM_X(overlap.first->typeInfo == typeInfo,
+                            QLatin1StringView(className) % " claims '"_L1 % overlap.second
                                 % "' repeatedly; check that the C++ symbol is properly exported"_L1))
                 return; // That situation is very wrong (see #413) so maybe std::terminate() even?
 
-            qWarning(EVENTS).nospace() << matrixId << " is already mapped to "
-                                       << (*existing)->className << " before " << className
+            qWarning(EVENTS).nospace() << overlap.second << " is already mapped to "
+                                       << overlap.first->className << " before " << className
                                        << "; unless the two have different isValid() conditions, "
                                           "the latter class will never be used";
         }
         nearestBase->_derivedTypes.emplace_back(this);
-        qDebug(EVENTS).nospace() << matrixId << " -> " << className << "; "
-                                 << nearestBase->_derivedTypes.size()
-                                 << " derived type(s) registered for " << nearestBase->className;
+        qDebug(EVENTS).nospace().noquote()
+            << std::format("{:n:s}", matrixIds) << " -> " << className << "; "
+            << nearestBase->_derivedTypes.size() << " derived type(s) registered for "
+            << nearestBase->className;
     }
 }
 

--- a/Quotient/events/event.cpp
+++ b/Quotient/events/event.cpp
@@ -8,14 +8,15 @@
 #include <QtCore/QJsonDocument>
 #include <QtCore/QStringBuilder>
 
+#include <ranges>
+
 using namespace Quotient;
+using namespace std::ranges;
 
 namespace {
 std::pair<const AbstractEventMetaType *, event_type_t> findFirstOverlap(
-    std::span<const AbstractEventMetaType *const> metaTypes,
-    std::span<event_type_t const> matrixTypeIds)
+    std::span<const AbstractEventMetaType *const> metaTypes, range auto matrixTypeIds)
 {
-    using namespace std::ranges;
     for (const auto *metaType : metaTypes)
         if (const auto overlappingIdIt = find_first_of(matrixTypeIds, metaType->matrixIds);
             overlappingIdIt != end(matrixTypeIds))
@@ -25,17 +26,44 @@ std::pair<const AbstractEventMetaType *, event_type_t> findFirstOverlap(
 }
 
 AbstractEventMetaType::AbstractEventMetaType(const std::type_info &typeInfo, const char *className,
+                                             AbstractEventMetaType *nearestBase)
+    : typeInfo(typeInfo), className(className), baseType(nearestBase)
+{
+    auto dbg = qDebug(EVENTS).nospace();
+    dbg << "New base event class " << className;
+    if (nearestBase) {
+        // We can't check attempts to use the same Matrix type ids here but we can check attempts
+        // to use the same className at least
+        if (const auto existing =
+                find(nearestBase->derivedTypes(), className, &AbstractEventMetaType::className);
+            existing != cend(nearestBase->derivedTypes())) {
+            QUO_ALARM_X(*existing == this, "Attempt to re-register the same event class");
+            QUO_ALARM_X(true, std::format("Attempt to register distinct classes with the same name "
+                                          "{:s}; check that the C++ symbol is properly exported",
+                                          className));
+            return;
+        }
+        nearestBase->_derivedTypes.emplace_back(this);
+        dbg << ", derived from " << nearestBase->className << "; "
+            << nearestBase->_derivedTypes.size() << " type(s) derived from "
+            << nearestBase->className;
+    }
+}
+
+AbstractEventMetaType::AbstractEventMetaType(const std::type_info &typeInfo, const char *className,
                                              AbstractEventMetaType *nearestBase,
-                                             std::vector<event_type_t> matrixTypeIds)
+                                             TypeIds matrixTypeIds)
     : typeInfo(typeInfo)
     , className(className)
     , baseType(nearestBase)
     , matrixIds(std::move(matrixTypeIds))
 {
+    QUO_CHECK(!matrixIds.front().isEmpty());
     if (nearestBase) {
-        if (const auto overlap = findFirstOverlap(nearestBase->derivedTypes(), matrixIds);
-            overlap.first)
-        {
+        if (const auto overlap =
+                findFirstOverlap(nearestBase->derivedTypes(),
+                                 filter_view(matrixIds, std::not_fn(&QLatin1String::isEmpty)));
+            overlap.first) {
             if (QUO_ALARM_X(overlap.first == this, "Attempt to re-register the same event class"))
                 return; // This is kinda fine but extremely fishy
 
@@ -52,11 +80,13 @@ AbstractEventMetaType::AbstractEventMetaType(const std::type_info &typeInfo, con
                                           "the latter class will never be used";
         }
         nearestBase->_derivedTypes.emplace_back(this);
-        qDebug(EVENTS).nospace().noquote()
-            << std::format("{:n:s}", matrixIds) << " -> " << className << "; "
-            << nearestBase->_derivedTypes.size() << " derived type(s) registered for "
-            << nearestBase->className;
     }
+    auto dbg = qDebug(EVENTS).nospace();
+    dbg << matrixIds.front();
+    if (!matrixIds.back().isEmpty())
+        dbg << ", " << matrixIds.back();
+    dbg << " -> " << className << "; " << nearestBase->_derivedTypes.size()
+        << " type(s) derived from " << nearestBase->className;
 }
 
 Event::Event(const QJsonObject& json) : _json(json) {}

--- a/Quotient/events/event.h
+++ b/Quotient/events/event.h
@@ -41,12 +41,14 @@ bool is(const Event& e);
 //! a whole new kind of event metatypes.
 class QUOTIENT_API AbstractEventMetaType {
 public:
+    using TypeIds = std::array<event_type_t, 2>;
+
     // The public fields here are const and are not to be changeable anyway.
     // NOLINTBEGIN(misc-non-private-member-variables-in-classes)
     const std::type_info &typeInfo;
     const char *const className;
     const AbstractEventMetaType *const baseType;
-    const std::vector<event_type_t> matrixIds;
+    const TypeIds matrixIds{};
     // NOLINTEND(misc-non-private-member-variables-in-classes)
 
     auto derivedTypes() const { return std::span(_derivedTypes); }
@@ -63,9 +65,11 @@ protected:
     template <class EventT>
     friend class EventMetaType;
 
-    explicit AbstractEventMetaType(const std::type_info &typeInfo, const char *className,
-                                   AbstractEventMetaType *nearestBase,
-                                   std::vector<event_type_t> matrixTypeIds);
+    AbstractEventMetaType(const std::type_info &typeInfo, const char *className,
+                          AbstractEventMetaType *nearestBase);
+
+    AbstractEventMetaType(const std::type_info &typeInfo, const char *className,
+                                   AbstractEventMetaType *nearestBase, TypeIds matrixTypeIds);
 
     // The returned value indicates whether a generic object has to be created
     // on the top level when `event` is empty, instead of returning nullptr
@@ -92,13 +96,20 @@ class QUOTIENT_API EventMetaType : public AbstractEventMetaType {
     // Above: can't constrain EventT to be EventClass because it's incomplete
     // at the point of EventMetaType<EventT> instantiation (see QUO_BASE_EVENT and QUO_EVENT)
 public:
-    template <std::same_as<const char *>... TypeIdTs>
-    explicit EventMetaType(AbstractEventMetaType *nearestBase = nullptr, TypeIdTs... matrixTypeIds)
-        requires (sizeof...(TypeIdTs) <= 2)
+    //! Construct an event metatype class for a base event type
+    explicit EventMetaType(AbstractEventMetaType *nearestBase = nullptr)
         // NB: typeid(T&) == typeid(T) but typeid(T&) can be used with an incomplete type
         // NB2: it would be lovely to "just" use QMetaType::fromType<> instead of QtPrivate API
         //      but QMetaType tries to instantiate constructor wrappers and it's not possible while
         //      the type is incomplete
+        : AbstractEventMetaType(typeid(EventT &), QtPrivate::QMetaTypeForType<EventT>().getName(),
+                                nearestBase)
+    {}
+
+    //! Construct an event metatype class for an event type that can be loaded from \p TypeIdTs
+    template <std::same_as<const char *>... TypeIdTs>
+    explicit EventMetaType(AbstractEventMetaType *nearestBase, TypeIdTs... matrixTypeIds)
+        requires (sizeof...(TypeIdTs) > 0 && sizeof...(TypeIdTs) <= 2)
         : AbstractEventMetaType(typeid(EventT &), QtPrivate::QMetaTypeForType<EventT>().getName(),
                                 nearestBase, {event_type_t(matrixTypeIds)...})
     {}
@@ -410,8 +421,8 @@ public:
 //! initialised by parameters passed to the macro, and a metaType() override
 //! pointing to that BaseMetaType.
 //! \sa EventMetaType
-#define QUO_BASE_EVENT(CppType_, BaseCppType_, ...) \
-    QUO_EVENT_IMPL(BaseMetaType, CppType_, &BaseCppType_::BaseMetaType __VA_OPT__(, ) __VA_ARGS__)
+#define QUO_BASE_EVENT(CppType_, BaseCppType_) \
+    QUO_EVENT_IMPL(BaseMetaType, CppType_, &BaseCppType_::BaseMetaType)
 
 //! A helper macro to pass two event type identifiers to QUO_EVENT and QUO_DEFINE_SIMPLE_EVENT
 #define QUO_LIST(...) __VA_ARGS__

--- a/Quotient/events/event.h
+++ b/Quotient/events/event.h
@@ -46,7 +46,7 @@ public:
     const std::type_info &typeInfo;
     const char *const className;
     const AbstractEventMetaType *const baseType;
-    const event_type_t matrixId;
+    const std::vector<event_type_t> matrixIds;
     // NOLINTEND(misc-non-private-member-variables-in-classes)
 
     auto derivedTypes() const { return std::span(_derivedTypes); }
@@ -64,8 +64,8 @@ protected:
     friend class EventMetaType;
 
     explicit AbstractEventMetaType(const std::type_info &typeInfo, const char *className,
-                                   AbstractEventMetaType *nearestBase = nullptr,
-                                   event_type_t matrixId = nullptr);
+                                   AbstractEventMetaType *nearestBase,
+                                   std::vector<event_type_t> matrixTypeIds);
 
     // The returned value indicates whether a generic object has to be created
     // on the top level when `event` is empty, instead of returning nullptr
@@ -92,14 +92,15 @@ class QUOTIENT_API EventMetaType : public AbstractEventMetaType {
     // Above: can't constrain EventT to be EventClass because it's incomplete
     // at the point of EventMetaType<EventT> instantiation (see QUO_BASE_EVENT and QUO_EVENT)
 public:
-    explicit EventMetaType(AbstractEventMetaType *nearestBase = nullptr,
-                           const char* matrixTypeId = {})
+    template <std::same_as<const char *>... TypeIdTs>
+    explicit EventMetaType(AbstractEventMetaType *nearestBase = nullptr, TypeIdTs... matrixTypeIds)
+        requires (sizeof...(TypeIdTs) <= 2)
         // NB: typeid(T&) == typeid(T) but typeid(T&) can be used with an incomplete type
         // NB2: it would be lovely to "just" use QMetaType::fromType<> instead of QtPrivate API
         //      but QMetaType tries to instantiate constructor wrappers and it's not possible while
         //      the type is incomplete
         : AbstractEventMetaType(typeid(EventT &), QtPrivate::QMetaTypeForType<EventT>().getName(),
-                                nearestBase, event_type_t(matrixTypeId))
+                                nearestBase, {event_type_t(matrixTypeIds)...})
     {}
 
     //! \brief Try to load an event from JSON, with dynamic type resolution
@@ -107,9 +108,9 @@ public:
     //! The generic logic defined in this class template and invoked applies to
     //! all event types defined in the library and boils down to the following:
     //! 1.
-    //!    a. If EventT has TypeId defined (which normally is a case of
-    //!       all leaf - specific - event types, via QUO_EVENT macro) and
-    //!       \p type doesn't exactly match it, nullptr is immediately returned.
+    //!    a. If EventT has TypeId defined (which normally is a case of all leaf - specific -
+    //!       event types, via QUO_EVENT macro) and \p type doesn't exactly match any of matrixIds,
+    //!       nullptr is immediately returned.
     //!    b. In absence of TypeId, an event type is assumed to be a base;
     //!       its derivedTypes are examined, and this algorithm is applied
     //!       recursively on each.
@@ -120,8 +121,8 @@ public:
     //!    of `state_key` is checked in any type derived from StateEvent.
     //! 3. If step 1b above returned non-nullptr, immediately return it.
     //! 4.
-    //!    a. If EventT::isValid() or EventT::TypeId (either, or both) exist and
-    //!       are satisfied (see steps 1a and 2 above), an object of this type
+    //!    a. If EventT::isValid() or EventT::TypeId (either, or both) exist and validations in
+    //!       steps 1a and 2 have been either skipped or satisfied, an object of this type
     //!       is created from the passed JSON and returned. In case of a base
     //!       event type, this will be a generic (aka "unknown") event.
     //!    b. If neither exists, a generic event is only created and returned
@@ -147,7 +148,7 @@ private:
                     Event*& event) const override
     {
         if constexpr (requires { EventT::TypeId; }) {
-            if (EventT::TypeId != type)
+            if (std::ranges::find(matrixIds, type) == std::ranges::end(matrixIds))
                 return false;
         } else {
             for (const auto& p : _derivedTypes) {
@@ -392,6 +393,14 @@ public:
     ContentT content() const { return fromJson<ContentT>(this->contentJson()); }
 };
 
+#define QUO_EVENT_IMPL(StaticVarName_, CppType_, ...)                                 \
+    friend class EventMetaType<CppType_>;                                             \
+    static inline auto StaticVarName_ = EventMetaType<CppType_>(__VA_ARGS__);         \
+    static_assert(&CppType_::StaticVarName_ == &StaticVarName_,                       \
+                  #CppType_ " is wrong here - check for copy-pasta");                 \
+    const AbstractEventMetaType &metaType() const override { return StaticVarName_; } \
+    // End of macro
+
 //! \brief Supply event metatype information in base event types
 //!
 //! Use this macro in a public section of your base event class to provide
@@ -401,14 +410,11 @@ public:
 //! initialised by parameters passed to the macro, and a metaType() override
 //! pointing to that BaseMetaType.
 //! \sa EventMetaType
-#define QUO_BASE_EVENT(CppType_, BaseCppType_, ...)                                      \
-    friend class EventMetaType<CppType_>;                                                \
-    static inline auto BaseMetaType =                                                    \
-        EventMetaType<CppType_>(&BaseCppType_::BaseMetaType __VA_OPT__(, ) __VA_ARGS__); \
-    static_assert(&CppType_::BaseMetaType == &BaseMetaType,                              \
-                  #CppType_ " is wrong here - check for copy-pasta");                    \
-    const AbstractEventMetaType &metaType() const override { return BaseMetaType; }      \
-    // End of macro
+#define QUO_BASE_EVENT(CppType_, BaseCppType_, ...) \
+    QUO_EVENT_IMPL(BaseMetaType, CppType_, &BaseCppType_::BaseMetaType __VA_OPT__(, ) __VA_ARGS__)
+
+//! A helper macro to pass two event type identifiers to QUO_EVENT and QUO_DEFINE_SIMPLE_EVENT
+#define QUO_LIST(...) __VA_ARGS__
 
 //! \brief Supply event metatype information in (specific) event types
 //!
@@ -417,21 +423,26 @@ public:
 //! Do _not_ use this macro if your class is an intermediate wrapper and is not
 //! supposed to be instantiated on its own. Provides MetaType static field
 //! initialised as described below; a metaType() override pointing to it; and
-//! the TypeId static field that is equal to MetaType.matrixId.
+//! the TypeId static field that is equal to MetaType.matrixIds[0].
 //!
-//! The first two macro parameters are used as the first two EventMetaType
-//! constructor parameters; the third EventMetaType parameter is always
-//! BaseMetaType; and additional base types can be passed in extra macro
-//! parameters if you need to include the same event type in more than one
-//! event factory hierarchy (e.g., EncryptedEvent).
-//! \sa EventMetaType
-#define QUO_EVENT(CppType_, MatrixType_)                                                     \
-    friend class EventMetaType<CppType_>;                                                    \
-    static inline const auto MetaType = EventMetaType<CppType_>(&BaseMetaType, MatrixType_); \
-    static_assert(&CppType_::MetaType == &MetaType,                                          \
-                  #CppType_ " is wrong here - check for copy-pasta");                        \
-    static inline const auto &TypeId = MetaType.matrixId;                                    \
-    const AbstractEventMetaType &metaType() const override { return MetaType; }              \
+//! There are cases when the underlying Matrix event type has two type ids, namely when the type
+//! is being proposed for the specification (i.e. there's an MSC for it) or has just been merged
+//! into the spec. In such situations it is often desirable to recognise both the canonical
+//! ("m.example_event") and the unstable (i.e., "org.matrix.mscXXXX.example_event") types but only
+//! send events with the unstable (while the MSC is in flight) or, later, stable (when it is
+//! accepted) types. If you use QUO_LIST to pass two event type ids instead of one, e.g.
+//! `QUO_EVENT(ExampleEvent, QUO_LIST("org.matrix.mscXXXX.example_event", "m.example_event"))`, then
+//! only the first type will be used both to load the event from JSON and create a new instance of
+//! the event, the second type will only be used to detect the event in JSON but you cannot create
+//! new class instances using this type. Once the MSC is accepted, simply switch the two type ids
+//! around and rebuild the code that creates or loads events of this type.
+//! \note QUO_LIST is used here instead of making QUO_EVENT a variadic macro to provide an extra
+//!       safeguard, but also to use the same syntax in cases when the type id is not the last
+//!       parameter, e.g. for DEFINE_SIMPLE_EVENT
+//! \sa Quotient::EventMetaType, QUO_LIST
+#define QUO_EVENT(CppType_, MatrixTypeOrTypeList_)                           \
+    QUO_EVENT_IMPL(MetaType, CppType_, &BaseMetaType, MatrixTypeOrTypeList_) \
+    static inline const auto &TypeId = MetaType.matrixIds[0];                \
     // End of macro
 
 #define QUO_CONTENT_GETTER_X(PartType_, PartName_, JsonKey_) \
@@ -452,26 +463,31 @@ public:
 #define QUO_CONTENT_GETTER(PartType_, PartName_) \
     QUO_CONTENT_GETTER_X(PartType_, PartName_, toSnakeCase(#PartName_##_L1))
 
-/// \brief Define a new event class with a single key-value pair in the content
-///
-/// This macro defines a new event class \p Name_ derived from \p Base_,
-/// with Matrix event type \p TypeId_, providing a getter named \p GetterName_
-/// for a single value of type \p ValueType_ inside the event content.
-/// To retrieve the value the getter uses a JSON key name that corresponds to
-/// its own (getter's) name but written in snake_case. \p GetterName_ must be
-/// in camelCase, no quotes (an identifier, not a literal).
-#define DEFINE_SIMPLE_EVENT(Name_, Base_, TypeId_, ValueType_, GetterName_, JsonKey_)      \
-    constexpr inline auto Name_##ContentKey = JsonKey_##_L1;                               \
-    class QUOTIENT_API Name_                                                               \
-        : public ::Quotient::EventTemplate<                                                \
-              Name_, Base_, EventContent::SingleKeyValue<ValueType_, Name_##ContentKey>> { \
-    public:                                                                                \
-        QUO_EVENT(Name_, TypeId_)                                                          \
-        using value_type = ValueType_;                                                     \
-        using EventTemplate::EventTemplate;                                                \
-        QUO_CONTENT_GETTER_X(ValueType_, GetterName_, Name_##ContentKey)                   \
-    };                                                                                     \
+//! \brief Define a new event class with a single key-value pair in the content
+//!
+//! This macro defines a new event class \p Name_ derived from \p Base_, with Matrix event type
+//! \p TypeId_, providing a getter named \p GetterName_ for a single value of type \p ValueType_
+//! stored under \p JsonKey_ inside the event content.
+//!
+//! \p TypeId_ can be a QUO_LIST() with two event types, the same way it works with QUO_EVENT.
+//! \sa QUO_LIST, QUO_EVENT
+#define QUO_DEFINE_SIMPLE_EVENT(Name_, Base_, TypeId_, ValueType_, GetterName_, JsonKey_) \
+    constexpr inline auto Name_##ContentKey = QLatin1String(JsonKey_);                    \
+    class QUOTIENT_API Name_                                                              \
+        : public ::Quotient::EventTemplate<                                               \
+              Name_, Base_, EventContent::SingleKeyValue<ValueType_, Name_##ContentKey>>  \
+    {                                                                                     \
+    public:                                                                               \
+        QUO_EVENT(Name_, QUO_LIST(TypeId_))                                               \
+        using value_type = ValueType_;                                                    \
+        using EventTemplate::EventTemplate;                                               \
+        QUO_CONTENT_GETTER_X(ValueType_, GetterName_, Name_##ContentKey)                  \
+    };                                                                                    \
     // End of macro
+
+//! \deprecated Use QUO_DEFINE_SIMPLE_EVENT instead
+#define DEFINE_SIMPLE_EVENT(Name_, Base_, TypeId_, ValueType_, GetterName_, JsonKey_) \
+    QUO_DEFINE_SIMPLE_EVENT(Name_, Base_, QUO_LIST(TypeId_), ValueType_, GetterName_, JsonKey_)
 
 // === is<>(), eventCast<>() and switchOnType<>() ===
 

--- a/Quotient/events/keyverificationevent.h
+++ b/Quotient/events/keyverificationevent.h
@@ -15,7 +15,7 @@ constexpr inline auto SasV1Method = "m.sas.v1"_L1;
 // event room-specific attributes will be empty.
 class QUOTIENT_API KeyVerificationEvent : public RoomEvent {
 public:
-    QUO_BASE_EVENT(KeyVerificationEvent, RoomEvent, "m.key.*")
+    QUO_BASE_EVENT(KeyVerificationEvent, RoomEvent)
 
     using RoomEvent::RoomEvent;
 

--- a/Quotient/events/roomevent.cpp
+++ b/Quotient/events/roomevent.cpp
@@ -103,10 +103,11 @@ const QJsonObject RoomEvent::encryptedJson() const
 }
 
 namespace {
-bool containsEventType(const auto& haystack, const auto& needle)
+bool containsEventType(std::span<const AbstractEventMetaType *const> haystack, const QString &needle)
 {
-    return std::ranges::any_of(haystack, [needle](const AbstractEventMetaType* candidate) {
-        return candidate->matrixId == needle || containsEventType(candidate->derivedTypes(), needle);
+    return std::ranges::any_of(haystack, [needle](const AbstractEventMetaType *candidate) {
+        return std::ranges::contains(candidate->matrixIds, needle)
+               || containsEventType(candidate->derivedTypes(), needle);
     });
 }
 }

--- a/Quotient/events/roomevent.cpp
+++ b/Quotient/events/roomevent.cpp
@@ -6,8 +6,8 @@
 #include "encryptedevent.h"
 #include "redactionevent.h"
 #include "stateevent.h"
-
 #include "../logging_categories_p.h"
+#include "../ranges_extras.h"
 
 using namespace Quotient;
 
@@ -106,7 +106,7 @@ namespace {
 bool containsEventType(std::span<const AbstractEventMetaType *const> haystack, const QString &needle)
 {
     return std::ranges::any_of(haystack, [needle](const AbstractEventMetaType *candidate) {
-        return std::ranges::contains(candidate->matrixIds, needle)
+        return rangeContains(candidate->matrixIds, needle)
                || containsEventType(candidate->derivedTypes(), needle);
     });
 }

--- a/Quotient/events/stateevent.h
+++ b/Quotient/events/stateevent.h
@@ -11,7 +11,7 @@ constexpr inline auto PrevContentKey = "prev_content"_L1;
 
 class QUOTIENT_API StateEvent : public RoomEvent {
 public:
-    QUO_BASE_EVENT(StateEvent, RoomEvent, "json.contains('state_key')")
+    QUO_BASE_EVENT(StateEvent, RoomEvent)
 
     static bool isValid(const QJsonObject& fullJson)
     {

--- a/Quotient/keyverificationsession.cpp
+++ b/Quotient/keyverificationsession.cpp
@@ -719,7 +719,7 @@ void KeyVerificationSession::sendEvent(const QString &userId, const QString &dev
     if (m_room) {
         auto json = event.contentJson();
         json.remove("transaction_id"_L1);
-        if (event.metaType().matrixId == KeyVerificationRequestEvent::TypeId) {
+        if (event.is<KeyVerificationRequestEvent>()) {
             json["msgtype"_L1] = event.matrixType();
             json["body"_L1] = m_connection->userId() + " sent a verification request"_L1;
             json["to"_L1] = m_remoteUserId;

--- a/Quotient/ranges_extras.h
+++ b/Quotient/ranges_extras.h
@@ -85,7 +85,8 @@ template <template <typename> class TargetT, typename SourceT>
 #ifdef __cpp_lib_ranges_contains
 constexpr inline auto rangeContains = std::ranges::contains;
 #else
-[[nodiscard]] constexpr inline auto rangeContains(const auto& c, const auto& v, auto proj)
+template <typename ProjT = std::identity>
+[[nodiscard]] constexpr inline auto rangeContains(const auto& c, const auto& v, ProjT proj = {})
 {
     return std::ranges::find(c, v, std::move(proj)) != std::ranges::end(c);
 }

--- a/Quotient/roomstateview.h
+++ b/Quotient/roomstateview.h
@@ -50,11 +50,11 @@ public:
     template <Keyed_State_Event EvT>
     const EvT* get(const QString& stateKey = {}) const
     {
-        if (const auto* evt = get(EvT::TypeId, stateKey)) {
-            Q_ASSERT(evt->matrixType() == EvT::TypeId
-                     && evt->stateKey() == stateKey);
-            return eventCast<const EvT>(evt);
-        }
+        for (auto typeId : EvT::MetaType.matrixIds)
+            if (const auto *evt = get(typeId, stateKey)) {
+                Q_ASSERT(evt->matrixType() == typeId && evt->stateKey() == stateKey);
+                return eventCast<const EvT>(evt);
+            }
         return nullptr;
     }
 
@@ -66,10 +66,11 @@ public:
     template <Keyless_State_Event EvT>
     const EvT* get() const
     {
-        if (const auto* evt = get(EvT::TypeId)) {
-            Q_ASSERT(evt->matrixType() == EvT::TypeId);
-            return eventCast<const EvT>(evt);
-        }
+        for (auto typeId : EvT::MetaType.matrixIds)
+            if (const auto *evt = get(typeId)) {
+                Q_ASSERT(evt->matrixType() == typeId);
+                return eventCast<const EvT>(evt);
+            }
         return nullptr;
     }
 
@@ -80,20 +81,23 @@ public:
     template <Keyed_State_Event EvT>
     bool contains(const QString& stateKey = {}) const
     {
-        return contains(EvT::TypeId, stateKey);
+        return std::ranges::any_of(EvT::MetaType.matrixIds, [this, &stateKey](event_type_t typeId) {
+            return contains(typeId, stateKey);
+        });
     }
 
     template <Keyless_State_Event EvT>
     bool contains() const
     {
-        return contains(EvT::TypeId);
+        return std::ranges::any_of(EvT::MetaType.matrixIds,
+                                   [this](event_type_t typeId) { return contains(typeId); });
     }
 
     template <Keyed_State_Event EvT>
     auto content(const QString& stateKey,
                  typename EvT::content_type defaultValue = {}) const
     {
-        // EventBase<>::content is special in that it returns a const-ref,
+        // EventTemplate<>::content for StateEvent is special in that it returns a const-ref,
         // and lift() inside queryOr() can't wrap that in a temporary optional.
         if (const auto evt = get<EvT>(stateKey))
             return evt->content();

--- a/quotest/quotest.cpp
+++ b/quotest/quotest.cpp
@@ -100,6 +100,7 @@ private slots:
     TEST_DECL(sendMessage)
     TEST_DECL(sendReaction)
     TEST_DECL(sendFile)
+    TEST_DECL(loadCustomEvent)
     TEST_DECL(sendCustomEvent)
     TEST_DECL(setTopic)
     TEST_DECL(redactEvent)
@@ -564,8 +565,19 @@ bool TestSuite::checkFileSendingOutcome(const TestToken& thisTest,
     return true;
 }
 
-DEFINE_SIMPLE_EVENT(CustomEvent, RoomEvent, "quotest.custom", int, testValue,
-                    "test_value")
+QUO_DEFINE_SIMPLE_EVENT(CustomEvent, RoomEvent,
+                        QUO_LIST("quotest.custom.unstable", "quotest.custom"), int, testValue,
+                        "test_value")
+
+TEST_IMPL(loadCustomEvent)
+{
+    // TODO: Make a unit test for event.*
+    FAIL_TEST_IF(CustomEvent::MetaType.matrixIds.size() != 2);
+    auto testEvent = loadEvent<RoomEvent>(CustomEvent::MetaType.matrixIds[1],
+                                          QJsonObject{{"test_value"_L1, 17}});
+    FINISH_TEST(testEvent && testEvent->is<CustomEvent>()
+                && eventCast<CustomEvent>(testEvent)->testValue() == 17);
+}
 
 TEST_IMPL(sendCustomEvent)
 {


### PR DESCRIPTION
This PR makes it possible to provide two event types for a given event class in `QUO_EVENT` - normally one will be stable and another unstable. No new event types are introduced, except extending `CustomEvent` in Quotest in order to test the functionality.