### PR TITLE
Connection::join(AndGet)Room(): return the right room object

### DIFF
--- a/Quotient/connection.cpp
+++ b/Quotient/connection.cpp
@@ -669,13 +669,13 @@ JobHandle<JoinRoomJob> Connection::joinRoom(const QString& roomAlias, const QStr
     // If the room object is not there, provideRoom() will create it in Join state. Using
     // the continuation ensures that the room is provided before any client connections.
     return callApi<JoinRoomJob>(roomAlias, serverNames, serverNames)
-        .then([this](const QString& roomId) { provideRoom(roomId); });
+        .then([this](const QString& roomId) { provideRoom(roomId, JoinState::Join); });
 }
 
 QFuture<Room*> Connection::joinAndGetRoom(const QString& roomAlias, const QStringList& serverNames)
 {
     return callApi<JoinRoomJob>(roomAlias, serverNames, serverNames)
-        .then([this](const QString& roomId) { return provideRoom(roomId); });
+        .then([this](const QString& roomId) { return provideRoom(roomId, JoinState::Join); });
 }
 
 QFuture<Room *> Connection::waitForNewRoom(const QString &roomId)


### PR DESCRIPTION
At the moment JoinRoomJob completes it's most likely that sync hasn't brought the newly joined room yet. By default provideRoom() returns any room object it can find, in Invite or Join state; so if there is an outstanding invite at the moment of joining, provideRoom() will return the room object in Invite state, rather than create a new one in Joined state. This is surprising for the caller (you get a room in Joined state if you weren't invited but in Invite state if you were), useless (the caller has to separately connect to joinedRoom to get the right object) and borderline harmful because the room object in Invite state is getting deleted right after the sync brings the actual joined room.

Because we can't meaningfully populate the room with data before the sync for it arrives, the created and returned room object only has its id but is otherwise empty. You can already start sending events to it (useful for bots and tests) but you can't check literally anything about it - the object doesn't even know the freshly joined member.

Ideally, the event queueing+sending logic should be pulled out of Room to some kind of EventSender state machine, and Room would only be created from the first sync batch, in a proper RAII fashion. But we're far from being there yet.