### PR TITLE
Fix undefined read in Room::markAllMessagesAsRead

### DIFF
--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -1060,7 +1060,9 @@ void Room::markMessagesAsRead(const QString& uptoEventId)
 
 void Room::markAllMessagesAsRead()
 {
-    d->markMessagesAsRead(d->timeline.crbegin());
+    if (!d->timeline.empty()) {
+        d->markMessagesAsRead(d->timeline.crbegin());
+    }
 }
 
 bool Room::canSwitchVersions() const


### PR DESCRIPTION
If the timeline is empty, we end up reading something invalid which isn't entirely correct. It doesn't seem to cause crashes, but definitely trips up ASan.