### PR TITLE
Code cleanup

### DIFF
--- a/Quotient/events/encryptedevent.cpp
+++ b/Quotient/events/encryptedevent.cpp
@@ -49,7 +49,9 @@ RoomEventPtr EncryptedEvent::createDecrypted(const QString &decrypted) const
     return loadEvent<RoomEvent>(eventObject);
 }
 
-void EncryptedEvent::setRelation(const QJsonObject& relation)
+void EncryptedEvent::applyRelationFrom(const RoomEvent &unencryptedEvent)
 {
-    replaceSubvalue(editJson(), ContentKey, RelatesToKey, relation);
+    if (const auto relation = unencryptedEvent.contentPart<QJsonObject>(RelatesToKey);
+        !relation.isEmpty())
+        replaceSubvalue(editJson(), ContentKey, RelatesToKey, relation);
 }

--- a/Quotient/events/encryptedevent.h
+++ b/Quotient/events/encryptedevent.h
@@ -64,7 +64,7 @@ public:
     QString sessionId() const { return contentPart<QString>(SessionIdKey); }
     RoomEventPtr createDecrypted(const QString &decrypted) const;
 
-    void setRelation(const QJsonObject& relation);
+    void applyRelationFrom(const RoomEvent& unencryptedEvent);
 };
 
 class QUOTIENT_API DummyEvent : public Event {

--- a/Quotient/events/roomevent.cpp
+++ b/Quotient/events/roomevent.cpp
@@ -191,7 +191,7 @@ bool RoomEvent::isThreaded() const
 {
     const auto relation = relatesTo();
     return (relation && relation->type == EventRelation::ThreadType)
-           || unsignedPart<QJsonObject>(RelationsKey).contains(EventRelation::ThreadType);
+           || hasRelationship(EventRelation::ThreadType);
 }
 
 QString RoomEvent::threadRootEventId() const
@@ -199,7 +199,7 @@ QString RoomEvent::threadRootEventId() const
     if (const auto relation = relatesTo(); relation && relation->type == EventRelation::ThreadType) {
         return relation->eventId;
     }
-    if (unsignedPart<QJsonObject>(RelationsKey).contains(EventRelation::ThreadType)) {
+    if (hasRelationship(EventRelation::ThreadType)) {
         return id();
     }
     return {};

--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -2138,9 +2138,7 @@ const PendingEventItem& Room::Private::doSendEvent(PendingEvents::iterator event
         encryptedEvent->setTransactionId(connection->generateTxnId());
         encryptedEvent->setRoomId(id);
         encryptedEvent->setSender(connection->userId());
-        if (eventItem->contentJson().contains(RelatesToKey)) {
-            encryptedEvent->setRelation(eventItem->contentJson()[RelatesToKey].toObject());
-        }
+        encryptedEvent->applyRelationFrom(*eventItem);
         // We show the unencrypted event locally while pending. The echo
         // check will throw the encrypted version out
         _event = encryptedEvent.get();

--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -1884,7 +1884,7 @@ void Room::Private::updateThread(const RoomEvent* event)
 
     auto& thread = threads[event->threadRootEventId()];
     const auto isNew = thread.threadRootId.isEmpty();
-    if (thread.threadRootId.isEmpty()) {
+    if (isNew) {
         thread.threadRootId = event->threadRootEventId();
         // If we can't find the root we assume it's a historical event and will be loaded later.
         if (auto rootIt = q->findInTimeline(thread.threadRootId); rootIt != historyEdge()) {

--- a/autotests/testolmaccount.cpp
+++ b/autotests/testolmaccount.cpp
@@ -173,7 +173,7 @@ void TestOlmAccount::encryptedFile()
 
 void TestOlmAccount::uploadIdentityKey()
 {
-    CREATE_CONNECTION(conn, "alice1"_L1, "secret"_L1, "AlicePhone"_L1)
+    CREATE_CONNECTION(conn, "alice1"_L1, "secret"_L1, "AlicePhone"_L1);
 
     auto olmAccount = conn->olmAccount();
     auto idKeys = olmAccount->identityKeys();
@@ -196,7 +196,7 @@ void TestOlmAccount::uploadIdentityKey()
 
 void TestOlmAccount::uploadOneTimeKeys()
 {
-    CREATE_CONNECTION(conn, "alice2"_L1, "secret"_L1, "AlicePhone"_L1)
+    CREATE_CONNECTION(conn, "alice2"_L1, "secret"_L1, "AlicePhone"_L1);
     auto olmAccount = conn->olmAccount();
 
     auto nKeys = olmAccount->generateOneTimeKeys(5);
@@ -219,7 +219,7 @@ void TestOlmAccount::uploadOneTimeKeys()
 
 void TestOlmAccount::uploadSignedOneTimeKeys()
 {
-    CREATE_CONNECTION(conn, "alice3"_L1, "secret"_L1, "AlicePhone"_L1)
+    CREATE_CONNECTION(conn, "alice3"_L1, "secret"_L1, "AlicePhone"_L1);
     auto olmAccount = conn->olmAccount();
     auto nKeys = olmAccount->generateOneTimeKeys(5);
     QCOMPARE(nKeys, 5);
@@ -238,7 +238,7 @@ void TestOlmAccount::uploadSignedOneTimeKeys()
 
 void TestOlmAccount::uploadKeys()
 {
-    CREATE_CONNECTION(conn, "alice4"_L1, "secret"_L1, "AlicePhone"_L1)
+    CREATE_CONNECTION(conn, "alice4"_L1, "secret"_L1, "AlicePhone"_L1);
     auto olmAccount = conn->olmAccount();
     auto idks = olmAccount->identityKeys();
     olmAccount->generateOneTimeKeys(1);
@@ -254,8 +254,8 @@ void TestOlmAccount::uploadKeys()
 
 void TestOlmAccount::queryTest()
 {
-    CREATE_CONNECTION(alice, "alice5"_L1, "secret"_L1, "AlicePhone"_L1)
-    CREATE_CONNECTION(bob, "bob1"_L1, "secret"_L1, "BobPhone"_L1)
+    CREATE_CONNECTION(alice, "alice5"_L1, "secret"_L1, "AlicePhone"_L1);
+    CREATE_CONNECTION(bob, "bob1"_L1, "secret"_L1, "BobPhone"_L1);
 
     // Create and upload keys for both users.
     auto aliceOlm = alice->olmAccount();
@@ -314,8 +314,8 @@ void TestOlmAccount::queryTest()
 
 void TestOlmAccount::claimKeys()
 {
-    CREATE_CONNECTION(alice, "alice6"_L1, "secret"_L1, "AlicePhone"_L1)
-    CREATE_CONNECTION(bob, "bob2"_L1, "secret"_L1, "BobPhone"_L1)
+    CREATE_CONNECTION(alice, "alice6"_L1, "secret"_L1, "AlicePhone"_L1);
+    CREATE_CONNECTION(bob, "bob2"_L1, "secret"_L1, "BobPhone"_L1);
 
     // Bob uploads his keys.
     auto *bobOlm = bob->olmAccount();
@@ -369,9 +369,9 @@ void TestOlmAccount::claimKeys()
 void TestOlmAccount::claimMultipleKeys()
 {
     // Login with alice multiple times
-    CREATE_CONNECTION(alice, "alice7"_L1, "secret"_L1, "AlicePhone"_L1)
-    CREATE_CONNECTION(alice1, "alice7"_L1, "secret"_L1, "AlicePhone"_L1)
-    CREATE_CONNECTION(alice2, "alice7"_L1, "secret"_L1, "AlicePhone"_L1)
+    CREATE_CONNECTION(alice, "alice7"_L1, "secret"_L1, "AlicePhone"_L1);
+    CREATE_CONNECTION(alice1, "alice7"_L1, "secret"_L1, "AlicePhone"_L1);
+    CREATE_CONNECTION(alice2, "alice7"_L1, "secret"_L1, "AlicePhone"_L1);
 
     auto olm = alice->olmAccount();
     olm->generateOneTimeKeys(10);
@@ -401,7 +401,7 @@ void TestOlmAccount::claimMultipleKeys()
     QVERIFY(waitForJob(alice2UploadKeyRequest));
 
     // Bob will claim keys from all Alice's devices
-    CREATE_CONNECTION(bob, "bob3"_L1, "secret"_L1, "BobPhone"_L1)
+    CREATE_CONNECTION(bob, "bob3"_L1, "secret"_L1, "BobPhone"_L1);
 
     QHash<QString, QHash<QString, QString>> oneTimeKeys;
     auto keyRequests = oneTimeKeys.insert(alice->userId(), {});
@@ -417,7 +417,7 @@ void TestOlmAccount::claimMultipleKeys()
 
 void TestOlmAccount::enableEncryption()
 {
-    CREATE_CONNECTION(alice, "alice9"_L1, "secret"_L1, "AlicePhone"_L1)
+    CREATE_CONNECTION(alice, "alice9"_L1, "secret"_L1, "AlicePhone"_L1);
 
     auto createRoomJob = alice->createRoom(Connection::PublishRoom, {}, {}, {}, {});
     auto futureEncryptedRoom = createRoomJob.then([alice](const QString& roomId) {

--- a/autotests/testutils.h
+++ b/autotests/testutils.h
@@ -27,8 +27,9 @@ inline event_ptr_tt<EventT> loadEventFromFile(const QString &eventFileName)
     if (!eventFileName.isEmpty()) {
         QFile testEventFile;
         testEventFile.setFileName(QLatin1StringView(DATA_DIR) + u'/' + eventFileName);
-        testEventFile.open(QIODevice::ReadOnly);
-        return loadEvent<EventT>(QJsonDocument::fromJson(testEventFile.readAll()).object());
+        return testEventFile.open(QIODevice::ReadOnly)
+                   ? loadEvent<EventT>(QJsonDocument::fromJson(testEventFile.readAll()).object())
+                   : nullptr;
     }
     return nullptr;
 }
@@ -36,16 +37,24 @@ inline event_ptr_tt<EventT> loadEventFromFile(const QString &eventFileName)
 
 #define CREATE_CONNECTION(VAR, USERNAME, SECRET, DEVICE_NAME)             \
     const auto VAR = createTestConnection(USERNAME, SECRET, DEVICE_NAME); \
-    if (!VAR)                                                             \
-        QFAIL("Could not set up test connection");
+    do {                                                                  \
+        if (!VAR)                                                         \
+            QFAIL("Could not set up test connection");                    \
+    } while (false)
 
 template <typename JobT>
 inline bool waitForJob(const Quotient::JobHandle<JobT>& job)
 {
+    using namespace std::chrono_literals;
     const auto& [timeouts, retryIntervals, _] = job->currentBackoffStrategy();
     return QTest::qWaitFor([job] { return job.isFinished(); },
+#ifdef __cpp_lib_ranges_fold // libc 20 and Apple Clang 16 still don't have it
+                           (std::ranges::fold_left(timeouts, 0ms, std::plus{})
+                            + std::ranges::fold_left(retryIntervals, 0ms, std::plus{}))
+#else
                            std::chrono::milliseconds(
                                std::reduce(timeouts.cbegin(), timeouts.cend())
                                + std::reduce(retryIntervals.cbegin(), retryIntervals.cend()))
+#endif
                                .count());
 }


### PR DESCRIPTION
Mostly an assortment of trivial stuff, the most significant is the rename in the first commit - I don't think EncryptedEvent::setRelation() has been (should have been) used anywhere outside the library, so should be fine.