### PR TITLE
Enable usage of ordinary fromJson/toJson on enums

### DIFF
--- a/Quotient/converters.h
+++ b/Quotient/converters.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "util.h"
+#include "quotient_common.h"
 
 #include <QtCore/QDate>
 #include <QtCore/QJsonArray> // Includes <QtCore/QJsonValue>
@@ -74,6 +74,10 @@ struct JsonObjectUnpacker {
 //! of overloading toJson() and specialising fromJson().
 template <typename T>
 struct JsonConverter : JsonObjectUnpacker<T> {
+    static_assert(std::is_class_v<T> || std::is_union_v<T>,
+                  "The default JsonConverter definition only supports class types; "
+                  "check the constraints on the specialisation you intended to invoke");
+
     static auto dump(const T& data)
     {
         if constexpr (requires() { data.toJson(); })
@@ -151,14 +155,6 @@ namespace _impl {
     QUOTIENT_API void reportEnumOutOfBounds(uint32_t v, const char* enumTypeName);
 }
 
-//! \brief Facility string-to-enum converter
-//!
-//! This is to simplify enum loading from JSON - just specialise
-//! Quotient::fromJson() and call this function from it, passing (aside from
-//! the JSON value for the enum - that must be a string, not an int) any
-//! iterable container of string'y values (const char*, QLatin1String, etc.)
-//! matching respective enum values, 0-based.
-//! \sa enumToJsonString
 template <typename EnumT>
 inline std::optional<EnumT> enumFromJsonString(const QString& s, const auto& enumValues)
 {
@@ -169,37 +165,18 @@ inline std::optional<EnumT> enumFromJsonString(const QString& s, const auto& enu
     return std::nullopt;
 }
 
-//! \brief Facility enum-to-string converter
-//!
-//! This does the same as enumFromJsonString, the other way around.
-//! \note The source enumeration must not have gaps in values, or \p enumValues
-//!       has to match those gaps (i.e., if the source enumeration is defined
-//!       as <tt>{ Value1 = 1, Value2 = 3, Value3 = 5 }</tt> then \p enumValues
-//!       should be defined as <tt>{ "", "Value1", "", "Value2", "", "Value3"
-//!       }</tt> (mind the gap at value 0, in particular).
-//! \sa enumFromJsonString
 template <typename EnumT>
 inline QString enumToJsonString(EnumT v, const auto& enumValues)
 {
     static_assert(std::is_unsigned_v<std::underlying_type_t<EnumT>>);
-    if (v < size(enumValues))
-        return enumValues[v];
+    const auto intV = std::to_underlying(v);
+    if (QUO_CHECK(intV < size(enumValues)))
+        return enumValues[intV];
 
-    _impl::reportEnumOutOfBounds(static_cast<uint32_t>(v),
-                                 qt_getEnumName(EnumT()));
-    Q_ASSERT(false);
+    _impl::reportEnumOutOfBounds(intV, qt_getEnumName(EnumT()));
     return {};
 }
 
-//! \brief Facility converter for flags
-//!
-//! This is very similar to enumFromJsonString, except that the target
-//! enumeration is assumed to be of a 'flag' kind - i.e. its values must be
-//! a power-of-two sequence starting from 1, without gaps, so exactly 1,2,4,8,16
-//! and so on.
-//! \note Unlike enumFromJsonString, the values start from 1 and not from 0.
-//! \note This function does not support flag combinations.
-//! \sa QUO_DECLARE_FLAGS, QUO_DECLARE_FLAGS_NS
 template <typename FlagT>
 inline std::optional<FlagT> flagFromJsonString(const QString& s, const auto& flagValues)
 {
@@ -215,11 +192,11 @@ template <typename FlagT>
 inline QString flagToJsonString(FlagT v, const auto& flagValues)
 {
     static_assert(std::is_unsigned_v<std::underlying_type_t<FlagT>>);
-    if (const auto offset = std::countr_zero(std::to_underlying(v)); offset < ssize(flagValues))
+    const auto intV = std::to_underlying(v);
+    if (const auto offset = std::countr_zero(intV); QUO_CHECK(offset < ssize(flagValues)))
         return flagValues[offset];
 
-    _impl::reportEnumOutOfBounds(static_cast<uint32_t>(v), qt_getEnumName(FlagT()));
-    Q_ASSERT(false);
+    _impl::reportEnumOutOfBounds(intV, qt_getEnumName(FlagT()));
     return {};
 }
 
@@ -242,6 +219,49 @@ inline qint64 fromJson(const QJsonValue& jv) { return qint64(jv.toDouble()); }
 
 template <>
 inline QString fromJson(const QJsonValue& jv) { return jv.toString(); }
+
+//! \brief JSON conversions for (non-flag) enums
+//!
+//! This specialisation gets applied to any enumeration (in fact - any type at all) for which
+//! there is a specialisation of MetaEnum template such that Serializable_Enum is satisfied. See
+//! the documentation for MetaEnum for the
+template <Serializable_Enum EnumT>
+struct JsonConverter<EnumT>
+{
+    //! \return if \p jv has a string, the ordinal (0-based) index of it in
+    //!         `MetaEnum<EnumT>::strings`; or `MetaEnum<EnumT>::defaultValue` if the string is
+    //!         not found in `MetaEnum<EnumT>::strings`, or \p jv doesn't hold a string
+    static auto load(const QJsonValue &jv)
+    {
+        return enumFromJsonString<EnumT>(jv.toString(), MetaEnum<EnumT>::strings)
+            .value_or(MetaEnum<EnumT>::defaultValue);
+    }
+
+    //! \return the string found at \p val in `MetaEnum<EnumT>::strings`; \p val must correspond to
+    //!         a valid 0-based index into `MetaEnum<EnumT>::strings` (i.e. it's between 0 and
+    //!         `std::size(MetaEnum<EnumT>::strings) - 1`, inclusive).
+    static auto dump(EnumT val) { return enumToJsonString(val, MetaEnum<EnumT>::strings); }
+};
+
+template <Serializable_Flag FlagT>
+struct JsonConverter<FlagT>
+{
+    //! \return if \p jv has a string, the index of it in `MetaEnum<FlagT>::strings`, power of 2
+    //!         (i.e. 1 for 0-th entry, 2 for the first entry, 4 for the second one and so on);
+    //!         or `MetaEnum<FlagT>::defaultValue` if the string is not found in
+    //!         `MetaEnum<FlagT>::strings`, or \p jv doesn't hold a string
+    static auto load(const QJsonValue &jv)
+    {
+        return flagFromJsonString<FlagT>(jv.toString(), MetaEnum<FlagT>::strings)
+            .value_or(MetaEnum<FlagT>::defaultValue);
+    }
+
+    //! \return the string found at `\p val log 2 in` `MetaEnum<FlagT>::strings` (i.e. 0-th string
+    //!         for 1, first one for 2, second for 4 and so on); \p val must be a power of 2 for
+    //!         a valid index into `MetaEnum<FlagT>::strings` - i.e. \p val must one of
+    //!         1, 2, 4,..., `2 ^ (std::size(MetaEnum<FlagT>::strings) - 1)`, inclusive
+    static auto dump(FlagT val) { return flagToJsonString(val, MetaEnum<FlagT>::strings); }
+};
 
 //! Use fromJson<QString> and then toLatin1()/toUtf8()/... to make QByteArray
 //!

--- a/Quotient/e2ee/e2ee_common.h
+++ b/Quotient/e2ee/e2ee_common.h
@@ -32,7 +32,6 @@ constexpr inline auto Curve25519Key = "curve25519"_L1;
 constexpr inline auto SignedCurve25519Key = "signed_curve25519"_L1;
 
 constexpr inline auto OlmV1Curve25519AesSha2AlgoKey = "m.olm.v1.curve25519-aes-sha2"_L1;
-constexpr inline auto MegolmV1AesSha2AlgoKey = "m.megolm.v1.aes-sha2"_L1;
 
 constexpr std::array SupportedAlgorithms { OlmV1Curve25519AesSha2AlgoKey,
                                            MegolmV1AesSha2AlgoKey };

--- a/Quotient/events/encryptionevent.cpp
+++ b/Quotient/events/encryptionevent.cpp
@@ -4,27 +4,9 @@
 
 #include "encryptionevent.h"
 
-#include "../logging_categories_p.h"
-
 #include "../e2ee/e2ee_common.h"
 
 using namespace Quotient;
-
-static constexpr std::array encryptionStrings { MegolmV1AesSha2AlgoKey };
-
-template <>
-EncryptionType Quotient::fromJson(const QJsonValue& jv)
-{
-    const auto& encryptionString = jv.toString();
-    for (auto it = encryptionStrings.begin(); it != encryptionStrings.end();
-         ++it)
-        if (encryptionString == *it)
-            return EncryptionType(it - encryptionStrings.begin());
-
-    if (!encryptionString.isEmpty())
-        qCWarning(EVENTS) << "Unknown EncryptionType: " << encryptionString;
-    return EncryptionType::Undefined;
-}
 
 EncryptionEventContent::EncryptionEventContent(const QJsonObject& json)
     : encryption(fromJson<Quotient::EncryptionType>(json[AlgorithmKeyL]))
@@ -39,7 +21,7 @@ EncryptionEventContent::EncryptionEventContent(Quotient::EncryptionType et)
     : encryption(et)
 {
     if(encryption != Quotient::EncryptionType::Undefined) {
-        algorithm = encryptionStrings[static_cast<size_t>(encryption)];
+        algorithm = Quotient::toJson(encryption);
     }
 }
 

--- a/Quotient/events/roomcreateevent.cpp
+++ b/Quotient/events/roomcreateevent.cpp
@@ -5,12 +5,6 @@
 
 using namespace Quotient;
 
-template <>
-RoomType Quotient::fromJson(const QJsonValue& jv)
-{
-    return enumFromJsonString<RoomType>(jv.toString(), RoomTypeStrings).value_or(RoomType::Undefined);
-}
-
 bool RoomCreateEvent::isFederated() const
 {
     return contentPart<bool>("m.federate"_L1);

--- a/Quotient/events/roomjoinrulesevent.h
+++ b/Quotient/events/roomjoinrulesevent.h
@@ -18,15 +18,6 @@ struct QUOTIENT_API AllowCondition {
     QString type;
 };
 
-[[maybe_unused]] constexpr std::array JoinRuleStrings {
-    "public"_L1,
-    "knock"_L1,
-    "invite"_L1,
-    "private"_L1,
-    "restricted"_L1,
-    "knock_restricted"_L1,
-};
-
 //! \brief The content of a join rule event
 //!
 //! \sa https://spec.matrix.org/latest/client-server-api/#mroomjoin_rules
@@ -36,12 +27,15 @@ struct QUOTIENT_API JoinRuleContent {
 };
 } // namespace EventContent
 
+constexpr inline auto JoinRuleKey = "join_rule"_L1;
+constexpr inline auto AllowKey = "allow"_L1;
+
 template<>
 inline EventContent::AllowCondition fromJson(const QJsonObject& jo)
 {
     return EventContent::AllowCondition {
-        fromJson<QString>(jo["room_id"_L1]),
-        fromJson<QString>(jo["type"_L1])
+        fromJson<QString>(jo[RoomIdKey]),
+        fromJson<QString>(jo[TypeKey])
     };
 }
 
@@ -49,26 +43,25 @@ template<>
 inline auto toJson(const EventContent::AllowCondition& c)
 {
     QJsonObject jo;
-    addParam<IfNotEmpty>(jo, "room_id"_L1, c.roomId);
-    addParam<IfNotEmpty>(jo, "type"_L1, c.type);
+    addParam<IfNotEmpty>(jo, RoomIdKey, c.roomId);
+    addParam<IfNotEmpty>(jo, TypeKey, c.type);
     return jo;
 }
 
 template<>
 inline EventContent::JoinRuleContent fromJson(const QJsonObject& jo)
 {
-    return EventContent::JoinRuleContent {
-        enumFromJsonString<JoinRule>(jo["join_rule"_L1].toString(), EventContent::JoinRuleStrings).value_or(Public),
-        fromJson<QList<EventContent::AllowCondition>>(jo["allow"_L1])
-    };
+    return EventContent::JoinRuleContent{fromJson<JoinRule>(jo[JoinRuleKey]),
+                                         fromJson<QList<EventContent::AllowCondition>>(
+                                             jo[AllowKey])};
 }
 
 template<>
 inline auto toJson(const EventContent::JoinRuleContent& c)
 {
     QJsonObject jo;
-    addParam<IfNotEmpty>(jo, "join_rule"_L1, enumToJsonString<JoinRule>(c.joinRule, EventContent::JoinRuleStrings));
-    addParam<IfNotEmpty>(jo, "allow"_L1, c.allow);
+    addParam<IfNotEmpty>(jo, JoinRuleKey, c.joinRule);
+    addParam<IfNotEmpty>(jo, AllowKey, c.allow);
     return jo;
 }
 

--- a/Quotient/events/roommemberevent.cpp
+++ b/Quotient/events/roommemberevent.cpp
@@ -6,20 +6,6 @@
 
 #include "../logging_categories_p.h"
 
-namespace Quotient {
-template <>
-struct JsonConverter<Membership> {
-    static Membership load(const QJsonValue& jv)
-    {
-        if (const auto& ms = jv.toString(); !ms.isEmpty())
-            return flagFromJsonString<Membership>(ms, MembershipStrings).value_or(Membership::Invalid);
-
-        qCWarning(EVENTS) << "Empty membership state";
-        return Membership::Invalid;
-    }
-};
-} // namespace Quotient
-
 using namespace Quotient;
 
 MemberEventContent::MemberEventContent(const QJsonObject& json)
@@ -37,7 +23,7 @@ QJsonObject MemberEventContent::toJson() const
 {
     QJsonObject o;
     if (membership != Membership::Invalid)
-        o.insert("membership"_L1, flagToJsonString(membership, MembershipStrings));
+        o.insert("membership"_L1, Quotient::toJson(membership));
     if (displayName)
         o.insert("displayname"_L1, *displayName);
     if (avatarUrl && avatarUrl->isValid())

--- a/Quotient/quotient_common.h
+++ b/Quotient/quotient_common.h
@@ -4,12 +4,12 @@
 #pragma once
 
 #include "quotient_export.h"
+#include "util.h" // IWYU pragma: keep - for Quotient::Literals::operator""_L1
 
 #include <qobjectdefs.h>
-#include "util.h" // For Quotient::Literals::operator""_L1
 
 #include <array>
-
+#include <span>
 
 //! \brief Quotient replacement for the Q_FLAG/Q_DECLARE_FLAGS combination
 //!
@@ -45,7 +45,77 @@
 namespace Quotient {
 Q_NAMESPACE_EXPORT(QUOTIENT_API)
 
-// TODO: code like this should be generated from the CS API definition
+//! \brief Enabling structure for conversion between a given enum and JSON
+//!
+//! Providing this structure in a way that satisfies either Serializable_Enum or Serializable_Flag
+//! enables de/serialisation using fromJson() and toJson() for the respective enum. See commented
+//! out code in the definition for an idea what should be there to satisfy either concept. `strings`
+//! has the list of JSON representations for respective enumerators. `defaultValue` should have
+//! the enumerator used when the string coming from JSON cannot be found in `strings`, or when
+//! the JSON value is not even a string. `isFlag` defines whether the enumeration should be treated
+//! as a collection of flag values (usually, such enum also has a QFlags counterpart type defined
+//! with Q_FLAG, Q_FLAG_NS, QUO_DECLARE_FLAGS or QUO_DECLARE_FLAGS_NS). `isFlag` can either be
+//! `false` or completely omitted from the definition for non-flag enumerations.
+//!
+//! \note This mechanism doesn't support using numeric values of enumerators in JSON; if you need
+//!       to store and load the numeric value, use fromJson() and toJson() with the underlying
+//!       integral type instead of the enumeration type.
+//!
+//! The rules to define enumerations and their string representations are different for non-flag and
+//! flag enumerations - see the respective note blocks below. These cannot be checked at
+//! compile-time, breaking them will lead to either assertion failures or incorrect conversion.
+//!
+//! \note For non-flag enumerations, \p EnumT must not have gaps in enumerators, or \p strings has
+//!       to match those gaps (i.e., if \p EnumT is defined as
+//!       <tt>{ Value1 = 1, Value2 = 3, Value3 = 5 }</tt> then \p strings should be defined as
+//!       <tt>{ "", "Value1", "", "Value2", "", "Value3" }</tt> (mind the gap at value 0,
+//!       in particular). Although it is allowed to have enumerations based
+//! \note For flag enumerations, enumerators of \p EnumT must follow the power-of-two sequence
+//!       starting from 1, so exactly 1,2,4,8,16 and so on. Having gaps is allowed but the same rule
+//!       as for non-flag enumerations applies: \p strings has to reflect this gap, skipping an
+//!       array item. As of now, there's no way to encode and decode the value of zero (no flags
+//!       set) or a combination of flags (i.e. Flag4|Flag16).
+//!
+//! In most cases you can use facility macros, QUO_META_ENUM and QUO_META_FLAG, instead of writing
+//! all the boilerplate yourself. The enumeration can be defined in any namespace but the macros
+//! are only valid when put into `namespace Quotient`. Clients are free to write
+//! `namespace Quotient { QUO_META_ENUM(...) }` for that matter.
+
+template <typename EnumT>
+struct QUOTIENT_API MetaEnum
+{
+    // static constexpr std::array strings{"one"_L1, "two"_L1, "three"_L1};
+    // static constexpr auto defaultValue = EnumT::Undefined;
+    // static constexpr bool isFlag = true; // If the enum should be treated as a flags group
+};
+
+template <typename EnumT>
+concept Serializable_Enum = requires {
+    typename MetaEnum<EnumT>;
+    { MetaEnum<EnumT>::strings } -> std::ranges::range;
+    { MetaEnum<EnumT>::defaultValue } -> std::convertible_to<EnumT>;
+};
+
+template <typename FlagT>
+concept Serializable_Flag = std::is_unsigned_v<std::underlying_type_t<FlagT>>
+                            && Serializable_Enum<FlagT> && MetaEnum<FlagT>::isFlag == true;
+
+#define QUO_META_ENUM_IMPL(EnumType_, IsFlag_, DefaultValue_, ...) \
+    template <>                                                    \
+    struct QUOTIENT_API MetaEnum<EnumType_>                        \
+    {                                                              \
+        static constexpr std::array strings{__VA_ARGS__};          \
+        static constexpr auto defaultValue = DefaultValue_;        \
+        static constexpr bool isFlag = IsFlag_;                    \
+    }; // End of macro
+
+#define QUO_META_ENUM(EnumType_, DefaultValue_, ...) \
+    QUO_META_ENUM_IMPL(EnumType_, false, DefaultValue_, __VA_ARGS__)
+
+#define QUO_META_FLAG(EnumType_, DefaultValue_, ...) \
+    QUO_META_ENUM_IMPL(EnumType_, true, DefaultValue_, __VA_ARGS__)
+
+// TODO: code like below should be generated from the CS API definition
 
 //! \brief Membership states
 //!
@@ -64,11 +134,8 @@ enum class Membership : uint16_t {
     Undefined = Invalid
 };
 QUO_DECLARE_FLAGS_NS(MembershipMask, Membership)
-
-constexpr std::array MembershipStrings {
-    // The order MUST be the same as the order in the Membership enum
-    "join"_L1, "leave"_L1, "invite"_L1, "knock"_L1, "ban"_L1
-};
+QUO_META_FLAG(Membership, Membership::Invalid, "join"_L1, "leave"_L1, "invite"_L1, "knock"_L1,
+              "ban"_L1)
 
 //! \brief Local user join-state names
 //!
@@ -84,10 +151,16 @@ enum class JoinState : std::underlying_type_t<Membership> {
 };
 QUO_DECLARE_FLAGS_NS(JoinStates, JoinState)
 
-[[maybe_unused]] constexpr std::array JoinStateStrings {
-    MembershipStrings[0], MembershipStrings[1], MembershipStrings[2],
-    MembershipStrings[3] /* same as MembershipStrings, sans "ban" */
+template <>
+struct QUOTIENT_API MetaEnum<JoinState> : MetaEnum<Membership>
+{
+    // Same as Membership, except "ban"
+    static constexpr auto strings = std::span(MetaEnum<Membership>::strings).subspan<0, 4>();
+    // Protect against Membership gaining new values without JoinState being revisited
+    static_assert(std::size(strings) + 1 == std::size(MetaEnum<Membership>::strings));
 };
+
+constexpr inline const auto &JoinStateStrings = MetaEnum<JoinState>::strings;
 
 //! \brief Network job running policy flags
 //!
@@ -113,14 +186,17 @@ enum class RoomType : uint8_t {
     Undefined = 0xFF,
 };
 Q_ENUM_NS(RoomType)
-
-[[maybe_unused]] constexpr std::array RoomTypeStrings { "m.space"_L1 };
+QUO_META_ENUM(RoomType, RoomType::Undefined, "m.space"_L1)
 
 enum class EncryptionType : uint8_t {
     MegolmV1AesSha2 = 0,
     Undefined = 0xFF,
 };
 Q_ENUM_NS(EncryptionType)
+
+constexpr inline auto MegolmV1AesSha2AlgoKey = "m.megolm.v1.aes-sha2"_L1;
+
+QUO_META_ENUM(EncryptionType, EncryptionType::Undefined, MegolmV1AesSha2AlgoKey)
 
 //! Enum representing the available room join rules
 enum JoinRule : uint16_t {
@@ -132,6 +208,8 @@ enum JoinRule : uint16_t {
     KnockRestricted,
 };
 Q_ENUM_NS(JoinRule)
+QUO_META_ENUM(JoinRule, JoinRule::Public, "public"_L1, "knock"_L1, "invite"_L1, "private"_L1,
+              "restricted"_L1, "knock_restricted"_L1)
 
 } // namespace Quotient
 Q_DECLARE_OPERATORS_FOR_FLAGS(Quotient::MembershipMask)


### PR DESCRIPTION
This helps to cut away repetitive `JsonConverter` specialisations, and generally unifies work with enums as any other type from JSON conversion perspective. Still have to add necessary metadata for each enum but in most cases it's as simple as a single macro expansion now.