### PR TITLE
Assume authenticated media if DownloadFileJob/MediaThumbnailJob is early

### DIFF
--- a/Quotient/jobs/downloadfilejob.cpp
+++ b/Quotient/jobs/downloadfilejob.cpp
@@ -46,7 +46,7 @@ QUrl DownloadFileJob::makeRequestUrl(const HomeserverData& hsData, const QString
                                      const QString& mediaId)
 {
     QT_IGNORE_DEPRECATIONS( // For GetContentJob
-        return hsData.checkMatrixSpecVersion(u"v1.11")
+        return hsData.checkMatrixSpecVersion(u"v1.11") || hsData.supportedSpecVersions.empty() // Assume that if we're called early, that the server uses auth media
                    ? GetContentAuthedJob::makeRequestUrl(hsData, serverName, mediaId)
                    : GetContentJob::makeRequestUrl(hsData, serverName, mediaId);)
 }

--- a/Quotient/jobs/mediathumbnailjob.cpp
+++ b/Quotient/jobs/mediathumbnailjob.cpp
@@ -22,7 +22,7 @@ QUrl MediaThumbnailJob::makeRequestUrl(const HomeserverData& hsData, const QStri
                                        std::optional<bool> animated)
 {
     QT_IGNORE_DEPRECATIONS( // For GetContentThumbnailJob
-        return hsData.checkMatrixSpecVersion(u"v1.11")
+        return hsData.checkMatrixSpecVersion(u"v1.11") || hsData.supportedSpecVersions.empty() // Assume that if we're called early, that the server uses auth media
                    ? GetContentThumbnailAuthedJob::makeRequestUrl(hsData, serverName, mediaId,
                                                                   requestedSize.width(),
                                                                   requestedSize.height(),


### PR DESCRIPTION
This frequently happens with our avatars in NeoChat, and it will also be logged as using v3 - despite the server actually using auth media. This is because these jobs were started before we loaded the spec versions, but I think it's safe to assume auth media support in this case.