### PR TITLE
Enable event relations on RoomEvent

### DIFF
--- a/Quotient/events/eventcontent.cpp
+++ b/Quotient/events/eventcontent.cpp
@@ -132,7 +132,7 @@ TextContent::TextContent(const QJsonObject& json)
 
     const auto relatesTo = fromJson<std::optional<EventRelation>>(json[RelatesToKey]);
 
-    const auto actualJson = relatesTo.has_value() && relatesTo->type == EventRelation::ReplacementType
+    const auto actualJson = relatesTo && relatesTo->type == EventRelation::ReplacementType
                                 ? json.value(NewContentKey).toObject()
                                 : json;
     // Special-casing the custom matrix.org's (actually, Element's) way

--- a/Quotient/events/roomevent.cpp
+++ b/Quotient/events/roomevent.cpp
@@ -146,10 +146,15 @@ std::optional<EventRelation> RoomEvent::relatesTo() const
 
 void RoomEvent::setRelation(const EventRelation &er)
 {
-    editJson().insert(RelatesToKey, toJson(er));
+    replaceSubvalue(editJson(), ContentKey, RelatesToKey, toJson(er));
 }
 
-void RoomEvent::clearRelation() { editJson().remove(RelatesToKey); }
+void RoomEvent::clearRelation()
+{
+    editSubobject(editJson(), ContentKey, [](QJsonObject& content) {
+        content.remove(RelatesToKey);
+    });
+}
 
 QJsonObject RoomEvent::relationsToThis() const
 {

--- a/Quotient/events/roomevent.cpp
+++ b/Quotient/events/roomevent.cpp
@@ -120,20 +120,20 @@ bool Quotient::isStateEvent(const QString& eventTypeId)
 bool RoomEvent::isReply(bool includeFallbacks) const
 {
     const auto relation = relatesTo();
-    return relation.has_value()
-           && (relation.value().type == EventRelation::ReplyType
-               || (relation.value().type == EventRelation::ThreadType
-                   && (relation.value().isFallingBack == false || includeFallbacks)));
+    return relation
+           && (relation->type == EventRelation::ReplyType
+               || (relation->type == EventRelation::ThreadType
+                   && (relation->isFallingBack == false || includeFallbacks)));
 }
 
 QString RoomEvent::replyEventId(bool includeFallbacks) const
 {
     if (const auto relation = relatesTo()) {
-        if (relation.value().type == EventRelation::ReplyType) {
-            return relation.value().eventId;
-        } else if (relation.value().type == EventRelation::ThreadType
-                   && (relation.value().isFallingBack == false || includeFallbacks)) {
-            return relation.value().inThreadReplyEventId;
+        if (relation->type == EventRelation::ReplyType) {
+            return relation->eventId;
+        } else if (relation->type == EventRelation::ThreadType
+                   && (relation->isFallingBack == false || includeFallbacks)) {
+            return relation->inThreadReplyEventId;
         }
     }
     return {};
@@ -144,11 +144,49 @@ std::optional<EventRelation> RoomEvent::relatesTo() const
     return contentPart<std::optional<EventRelation>>(RelatesToKey);
 }
 
+void RoomEvent::setRelation(const EventRelation &er)
+{
+    editJson().insert(RelatesToKey, toJson(er));
+}
+
+void RoomEvent::clearRelation() { editJson().remove(RelatesToKey); }
+
+QJsonObject RoomEvent::relationsToThis() const
+{
+    return unsignedPart<QJsonObject>(RelationsKey);
+}
+
+bool RoomEvent::hasRelationship(EventRelation::typeid_t relationTypeId) const
+{
+    return relationsToThis().contains(relationTypeId);
+}
+
+QString RoomEvent::replacedEvent() const
+{
+    if (is<StateEvent>())
+        return {}; // State events can't be replaced
+
+    const auto er = relatesTo();
+    return er && er->type == EventRelation::ReplacementType && contentJson().contains(NewContentKey)
+               ? er->eventId
+               : QString();
+}
+
+bool RoomEvent::isReplaced() const
+{
+    return hasRelationship(EventRelation::ReplacementType);
+}
+
+QString RoomEvent::replacedBy() const
+{
+    return relationsToThis().value(EventRelation::ReplacementType)[EventIdKey].toString();
+}
+
 bool RoomEvent::isThreaded() const
 {
     const auto relation = relatesTo();
-    return (relation && relation.value().type == EventRelation::ThreadType)
-           || unsignedPart<QJsonObject>("m.relations"_L1).contains(EventRelation::ThreadType);
+    return (relation && relation->type == EventRelation::ThreadType)
+           || unsignedPart<QJsonObject>(RelationsKey).contains(EventRelation::ThreadType);
 }
 
 QString RoomEvent::threadRootEventId() const
@@ -156,7 +194,7 @@ QString RoomEvent::threadRootEventId() const
     if (const auto relation = relatesTo(); relation && relation->type == EventRelation::ThreadType) {
         return relation->eventId;
     }
-    if (unsignedPart<QJsonObject>("m.relations"_L1).contains(EventRelation::ThreadType)) {
+    if (unsignedPart<QJsonObject>(RelationsKey).contains(EventRelation::ThreadType)) {
         return id();
     }
     return {};

--- a/Quotient/events/roomevent.h
+++ b/Quotient/events/roomevent.h
@@ -108,6 +108,48 @@ public:
     //!         std::nullopt otherwise.
     std::optional<EventRelation> relatesTo() const;
 
+    //! \brief Set the event relation data
+    //!
+    //! Adds the relation to another event with the contents of \p er. If another relation
+    //! exists it is entirely overwritten.
+    void setRelation(const EventRelation &er);
+
+    //! \brief Remove the event relation data
+    //!
+    //! Clears any relation from this event to another event.
+    //! \sa setRelation
+    void clearRelation();
+
+    //! \brief Get relations to this event
+    //!
+    //! This is a counterpart of relatesTo(): it returns the list of (known, see the note) relations
+    //! to the current event.
+    //! \note This method uses `unsigned/m.relations` object that may not have fully accurate data.
+    //!       Use with caution.
+    QJsonObject relationsToThis() const;
+
+    //! \brief Check whether there are other events relating to this
+    //! \note This method uses `unsigned/m.relations` object that may not have fully accurate data.
+    //!       Use with caution.
+    bool hasRelationship(EventRelation::typeid_t relationTypeId) const;
+
+    //! \brief Obtain id of an event replaced by the current one
+    //! \sa RoomEvent::isReplaced, RoomEvent::replacedBy
+    QString replacedEvent() const;
+
+    //! \brief Determine whether the event has been replaced
+    //!
+    //! \return true if this event has been overridden by another event
+    //!         with `"rel_type": "m.replace"`; false otherwise
+    bool isReplaced() const;
+
+    //! \brief Get the id of the event that replaced this one
+    //!
+    //! \return The id of the replacement event if the current event has been replaced
+    //!         by another one; an empty string otherwise.
+    //! \sa isReplaced, replacedEvent
+    QString replacedBy() const;
+
     //! \brief Determine whether the event is part of a thread.
     //!
     //! \return true if this event is part of a thread, i.e. it has
@@ -129,6 +171,8 @@ public:
 protected:
     explicit RoomEvent(const QJsonObject& json);
     void dumpTo(QDebug dbg) const override;
+
+    virtual void afterRelationChange() {}
 
 private:
     QString _id;

--- a/Quotient/events/roommessageevent.cpp
+++ b/Quotient/events/roommessageevent.cpp
@@ -80,11 +80,6 @@ MsgTypeDesc jsonToMsgTypeDesc(const QString& matrixType)
     return { {}, MsgType::Unknown, false, nullptr };
 }
 
-inline bool isReplacement(const std::optional<EventRelation>& rel)
-{
-    return rel && rel->type == EventRelation::ReplacementType;
-}
-
 } // anonymous namespace
 
 QJsonObject RoomMessageEvent::assembleContentJson(const QString& plainBody,
@@ -249,31 +244,6 @@ bool RoomMessageEvent::has<LocationContent>() const
     return rawMsgtype() == LocationTypeId;
 }
 
-QString RoomMessageEvent::upstreamEventId() const
-{
-    const auto relation = relatesTo();
-    return relation ? relation.value().eventId : QString();
-}
-
-QString RoomMessageEvent::replacedEvent() const
-{
-    if (!has<TextContent>())
-        return {};
-
-    const auto er = relatesTo();
-    return isReplacement(er) ? er->eventId : QString();
-}
-
-bool RoomMessageEvent::isReplaced() const
-{
-    return unsignedPart<QJsonObject>("m.relations"_L1).contains(EventRelation::ReplacementType);
-}
-
-QString RoomMessageEvent::replacedBy() const
-{
-    return unsignedPart<QJsonObject>("m.relations"_L1)[EventRelation::ReplacementType][EventIdKey]
-        .toString();
-}
 
 namespace {
 QString safeFileName(QString rawName)

--- a/Quotient/events/roommessageevent.h
+++ b/Quotient/events/roommessageevent.h
@@ -93,28 +93,6 @@ public:
     //! Retrieve a thumbnail from the message event
     EventContent::Thumbnail getThumbnail() const;
 
-    //! \brief The upstream event ID for the relation.
-    //!
-    //! \warning If your client is not thread aware use replyEventId() as this will
-    //!          return the fallback reply ID so you can treat a threaded reply like a normal one.
-    //!
-    //! \warning If your client is thread aware use threadRootEventId() to get the
-    //!          thread root ID as this will return an empty string on the root event.
-    //!          threadRootEventId() will return the root messages ID on itself.
-    QString upstreamEventId() const;
-
-    //! \brief Obtain id of an event replaced by the current one
-    //! \sa RoomEvent::isReplaced, RoomEvent::replacedBy
-    QString replacedEvent() const;
-
-    //! \brief Determine whether the event has been replaced
-    //!
-    //! \return true if this event has been overridden by another event
-    //!         with `"rel_type": "m.replace"`; false otherwise
-    bool isReplaced() const;
-
-    QString replacedBy() const;
-
     QString fileNameToDownload() const;
 
     void updateFileSourceInfo(const FileSourceInfo& fsi);

--- a/quotest/quotest.cpp
+++ b/quotest/quotest.cpp
@@ -451,8 +451,15 @@ TEST_IMPL(sendReaction)
                              FAIL_TEST_IF(reactions.size() != 1);
 
                              const auto* evt = eventCast<const ReactionEvent>(reactions.back());
-                             FINISH_TEST(is<ReactionEvent>(*evt) && !evt->id().isEmpty()
-                                         && evt->key() == key && evt->transactionId() == txnId);
+                             FAIL_TEST_IF(!is<ReactionEvent>(*evt) || evt->id().isEmpty()
+                                         || evt->key() != key || evt->transactionId() != txnId,
+                                         "Reaction event validation failed");
+
+                             // Test the new RoomEvent relation API
+                             const auto relation = evt->relatesTo();
+                             FINISH_TEST(relation && relation->type == EventRelation::AnnotationType
+                                        && relation->eventId == targetEvtId
+                                        && relation->key == key);
                              // TODO: Test removing the reaction
                          });
             return false;
