### PR TITLE
Don't cache content of state events

### DIFF
--- a/Quotient/events/event.h
+++ b/Quotient/events/event.h
@@ -338,6 +338,14 @@ protected:
     explicit Event(const QJsonObject& json);
 
     QJsonObject& editJson() { return _json; }
+
+    virtual void onContentChanged() {}
+    void editContentJson(auto visitor)
+    {
+        editSubobject(_json, ContentKey, visitor);
+        onContentChanged();
+    }
+
     virtual void dumpTo(QDebug dbg) const;
 
 private:

--- a/Quotient/events/roommemberevent.h
+++ b/Quotient/events/roommemberevent.h
@@ -36,12 +36,17 @@ public:
 
     using KeyedStateEventBase::KeyedStateEventBase;
 
-    Membership membership() const { return content().membership; }
+    QUO_CONTENT_GETTER(Membership, membership)
+    // Membership membership() const { return content().membership; }
     QString userId() const { return stateKey(); }
-    bool isDirect() const { return content().isDirect; }
-    std::optional<QString> newDisplayName() const { return content().displayName; }
-    std::optional<QUrl> newAvatarUrl() const { return content().avatarUrl; }
-    QString reason() const { return content().reason; }
+    QUO_CONTENT_GETTER(bool, isDirect)
+    // bool isDirect() const { return content().isDirect; }
+    QUO_CONTENT_GETTER_X(std::optional<QString>, newDisplayName, "displayname"_L1)
+    // std::optional<QString> newDisplayName() const { return content().displayName; }
+    QUO_CONTENT_GETTER_X(std::optional<QUrl>, newAvatarUrl, "avatar_url"_L1)
+    // std::optional<QUrl> newAvatarUrl() const { return content().avatarUrl; }
+    QUO_CONTENT_GETTER(QString, reason)
+    // QString reason() const { return content().reason; }
     bool changesMembership() const;
     bool isBan() const;
     bool isUnban() const;

--- a/Quotient/events/roommessageevent.cpp
+++ b/Quotient/events/roommessageevent.cpp
@@ -316,9 +316,8 @@ QString RoomMessageEvent::fileNameToDownload() const
 
 void RoomMessageEvent::updateFileSourceInfo(const FileSourceInfo& fsi)
 {
-    editSubobject(editJson(), ContentKey, [&fsi](QJsonObject& contentJson) {
-        Quotient::fillJson(contentJson, { "url"_L1, "file"_L1 }, fsi);
-    });
+    editContentJson(
+        [&fsi](QJsonObject &contentJson) { fillJson(contentJson, {"url"_L1, "file"_L1}, fsi); });
 }
 
 QString rawMsgTypeForMimeType(const QMimeType& mimeType)

