### PR TITLE
emit SSSSHandler::keyBackupUnlocked when receiving backup key from another device - 0.9

### DIFF
--- a/Quotient/e2ee/sssshandler.cpp
+++ b/Quotient/e2ee/sssshandler.cpp
@@ -148,6 +148,7 @@ void SSSSHandler::unlockSSSSFromCrossSigning()
     Q_ASSERT(m_connection);
     m_connection->requestKeyFromDevices(MegolmBackupKey).then([this](const QByteArray& key) {
         loadMegolmBackup(key);
+        emit keyBackupUnlocked();
     });
     for (auto k : {CrossSigningUserSigningKey, CrossSigningSelfSigningKey, CrossSigningMasterKey})
         m_connection->requestKeyFromDevices(k);


### PR DESCRIPTION
Same as #933 but for the stable branch.