### PR TITLE
Add missing hasOlmSession check in sendToDevice

### DIFF
--- a/Quotient/connection.cpp
+++ b/Quotient/connection.cpp
@@ -1838,6 +1838,10 @@ void Connection::sendToDevice(const QString& targetUserId,
         return;
     }
 
+    if (encrypted && !d->encryptionData->hasOlmSession(targetUserId, targetDeviceId)) {
+        return;
+    }
+
     const auto contentJson =
         encrypted
             ? d->encryptionData->assembleEncryptedContent(event.fullJson(),

--- a/Quotient/connection.cpp
+++ b/Quotient/connection.cpp
@@ -1832,24 +1832,25 @@ void Connection::sendToDevice(const QString& targetUserId,
                               const QString& targetDeviceId, const Event& event,
                               bool encrypted)
 {
-    if (encrypted && !d->encryptionData) {
+    if (!encrypted) {
+        sendToDevices(event.matrixType(), {{targetUserId, {{targetDeviceId, event.contentJson()}}}});
+        return;
+    }
+
+    if (!d->encryptionData) {
         qWarning(E2EE) << "E2EE is off for" << objectName()
                        << "- no encrypted to-device message will be sent";
         return;
     }
-
-    if (encrypted && !d->encryptionData->hasOlmSession(targetUserId, targetDeviceId)) {
+    if (!d->encryptionData->hasOlmSession(targetUserId, targetDeviceId)) {
+        qWarning(E2EE) << "Olm session for" << targetUserId << '/' << targetDeviceId
+                       << "is missing, to-device message won't be sent";
         return;
     }
-
-    const auto contentJson =
-        encrypted
-            ? d->encryptionData->assembleEncryptedContent(event.fullJson(),
-                                                          targetUserId,
-                                                          targetDeviceId)
-            : event.contentJson();
-    sendToDevices(encrypted ? EncryptedEvent::TypeId : event.matrixType(),
-                  { { targetUserId, { { targetDeviceId, contentJson } } } });
+    sendToDevices(EncryptedEvent::TypeId,
+                  {{targetUserId,
+                    {{targetDeviceId, d->encryptionData->assembleEncryptedContent(
+                                          event.fullJson(), targetUserId, targetDeviceId)}}}});
 }
 
 bool Connection::isVerifiedSession(const QByteArray& megolmSessionId) const


### PR DESCRIPTION
There is a rare bug we saw in NeoChat that caused a crash because of accessing a non-existent session. This is kind of fine because it's a well-documented behavior in assembleEncryptedContent etc. and this has to be checked at the call-site. Connection's sendToDevice did not however, but now that's fixed.

Link: https://bugs.kde.org/show_bug.cgi?id=514777