--- a/Quotient/events/simplestateevents.h
+++ b/Quotient/events/simplestateevents.h
@@ -9,16 +9,17 @@
 
 namespace Quotient {
 
-#define DEFINE_SIMPLE_STATE_EVENT(Name_, TypeId_, ValueType_, GetterName_, JsonKey_)              \
-    constexpr inline auto Name_##Key = JsonKey_##_L1;                                             \
-    class QUOTIENT_API Name_ : public ::Quotient::KeylessStateEventBase<                          \
-                                   Name_, EventContent::SingleKeyValue<ValueType_, Name_##Key>> { \
-    public:                                                                                       \
-        using value_type = ValueType_;                                                            \
-        QUO_EVENT(Name_, TypeId_)                                                                 \
-        using KeylessStateEventBase::KeylessStateEventBase;                                       \
-        auto GetterName_() const { return content().value; }                                      \
-    };                                                                                            \
+#define DEFINE_SIMPLE_STATE_EVENT(Name_, TypeId_, ValueType_, GetterName_, JsonKey_)            \
+    constexpr inline auto Name_##Key = JsonKey_##_L1;                                           \
+    class QUOTIENT_API Name_ : public ::Quotient::KeylessStateEventBase<                        \
+                                   Name_, EventContent::SingleKeyValue<ValueType_, Name_##Key>> \
+    {                                                                                           \
+    public:                                                                                     \
+        using value_type = ValueType_;                                                          \
+        QUO_EVENT(Name_, TypeId_)                                                               \
+        using KeylessStateEventBase::KeylessStateEventBase;                                     \
+        QUO_CONTENT_GETTER_X(ValueType_, GetterName_, Name_##Key)                               \
+    };                                                                                          \
     // End of macro
 
 DEFINE_SIMPLE_STATE_EVENT(RoomNameEvent, "m.room.name", QString, name, "name")

--- a/Quotient/events/stateevent.h
+++ b/Quotient/events/stateevent.h
@@ -63,46 +63,30 @@ class EventTemplate<EventT, StateEvent, ContentT>
 public:
     using content_type = ContentT;
 
-    struct Prev {
-        explicit Prev() = default;
-        explicit Prev(const QJsonObject& unsignedJson)
-            : senderId(fromJson<QString>(unsignedJson["prev_sender"_L1]))
-            , content(fromJson<std::optional<ContentT>>(unsignedJson[PrevContentKey]))
-        {}
+    explicit EventTemplate(const QJsonObject &fullJson) : StateEvent(fullJson) {}
 
-        QString senderId;
-        std::optional<ContentT> content;
-    };
-
-    explicit EventTemplate(const QJsonObject& fullJson)
-        : StateEvent(fullJson)
-        , _content(fromJson<ContentT>(Event::contentJson()))
-        , _prev(unsignedJson())
-    {}
     template <typename... ContentParamTs>
-    explicit EventTemplate(const QString& stateKey,
-                           ContentParamTs&&... contentParams)
-        : StateEvent(EventT::TypeId, stateKey)
-        , _content { std::forward<ContentParamTs>(contentParams)... }
+    explicit EventTemplate(const QString &stateKey, ContentParamTs &&...contentParams)
+        : StateEvent(EventT::TypeId, stateKey,
+                     toJson(ContentT{std::forward<ContentParamTs>(contentParams)...}))
+    {}
+
+    ContentT content() const { return fromJson<ContentT>(Event::contentJson()); }
+
+    template <std::invocable<ContentT &> VisitorT>
+    void editContent(VisitorT &&visitor)
     {
-        editJson().insert(ContentKey, toJson(_content));
+        editContentJson([&visitor](QJsonObject &contentJson) mutable {
+            auto content = fromJson<ContentT>(contentJson);
+            std::invoke(std::forward<VisitorT>(visitor), content);
+            contentJson = toJson(content);
+        });
     }
-
-    const ContentT& content() const { return _content; }
-
-    void editContent(auto&& visitor)
+    std::optional<ContentT> prevContent() const
     {
-        visitor(_content);
-        editJson()[ContentKey] = toJson(_content);
+        return unsignedPart<std::optional<ContentT>>(PrevContentKey);
     }
-    const std::optional<ContentT>& prevContent() const { return _prev.content; }
-    QString prevSenderId() const { return _prev.senderId; }
-
-private:
-    void onContentChanged() override { _content = fromJson<ContentT>(Event::contentJson()); }
-
-    ContentT _content;
-    Prev _prev;
+    QString prevSenderId() const { return unsignedPart<QString>("prev_sender"_L1); }
 };
 
 template <typename EventT, typename ContentT>

--- a/Quotient/events/stateevent.h
+++ b/Quotient/events/stateevent.h
@@ -99,6 +99,8 @@ public:
     QString prevSenderId() const { return _prev.senderId; }
 
 private:
+    void onContentChanged() override { _content = fromJson<ContentT>(Event::contentJson()); }
+
     ContentT _content;
     Prev _prev;
 };

--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -3307,8 +3307,7 @@ Room::Change Room::Private::processStateEvent(const RoomEvent& curEvent,
         },
         [this, oldEvent](const JoinRulesEvent& evt) {
             if (const auto* oldJRE = static_cast<const JoinRulesEvent*>(oldEvent);
-                oldJRE && oldJRE->content().joinRule != evt.content().joinRule
-            ) {
+                oldJRE && oldJRE->joinRule() != evt.joinRule()) {
                 emit q->joinRuleChanged();
             }
             return Change::Other;


### PR DESCRIPTION
In most cases, the content of those events is not read, anyway - because not all events are actually displayed by clients. As 2f3be05896b07ee0beabbe56539719cc85006449 (the key commit in this PR) says, the slowdown in (slightly patched) Quotest - specifically, on a request of 1000 historical events - was about 2.5% and it was within the standard deviation. In the actual usage by client the difference is likely to be even less.

Why this change at all: while working on intentional mentions, I thought of introducing `RoomEvent::setMentions()` (I haven't found that mentions only can be used on message events so I will implement them on the room event level - coming in a separate PR), which will necessarily change the content JSON of the event because that's where the mentions are put. This is where the first commit comes from, actually - first, I introduced the way to change the event content JSON so that inheriting event classes are notified about the change via `onContentChanged()`. Then I figured that the only class of cases where such notification is needed atm seems to be state events because they store the deserialised content. So I tried to optimise this part away, and it seems things are not massively deteriorating.