### PR TITLE
Fix use as static library with Qt 6.10

### DIFF
--- a/cmake/QuotientConfig.cmake.in
+++ b/cmake/QuotientConfig.cmake.in
@@ -11,6 +11,10 @@ find_dependency(Olm)
 find_dependency(OpenSSL)
 find_dependency(@Qt@Sql)
 
+if(NOT @BUILD_SHARED_LIBS@ AND @Qt@Core_VERSION VERSION_GREATER_EQUAL 6.10)
+    find_dependency(@Qt@CorePrivate)
+endif()
+
 include("${CMAKE_CURRENT_LIST_DIR}/@QUOTIENT_LIB_NAME@Targets.cmake")
 
 if (NOT QUOTIENT_FORCE_NAMESPACED_INCLUDES)


### PR DESCRIPTION
In a static build private link dependencies become public, and with Qt 6.10 we need to explicitly search for private Qt libraries.