### PR TITLE
Use configure_package_config_file when generating CMake config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -409,9 +409,12 @@ export(EXPORT ${QUOTIENT_LIB_NAME}Targets
 if (NOT DEFINED BUILD_SHARED_LIBS)
     set(BUILD_SHARED_LIBS OFF)
 endif()
-configure_file(cmake/${PROJECT_NAME}Config.cmake.in
+configure_package_config_file(cmake/${PROJECT_NAME}Config.cmake.in
     "${CMAKE_CURRENT_BINARY_DIR}/${QUOTIENT_LIB_NAME}/${QUOTIENT_LIB_NAME}Config.cmake"
-    @ONLY
+    INSTALL_DESTINATION
+    "${CMAKE_INSTALL_PREFIX}/${CMakeFilesLocation}"
+    NO_SET_AND_CHECK_MACRO
+    NO_CHECK_REQUIRED_COMPONENTS_MACRO
 )
 
 install(EXPORT ${QUOTIENT_LIB_NAME}Targets

--- a/cmake/QuotientConfig.cmake.in
+++ b/cmake/QuotientConfig.cmake.in
@@ -1,3 +1,5 @@
+@PACKAGE_INIT@
+
 include(CMakeFindDependencyMacro)
 
 find_dependency(@Qt@Core)


### PR DESCRIPTION
This is needed for future dependencies (namely Rust-based libraries with Corrosion) which depend on `PACKAGE_PREFIX_DIR` variable. We can generate this with [configure_package_config_file](https://cmake.org/cmake/help/latest/module/CMakePackageConfigHelpers.html), and this just adds a few lines to our config file for this.