### PR TITLE
RoomEvent: Cache event id

### DIFF
--- a/Quotient/events/roomevent.cpp
+++ b/Quotient/events/roomevent.cpp
@@ -11,7 +11,7 @@
 
 using namespace Quotient;
 
-RoomEvent::RoomEvent(const QJsonObject& json) : Event(json)
+RoomEvent::RoomEvent(const QJsonObject &json) : Event(json), _id(fullJson()[EventIdKey].toString())
 {
     if (const auto redaction = unsignedPart<QJsonObject>(RedactedCauseKey);
         !redaction.isEmpty())
@@ -22,7 +22,7 @@ RoomEvent::~RoomEvent() = default; // Let the smart pointer do its job
 
 QString RoomEvent::displayId() const { return id().isEmpty() ? transactionId() : id(); }
 
-QString RoomEvent::id() const { return fullJson()[EventIdKey].toString(); }
+QString RoomEvent::id() const { return _id; }
 
 QDateTime RoomEvent::originTimestamp() const
 {
@@ -79,6 +79,7 @@ void RoomEvent::addId(const QString& newId)
     Q_ASSERT(id().isEmpty());
     Q_ASSERT(!newId.isEmpty());
     editJson().insert(EventIdKey, newId);
+    _id = newId;
     qCDebug(EVENTS) << "Event txnId -> id:" << transactionId() << "->" << id();
     Q_ASSERT(id() == newId);
 }

--- a/Quotient/events/roomevent.h
+++ b/Quotient/events/roomevent.h
@@ -131,6 +131,8 @@ protected:
     void dumpTo(QDebug dbg) const override;
 
 private:
+    QString _id;
+
     // RedactionEvent is an incomplete type here so we cannot inline
     // constructors using it and also destructors (with 'using', in particular).
     event_ptr_tt<RedactionEvent> _redactedBecause;


### PR DESCRIPTION
It's used to find events and resolving duplicates - pretty performance- sensitive therefore. Caching it can save up to 10% on larger chunks of event processing. The trade-off is that the footprint of each room event is now 56 bytes instead of 32 but JSON for each event is much larger than that (usually hundreds of bytes) so I think that's reasonable.