@@ -882,26 +889,56 @@ TEST_IMPL(visitResources)
 TEST_IMPL(thread)
 {
     auto rootTxnId = targetRoom->postText("Threadroot"_L1);
-    connect(targetRoom, &Room::pendingEventAboutToMerge, this, [this, thisTest, rootTxnId](Quotient::RoomEvent* rootEvt) {
-        if (rootEvt->transactionId() == rootTxnId) {
-            const auto relation = EventRelation::replyInThread(rootEvt->id(), true, rootEvt->id());
-            targetRoom->post<Quotient::RoomMessageEvent>(u"Thread reply 1"_s, Quotient::RoomMessageEvent::MsgType::Text, nullptr, relation)
-                .whenMerged()
-                .then([this, thisTest](const RoomEvent& replyEvt) {
-                    replyEvt.switchOnType(
-                        [&](const RoomMessageEvent& rmReplyEvt) {
-                            const auto thread = targetRoom->threads()[rmReplyEvt.threadRootEventId()];
-                            FINISH_TEST(thread.threadRootId == rmReplyEvt.threadRootEventId() &&
-                                        thread.latestEventId == rmReplyEvt.id() &&
-                                        thread.size == 2
-                            );
-                        },
-                        [this, thisTest](const RoomEvent&) { FAIL_TEST(); }
-                    );
-                });
-        }
-    });
+    connectUntil(targetRoom, &Room::pendingEventAboutToMerge, this,
+                 [this, thisTest, rootTxnId](RoomEvent *rootEvt) {
+        if (rootEvt->transactionId() != rootTxnId)
+            return false;
 
+        const auto rootEvtId = rootEvt->id();
+        // Create a reply event without a relation, to test setRelation()
+        auto replyEvent =
+            makeEvent<RoomMessageEvent>(u"Thread reply 1"_s, RoomMessageEvent::MsgType::Text);
+        replyEvent->setRelation(EventRelation::replyInThread(rootEvtId, true, rootEvtId));
+
+        const auto setRelation = replyEvent->relatesTo();
+        FAIL_TEST_IF(!setRelation || setRelation->type != EventRelation::ThreadType
+                         || setRelation->eventId != rootEvtId,
+                     "Relation not set correctly after setRelation()");
+
+        const auto &pendingItem = targetRoom->post(std::move(replyEvent));
+        const auto replyTxnId = pendingItem->transactionId();
+
+        targetRoom->whenMessageMerged(replyTxnId)
+            .then(this, [this, thisTest, rootEvtId](const RoomEvent &replyEvt) {
+            replyEvt.switchOnType([&](const RoomMessageEvent &mergedReply) {
+                const auto relation = mergedReply.relatesTo();
+                FAIL_TEST_IF(!relation, "No relation on merged event");
+                FAIL_TEST_IF(relation->type != EventRelation::ThreadType,
+                             "Incorrect relation type on merged event");
+                FAIL_TEST_IF(relation->eventId != rootEvtId,
+                             "Thread root eventId doesn't match on merged event");
+
+                FAIL_TEST_IF(!mergedReply.isThreaded(),
+                             "isThreaded() returned false for thread reply");
+                FAIL_TEST_IF(mergedReply.threadRootEventId() != rootEvtId,
+                             "threadRootEventId() doesn't match root");
+
+                // Threaded events are considered replies as a fallback; they are not "normal"
+                // one-off replies
+                FAIL_TEST_IF(!mergedReply.isReply(true),
+                             "isReply() with fallbacks still returned false for thread reply");
+                FAIL_TEST_IF(mergedReply.isReply(false),
+                             "isReply() without fallbacks considered a threaded event as a reply");
+                FAIL_TEST_IF(mergedReply.replyEventId(true) != rootEvtId,
+                             "replyEventId() doesn't match root");
+
+                const auto thread = targetRoom->threads()[mergedReply.threadRootEventId()];
+                FINISH_TEST(thread.threadRootId == mergedReply.threadRootEventId()
+                            && thread.latestEventId == mergedReply.id() && thread.size == 2);
+            }, [this, thisTest](const RoomEvent &) { FAIL_TEST(); });
+        });
+        return true;
+    });
     return false;
 }
 

