### PR TITLE
Replace literals with constants; other minor cleanup

### DIFF
--- a/Quotient/events/eventcontent.cpp
+++ b/Quotient/events/eventcontent.cpp
@@ -133,11 +133,11 @@ TextContent::TextContent(const QJsonObject& json)
     const auto relatesTo = fromJson<std::optional<EventRelation>>(json[RelatesToKey]);
 
     const auto actualJson = relatesTo.has_value() && relatesTo->type == EventRelation::ReplacementType
-                                ? json.value("m.new_content"_L1).toObject()
+                                ? json.value(NewContentKey).toObject()
                                 : json;
     // Special-casing the custom matrix.org's (actually, Element's) way
     // of sending HTML messages.
-    if (actualJson["format"_L1].toString() == HtmlContentTypeId) {
+    if (actualJson[FormatKey].toString() == HtmlContentTypeId) {
         mimeType = HtmlMimeType;
         body = actualJson[FormattedBodyKey].toString();
     } else {

--- a/Quotient/events/eventrelation.h
+++ b/Quotient/events/eventrelation.h
@@ -10,9 +10,16 @@ namespace Quotient {
 constexpr inline auto RelatesToKey = "m.relates_to"_L1;
 constexpr inline auto RelTypeKey = "rel_type"_L1;
 constexpr inline auto IsFallingBackKey = "is_falling_back"_L1;
+constexpr inline auto NewContentKey = "m.new_content"_L1;
+constexpr inline auto RelationsKey = "m.relations"_L1;
 
+//! \brief Data about one relation of an event to an upstream event (e.g. a reply or a reaction)
+//!
+//! This structure contains all information pertaining to a single event relation. In terms of
+//! CS API it corresponds to the contents of `m.relates_to` and `m.in_reply_to` JSON objects.
 struct QUOTIENT_API EventRelation {
-    using reltypeid_t = QLatin1String;
+    using typeid_t = QLatin1String;
+    using reltypeid_t [[deprecated("Use typeid_t")]] = typeid_t;
 
     QString type;
     QString eventId;

--- a/Quotient/events/roommessageevent.cpp
+++ b/Quotient/events/roommessageevent.cpp
@@ -110,7 +110,7 @@ QJsonObject RoomMessageEvent::assembleContentJson(const QString& plainBody,
             }
             newContentJson.insert(BodyKey, plainBody);
             newContentJson.insert(MsgTypeKey, jsonMsgType);
-            json.insert("m.new_content"_L1, newContentJson);
+            json.insert(NewContentKey, newContentJson);
             json.insert(BodyKey, "* "_L1 + plainBody);
         }
     }

--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -2817,12 +2817,12 @@ bool Room::Private::processRedaction(const RedactionEvent& redaction)
 RoomEventPtr makeReplaced(const RoomEvent& target,
                           const RoomMessageEvent& replacement)
 {
-    auto newContent = replacement.contentPart<QJsonObject>("m.new_content"_L1);
+    auto newContent = replacement.contentPart<QJsonObject>(NewContentKey);
     addParam<IfNotEmpty>(newContent, RelatesToKey, target.contentPart<QJsonObject>(RelatesToKey));
     auto originalJson = target.fullJson();
     originalJson[ContentKey] = newContent;
     editSubobject(originalJson, UnsignedKey, [&replacement](QJsonObject& unsignedData) {
-        replaceSubvalue(unsignedData, "m.relations"_L1, "m.replace"_L1, replacement.id());
+        replaceSubvalue(unsignedData, RelationsKey, EventRelation::ReplacementType, replacement.id());
     });
 
     return loadEvent<RoomEvent>(originalJson);


### PR DESCRIPTION
- New constants for literals: NewContentKey, RelationsKey
- Rename reltypeid_t to typeid_t; the old alias is still there, now deprecated
- Document EventRelation