### PR TITLE
Deprecate encryption pickle operations in AccountSettings - 0.9

### DIFF
--- a/Quotient/settings.h
+++ b/Quotient/settings.h
@@ -154,7 +154,9 @@ public:
     QUrl homeserver() const;
     void setHomeserver(const QUrl& url);
 
+    [[deprecated("Client code shouldn't use the pickle; and the library stores it in a keychain")]]
     QByteArray encryptionAccountPickle();
+    [[deprecated("Client code shouldn't use the pickle; and the library stores it in a keychain")]]
     void setEncryptionAccountPickle(const QByteArray& encryptionAccountPickle);
     Q_INVOKABLE void clearEncryptionAccountPickle();
 };


### PR DESCRIPTION
Same as #935, for the stable branch.