--- a/quotest/quotest.cpp
+++ b/quotest/quotest.cpp
@@ -109,6 +109,7 @@ private slots:
     TEST_DECL(markDirectChat)
     TEST_DECL(visitResources)
     TEST_DECL(thread)
+    TEST_DECL(reply)
     // Add more tests above here
 
 public:
@@ -940,6 +941,49 @@ TEST_IMPL(thread)
         return true;
     });
     return false;
+}
+
+TEST_IMPL(reply)
+{
+    return targetRoom->post<RoomMessageEvent>(u"Reply target"_s)
+        .whenMerged()
+        .then([this, thisTest](const RoomEvent &rootEvt) {
+        const auto rootEvtId = rootEvt.id();
+        const auto replyRelation = EventRelation::replyTo(rootEvtId);
+        auto replyEvent = makeEvent<RoomMessageEvent>(u"Reply message"_s,
+                                                      RoomMessageEvent::MsgType::Text, nullptr,
+                                                      replyRelation);
+
+        const auto setRelation = replyEvent->relatesTo();
+        FAIL_TEST_IF(!setRelation || setRelation->type != EventRelation::ReplyType
+                         || setRelation->eventId != rootEvtId,
+                     "Relation not set correctly after setRelation()");
+
+        replyEvent->clearRelation();
+        FAIL_TEST_IF(replyEvent->relatesTo().has_value(),
+                     "Relation still exists after clearRelation()");
+
+        // Restore the reply relation
+        replyEvent->setRelation(replyRelation);
+
+        targetRoom->post(std::move(replyEvent))
+            .whenMerged()
+            .then([this, thisTest, rootEvtId](const RoomEvent &replyEvt) {
+            replyEvt.switchOnType([&](const RoomMessageEvent &mergedReply) {
+                const auto relation = mergedReply.relatesTo();
+                FAIL_TEST_IF(!relation || relation->type != EventRelation::ReplyType,
+                             "None or incorrect relation on merged event");
+                FAIL_TEST_IF(relation->eventId != rootEvtId,
+                             "Replied-to eventId doesn't match on merged event");
+
+                FAIL_TEST_IF(mergedReply.isThreaded(),
+                             "Non-thread replies should not be considered threaded");
+                FAIL_TEST_IF(!mergedReply.isReply(), "isReply() returned false for reply");
+                FINISH_TEST(mergedReply.replyEventId() == rootEvtId);
+            }, [this, thisTest](const RoomEvent &) { FAIL_TEST(); });
+        });
+        return true;
+    }).isRunning();
 }
 
 void TestManager::conclude()


### PR DESCRIPTION
The first commit has most of it. Further on, we _might_ deprecate passing `EventRelation` to `RoomMessageEvent` constructor, recommending to use `setRelation()` instead; or we might not. The API shape, anything missing/extraneous - everything debatable.

The `Thread` API and logic will be adjusted in a separate PR.

In full disclosure, the refactoring and some parts of the code were made with Cursor assistance; all lines reviewed by myself.