### PR TITLE
Deprecate encryption pickle operations in AccountSettings

### DIFF
--- a/Quotient/settings.h
+++ b/Quotient/settings.h
@@ -126,7 +126,9 @@ public:
     QUrl homeserver() const;
     void setHomeserver(const QUrl& url);
 
+    [[deprecated("Client code shouldn't use the pickle; and the library stores it in a keychain")]]
     QByteArray encryptionAccountPickle();
+    [[deprecated("Client code shouldn't use the pickle; and the library stores it in a keychain")]]
     void setEncryptionAccountPickle(const QByteArray& encryptionAccountPickle);
     Q_INVOKABLE void clearEncryptionAccountPickle();
 };


### PR DESCRIPTION
Storing it via QSettings has never been secure and was a stopgap before adopting QtKeychain. clearEncryptionAccountPickle() is intentionally not deprecated, since clients (Quaternion, in particular) may want to remove it if they used it before.