### PR TITLE
Don't show the original event when loading historical messages

### DIFF
--- a/Quotient/eventitem.h
+++ b/Quotient/eventitem.h
@@ -23,16 +23,15 @@ namespace EventStatus {
      * All values except Redacted and Hidden are mutually exclusive.
      */
     enum Code : uint16_t {
-        Normal = 0x0, ///< No special designation
-        Submitted = 0x01, ///< The event has just been submitted for sending
-        FileUploaded = 0x02, ///< The file attached to the event has been
-                             ///  uploaded to the server
-        Departed = 0x03, ///< The event has left the client
-        ReachedServer = 0x04, ///< The server has received the event
-        SendingFailed = 0x05, ///< The server could not receive the event
-        Redacted = 0x08, ///< The event has been redacted
-        Replaced = 0x10, ///< The event has been replaced
-        Hidden = 0x100, ///< The event should not be shown in the timeline
+        Normal = 0x0,         //!< No special designation
+        Submitted = 0x01,     //!< The event has just been submitted for sending
+        FileUploaded = 0x02,  //!< The file attached to the event has been uploaded to the server
+        Departed = 0x03,      //!< The event has left the client
+        ReachedServer = 0x04, //!< The server has received the event
+        SendingFailed = 0x05, //!< The server could not receive the event
+        Redacted = 0x08,      //!< The event has been redacted
+        Replaced = 0x10,      //!< The event has been replaced
+        Hidden = 0x100,       //!< The event should not be shown in the timeline
     };
     Q_ENUM_NS(Code)
 } // namespace EventStatus

--- a/Quotient/events/roomevent.cpp
+++ b/Quotient/events/roomevent.cpp
@@ -5,8 +5,9 @@
 
 #include "encryptedevent.h"
 #include "redactionevent.h"
-#include "stateevent.h"
-
+#include "roomcreateevent.h"
+#include "roommemberevent.h"
+#include "roompowerlevelsevent.h"
 #include "../logging_categories_p.h"
 
 using namespace Quotient;
@@ -42,6 +43,57 @@ QString RoomEvent::senderId() const
 QString RoomEvent::redactionReason() const
 {
     return isRedacted() ? _redactedBecause->reason() : QString {};
+}
+
+event_ptr_tt<RoomEvent> RoomEvent::makeRedacted(const RedactionEvent &redaction) const
+{
+    // The logic below faithfully follows the spec despite quite a few of
+    // the preserved keys being only relevant for homeservers. Just in case.
+    static const QStringList TopLevelKeysToKeep{
+        EventIdKey,  TypeKey,          RoomIdKey,        SenderKey,
+        StateKeyKey, ContentKey,       "hashes"_L1,      "signatures"_L1,
+        "depth"_L1,  "prev_events"_L1, "auth_events"_L1, "origin_server_ts"_L1
+    };
+
+    auto originalJson = this->fullJson();
+    for (auto it = originalJson.begin(); it != originalJson.end();) {
+        if (!TopLevelKeysToKeep.contains(it.key()))
+            it = originalJson.erase(it);
+        else
+            ++it;
+    }
+    if (!this->is<RoomCreateEvent>()) { // See MSC2176 on create events
+        static const QHash<QString, QStringList> ContentKeysToKeepPerType{
+            { RedactionEvent::TypeId, { "redacts"_L1 } },
+            { RoomMemberEvent::TypeId,
+              { "membership"_L1, "join_authorised_via_users_server"_L1 } },
+            { RoomPowerLevelsEvent::TypeId,
+              { "ban"_L1, "events"_L1, "events_default"_L1, "invite"_L1,
+                "kick"_L1, "redact"_L1, "state_default"_L1, "users"_L1,
+                "users_default"_L1 } },
+            // TODO: Replace with RoomJoinRules::TypeId etc. once available
+            { "m.room.join_rules"_L1, { "join_rule"_L1, "allow"_L1 } },
+            { "m.room.history_visibility"_L1, { "history_visibility"_L1 } }
+        };
+
+        if (const auto contentKeysToKeep = ContentKeysToKeepPerType.value(this->matrixType());
+            !contentKeysToKeep.isEmpty()) {
+            editSubobject(originalJson, ContentKey, [&contentKeysToKeep](QJsonObject& content) {
+                for (auto it = content.begin(); it != content.end();) {
+                    if (!contentKeysToKeep.contains(it.key()))
+                        it = content.erase(it);
+                    else
+                        ++it;
+                }
+            });
+        } else {
+            originalJson.remove(ContentKey);
+            originalJson.remove(PrevContentKey);
+        }
+    }
+    replaceSubvalue(originalJson, UnsignedKey, RedactedCauseKey, redaction.fullJson());
+
+    return loadEvent<RoomEvent>(originalJson);
 }
 
 QString RoomEvent::transactionId() const
@@ -185,6 +237,21 @@ bool RoomEvent::isReplaced() const
 QString RoomEvent::replacedBy() const
 {
     return relationsToThis().value(EventRelation::ReplacementType)[EventIdKey].toString();
+}
+
+event_ptr_tt<RoomEvent> RoomEvent::makeReplaced(const RoomEvent &replacement) const
+{
+    // See https://spec.matrix.org/latest/client-server-api/#applying-mnew_content
+    auto newContent = replacement.contentPart<QJsonObject>(NewContentKey);
+    addParam<IfNotEmpty>(newContent, RelatesToKey, this->contentPart<QJsonObject>(RelatesToKey));
+    auto originalJson = this->fullJson();
+    originalJson.insert(ContentKey, newContent);
+    editSubobject(originalJson, UnsignedKey, [&replacement](QJsonObject &unsignedData) {
+        replaceSubvalue(unsignedData, RelationsKey, EventRelation::ReplacementType,
+                        replacement.id());
+    });
+
+    return loadEvent<RoomEvent>(originalJson);
 }
 
 bool RoomEvent::isThreaded() const

--- a/Quotient/events/roomevent.h
+++ b/Quotient/events/roomevent.h
@@ -46,6 +46,13 @@ public:
     }
     QString redactionReason() const;
 
+    //! \brief Make a redacted event
+    //!
+    //! This applies the redaction procedure as defined by the CS API specification to the event's
+    //! JSON and returns the resulting new event.
+    //! \note It is the responsibility of the caller to dispose of the original event after that.
+    event_ptr_tt<RoomEvent> makeRedacted(const RedactionEvent &redaction) const;
+
     //! The transaction_id JSON value for the event.
     QString transactionId() const;
 
@@ -149,6 +156,13 @@ public:
     //!         by another one; an empty string otherwise.
     //! \sa isReplaced, replacedEvent
     QString replacedBy() const;
+
+    //! \brief Make a replaced event
+    //!
+    //! \returns a clone of `*this` with content taken from \p replacement as described in
+    //!          https://spec.matrix.org/latest/client-server-api/#applying-mnew_content
+    //! \note Disposal of the original event after that is on the caller.
+    event_ptr_tt<RoomEvent> makeReplaced(const RoomEvent &replacementEvent) const;
 
     //! \brief Determine whether the event is part of a thread.
     //!

--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -199,8 +199,8 @@ public:
     /// A map from event/txn ids to information about the long operation;
     /// used for both download and upload operations
     QHash<QString, FileTransferPrivateInfo> fileTransfers;
-    /// A map of orphans of replacement events that are still looking for their related event in the past.
-    /// The key is the target event ID, and the value is the replacement event ID.
+    //! A map of orphans of replacement events that are still looking for their related event in the
+    //! past. The key is the target event ID, and the value is the replacement event ID.
     QHash<QString, QString> orphanedReplacementEvents;
 
     const RoomMessageEvent* getEventWithFile(const QString& eventId) const;
@@ -338,7 +338,7 @@ public:
      * content passed in \p newEvent.
      * \return true if the event has been found and replaced; false otherwise
      */
-    bool processReplacement(const RoomMessageEvent& newEvent);
+    bool processReplacement(const RoomEvent &newEvent);
 
     void setTags(TagsMap&& newTags);
 
@@ -2700,64 +2700,6 @@ void Room::Private::decryptIncomingEvents(RoomEvents& events)
             << "Decrypted" << totalDecrypted << "events in" << et;
 }
 
-//! \brief Make a redacted event
-//!
-//! This applies the redaction procedure as defined by the CS API specification
-//! to the event's JSON and returns the resulting new event. It is
-//! the responsibility of the caller to dispose of the original event after that.
-RoomEventPtr makeRedacted(const RoomEvent& target,
-                          const RedactionEvent& redaction)
-{
-    // The logic below faithfully follows the spec despite quite a few of
-    // the preserved keys being only relevant for homeservers. Just in case.
-    static const QStringList TopLevelKeysToKeep{
-        EventIdKey,  TypeKey,          RoomIdKey,        SenderKey,
-        StateKeyKey, ContentKey,       "hashes"_L1,      "signatures"_L1,
-        "depth"_L1,  "prev_events"_L1, "auth_events"_L1, "origin_server_ts"_L1
-    };
-
-    auto originalJson = target.fullJson();
-    for (auto it = originalJson.begin(); it != originalJson.end();) {
-        if (!TopLevelKeysToKeep.contains(it.key()))
-            it = originalJson.erase(it);
-        else
-            ++it;
-    }
-    if (!target.is<RoomCreateEvent>()) { // See MSC2176 on create events
-        static const QHash<QString, QStringList> ContentKeysToKeepPerType{
-            { RedactionEvent::TypeId, { "redacts"_L1 } },
-            { RoomMemberEvent::TypeId,
-              { "membership"_L1, "join_authorised_via_users_server"_L1 } },
-            { RoomPowerLevelsEvent::TypeId,
-              { "ban"_L1, "events"_L1, "events_default"_L1, "invite"_L1,
-                "kick"_L1, "redact"_L1, "state_default"_L1, "users"_L1,
-                "users_default"_L1 } },
-            // TODO: Replace with RoomJoinRules::TypeId etc. once available
-            { "m.room.join_rules"_L1, { "join_rule"_L1, "allow"_L1 } },
-            { "m.room.history_visibility"_L1, { "history_visibility"_L1 } }
-        };
-
-        if (const auto contentKeysToKeep = ContentKeysToKeepPerType.value(target.matrixType());
-            !contentKeysToKeep.isEmpty()) //
-        {
-            editSubobject(originalJson, ContentKey, [&contentKeysToKeep](QJsonObject& content) {
-                for (auto it = content.begin(); it != content.end();) {
-                    if (!contentKeysToKeep.contains(it.key()))
-                        it = content.erase(it);
-                    else
-                        ++it;
-                }
-            });
-        } else {
-            originalJson.remove(ContentKey);
-            originalJson.remove(PrevContentKey);
-        }
-    }
-    replaceSubvalue(originalJson, UnsignedKey, RedactedCauseKey, redaction.fullJson());
-
-    return loadEvent<RoomEvent>(originalJson);
-}
-
 bool Room::Private::processRedaction(const RedactionEvent& redaction)
 {
     // Can't use findInTimeline because it returns a const iterator, and
@@ -2779,7 +2721,7 @@ bool Room::Private::processRedaction(const RedactionEvent& redaction)
 
     // Make a new event from the redacted JSON and put it in the timeline
     // instead of the redacted one. oldEvent will be deleted on return.
-    auto oldEvent = ti.replaceEvent(makeRedacted(*ti, redaction));
+    auto oldEvent = ti.replaceEvent(ti->makeRedacted(redaction));
     qCDebug(EVENTS) << "Redacted" << oldEvent->id() << "with" << redaction.id();
     if (oldEvent->isStateEvent()) {
         // Check whether the old event was a part of current state; if it was,
@@ -2813,27 +2755,11 @@ bool Room::Private::processRedaction(const RedactionEvent& redaction)
     return true;
 }
 
-/** Make a replaced event
- *
- * Takes \p target and returns a copy of it with content taken from
- * \p replacement. Disposal of the original event after that is on the caller.
- */
-RoomEventPtr makeReplaced(const RoomEvent& target,
-                          const RoomMessageEvent& replacement)
+bool Room::Private::processReplacement(const RoomEvent &newEvent)
 {
-    auto newContent = replacement.contentPart<QJsonObject>(NewContentKey);
-    addParam<IfNotEmpty>(newContent, RelatesToKey, target.contentPart<QJsonObject>(RelatesToKey));
-    auto originalJson = target.fullJson();
-    originalJson[ContentKey] = newContent;
-    editSubobject(originalJson, UnsignedKey, [&replacement](QJsonObject& unsignedData) {
-        replaceSubvalue(unsignedData, RelationsKey, EventRelation::ReplacementType, replacement.id());
-    });
+    if (QUO_ALARM_X(newEvent.isStateEvent(), "Replacing state events is not allowed"))
+        return false;
 
-    return loadEvent<RoomEvent>(originalJson);
-}
-
-bool Room::Private::processReplacement(const RoomMessageEvent& newEvent)
-{
     // Can't use findInTimeline because it returns a const iterator, and
     // we need to change the underlying TimelineItem.
     const auto pIdx = eventsIndex.constFind(newEvent.replacedEvent());
@@ -2843,13 +2769,7 @@ bool Room::Private::processReplacement(const RoomMessageEvent& newEvent)
     Q_ASSERT(q->isValidIndex(*pIdx));
 
     auto& ti = timeline[Timeline::size_type(*pIdx - q->minTimelineIndex())];
-    const auto* const rme = ti.viewAs<RoomMessageEvent>();
-    if (!rme) {
-        qCWarning(STATE) << "Ignoring attempt to replace a non-message event"
-                         << ti->id();
-        return false;
-    }
-    if (rme->replacedBy() == newEvent.id()) {
+    if (ti->replacedBy() == newEvent.id()) {
         qCDebug(STATE) << "Event" << ti->id() << "is already replaced with"
                        << newEvent.id();
         return true;
@@ -2857,7 +2777,7 @@ bool Room::Private::processReplacement(const RoomMessageEvent& newEvent)
 
     // Make a new event from the redacted JSON and put it in the timeline
     // instead of the redacted one. oldEvent will be deleted on return.
-    auto oldEvent = ti.replaceEvent(makeReplaced(*ti, newEvent));
+    auto oldEvent = ti.replaceEvent(ti->makeReplaced(newEvent));
     qCDebug(STATE) << "Replaced" << oldEvent->id() << "with" << newEvent.id();
     emit q->replacedEvent(ti.event(), std::to_address(oldEvent));
     return true;
@@ -3285,55 +3205,77 @@ Room::Change Room::Private::processStateEvent(const RoomEvent& curEvent,
 void Room::Private::processRedactionsAndEdits(RoomEvents &events)
 {
     using namespace std::ranges;
-    // Pre-process redactions and edits so that events that get
-    // redacted/replaced in the same batch landed in the timeline already
-    // treated.
-    // NB: We have to store redacting/replacing events to the timeline too -
-    // see #220.
-    for (auto it = events.begin(); it != events.end(); ++it) {
-        // Process redaction relations:
-        if (const auto *r = eventCast<RedactionEvent>(*it)) {
-            // Try to find the target in the timeline:
+    // Pre-process redactions and edits so that events that get redacted/replaced in the same batch
+    // landed in the timeline already treated.
+    // NB: We have to store redacting/replacing events to the timeline too - see #220.
+    for (auto &evt : events) {
+        if (const auto *r = eventCast<RedactionEvent>(evt)) {
+            // Try to find the target in the timeline
             if (processRedaction(*r))
                 continue;
-            // Otherwise, check this batch for the event:
+            // Otherwise, check this batch for the event
             if (auto targetIt = find(events, r->redactedEvent(), &RoomEvent::id);
                 targetIt != events.end())
-                *targetIt = makeRedacted(**targetIt, *r);
+                *targetIt = (*targetIt)->makeRedacted(*r);
             else
                 qCDebug(STATE) << "Redaction" << r->id() << "ignored: target event"
                                << r->redactedEvent() << "is not found";
-            // If the target event comes later, it comes already redacted.
+            // If the target event comes later, we expected it to come already redacted
+            continue;
+            // We don't expect redaction events to participate in edits, although The Spec doesn't
+            // say anything about it
         }
 
-        // Process replacement relations:
-        if (const auto *msg = eventCast<RoomMessageEvent>(*it); msg != nullptr) {
-            // Check the messages we received in the batch, to see if we have orphaned replacements that to edit it
-            if (const auto targetEventId = orphanedReplacementEvents.take(msg->id()); !targetEventId.isEmpty()) {
-                auto replacementIt = q->findInTimeline(targetEventId);
-                if (replacementIt != historyEdge()) {
-                    if (const auto *replacementMsg = eventCast<const RoomMessageEvent>(replacementIt->event()); replacementMsg != nullptr) {
-                        qCDebug(EVENTS) << "Found parent" << msg->id() << "for orphan replacement event" << replacementMsg->id();
-                        *it = makeReplaced(**it, *replacementMsg);
-                        continue;
-                    }
+        // Check if we have orphaned replacements for the event just received; if yes, edit it
+        if (const auto replacementEventId = orphanedReplacementEvents.take(evt->id());
+            !replacementEventId.isEmpty()) {
+            // Check the replacement validity (see
+            // https://spec.matrix.org/v1.17/client-server-api/#validity-of-replacement-events);
+            // if the replacement is invalid, the old event will remain intact and the replacement
+            // we now know is invalid will be hidden anyway
+            if (evt->isStateEvent()) [[unlikely]]
+                qDebug(EVENTS).noquote()
+                    << "Attempt to replace state event" << evt->id() << "- skipping";
+            else if (!evt->hasRelationship(EventRelation::ReplacementType)) [[unlikely]]
+                qDebug(EVENTS).noquote() << "Attempt to replace event" << evt->id()
+                                         << "that is itself a replacement - skipping";
+            else if (const auto replacementIt = q->findInTimeline(replacementEventId);
+                     replacementIt != historyEdge()) {
+                if (evt->metaType() != (*replacementIt)->metaType()) [[unlikely]]
+                    qCDebug(EVENTS).noquote()
+                        << "Attempt to replace" << evt->matrixType() << "with"
+                        << (*replacementIt)->matrixType() << "- skipping";
+                else if (evt->senderId() != (*replacementIt)->senderId()) [[unlikely]]
+                    qCDebug(EVENTS).noquote()
+                        << "Attempt to replace an event from" << evt->senderId()
+                        << "with one from" << (*replacementIt)->senderId() << "- skipping";
+                else {
+                    qCDebug(EVENTS) << "Found parent" << evt->id() << "for replacement event"
+                                    << (*replacementIt)->id();
+                    evt = evt->makeReplaced(**replacementIt);
                 }
             }
+            continue;
+        }
 
-            // Process the other replacements, which we hopefully have the target for
-            if (const auto replacedEvent = msg->replacedEvent(); !replacedEvent.isEmpty()) {
-                // Try to find the target in the timeline:
-                if (processReplacement(*msg))
+        if (!evt->isStateEvent()) {
+            // Check if the event is a replacement, which we hopefully have the target for; if we
+            // don't then we store it in orphaned replacements and postpone any action until
+            // the original event becomes known
+            if (const auto replacedEventId = evt->replacedEvent(); !replacedEventId.isEmpty()) {
+                // Try to find the target in the timeline
+                if (processReplacement(*evt))
                     continue;
-                // Otherwise, check this batch for the event:
-                if (auto targetIt = find(events.begin(), events.end(), msg->replacedEvent(), &RoomEvent::id);
+                // Otherwise, check the current batch for the event
+                if (auto targetIt = find(events, replacedEventId, &RoomEvent::id);
                     targetIt != events.end())
-                    *targetIt = makeReplaced(**targetIt, *msg);
-                else {
-                    // If not found right now, store it later to possibly find it later.
-                    qCDebug(EVENTS) << "Replacing event" << msg->id() << "ignored: target event"
-                                    << msg->replacedEvent() << "is not found, will check for the parent in later batches";
-                    orphanedReplacementEvents[msg->replacedEvent()] = msg->id();
+                    *targetIt = (*targetIt)->makeReplaced(*evt);
+                else if (evt->isStateEvent()){
+                    qCDebug(EVENTS)
+                        << "Replacing event" << evt->id() << "postponed: target event"
+                        << evt->replacedEvent()
+                        << "is not found, will check for it in older batches when they come";
+                    orphanedReplacementEvents[evt->replacedEvent()] = evt->id();
                 }
             }
         }

--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -199,6 +199,9 @@ public:
     /// A map from event/txn ids to information about the long operation;
     /// used for both download and upload operations
     QHash<QString, FileTransferPrivateInfo> fileTransfers;
+    /// A map of orphans of replacement events that are still looking for their related event in the past.
+    /// The key is the target event ID, and the value is the replacement event ID.
+    QHash<QString, QString> orphanedReplacementEvents;
 
     const RoomMessageEvent* getEventWithFile(const QString& eventId) const;
 
@@ -208,6 +211,7 @@ public:
                               const RoomEvent* curEvent);
     Change processStateEvent(const RoomEvent& curEvent,
                              const RoomEvent* oldEvent);
+    void processRedactionsAndEdits(RoomEvents &events);
 
     void insertMemberIntoMap(const QString& memberId);
     void removeMemberFromMap(const QString& memberId);
@@ -331,7 +335,7 @@ public:
     /*! Apply a new revision of the event to the timeline
      *
      * Tries to find an event in the timeline and replace it with the new
-     * content passed in \p newMessage.
+     * content passed in \p newEvent.
      * \return true if the event has been found and replaced; false otherwise
      */
     bool processReplacement(const RoomMessageEvent& newEvent);
@@ -2938,49 +2942,10 @@ Room::Changes Room::Private::addNewMessageEvents(RoomEvents&& events)
         return Change::None;
 
     decryptIncomingEvents(events);
+    processRedactionsAndEdits(events);
 
     QElapsedTimer et;
     et.start();
-
-    {
-        using namespace std::ranges;
-        // Pre-process redactions and edits so that events that get
-        // redacted/replaced in the same batch landed in the timeline already
-        // treated.
-        // NB: We have to store redacting/replacing events to the timeline too -
-        // see #220.
-        auto it = find_if(events, isEditing);
-        for (const auto& eptr : subrange(it, events.end())) {
-            if (auto* r = eventCast<RedactionEvent>(eptr)) {
-                // Try to find the target in the timeline, then in the batch.
-                if (processRedaction(*r))
-                    continue;
-                if (auto targetIt = find(events, r->redactedEvent(), &RoomEvent::id);
-                    targetIt != events.end())
-                    *targetIt = makeRedacted(**targetIt, *r);
-                else
-                    qCDebug(STATE)
-                        << "Redaction" << r->id() << "ignored: target event"
-                        << r->redactedEvent() << "is not found";
-                // If the target event comes later, it comes already redacted.
-            }
-            if (auto* msg = eventCast<RoomMessageEvent>(eptr);
-                    msg && !msg->replacedEvent().isEmpty()) {
-                if (processReplacement(*msg))
-                    continue;
-                if (auto targetIt = find(events.begin(), it, msg->replacedEvent(), &RoomEvent::id);
-                    targetIt != it)
-                    *targetIt = makeReplaced(**targetIt, *msg);
-                else // FIXME: hide the replacing event when target arrives later
-                    qCDebug(EVENTS)
-                        << "Replacing event" << msg->id()
-                        << "ignored: target event" << msg->replacedEvent()
-                        << "is not found";
-                // Same as with redactions above, the replaced event coming
-                // later will come already with the new content.
-            }
-        }
-    }
 
     // State changes arrive as a part of timeline; the current room state gets
     // updated before merging events to the timeline because that's what
@@ -3094,6 +3059,7 @@ std::pair<Room::Changes, Room::rev_iter_t> Room::Private::addHistoricalMessageEv
 
     const auto timelineSize = timeline.size();
     decryptIncomingEvents(events);
+    processRedactionsAndEdits(events);
 
     QElapsedTimer et;
     et.start();
@@ -3314,6 +3280,64 @@ Room::Change Room::Private::processStateEvent(const RoomEvent& curEvent,
             return Change::Other;
         },
         Change::Other);
+}
+
+void Room::Private::processRedactionsAndEdits(RoomEvents &events)
+{
+    using namespace std::ranges;
+    // Pre-process redactions and edits so that events that get
+    // redacted/replaced in the same batch landed in the timeline already
+    // treated.
+    // NB: We have to store redacting/replacing events to the timeline too -
+    // see #220.
+    for (auto it = events.begin(); it != events.end(); ++it) {
+        // Process redaction relations:
+        if (const auto *r = eventCast<RedactionEvent>(*it)) {
+            // Try to find the target in the timeline:
+            if (processRedaction(*r))
+                continue;
+            // Otherwise, check this batch for the event:
+            if (auto targetIt = find(events, r->redactedEvent(), &RoomEvent::id);
+                targetIt != events.end())
+                *targetIt = makeRedacted(**targetIt, *r);
+            else
+                qCDebug(STATE) << "Redaction" << r->id() << "ignored: target event"
+                               << r->redactedEvent() << "is not found";
+            // If the target event comes later, it comes already redacted.
+        }
+
+        // Process replacement relations:
+        if (const auto *msg = eventCast<RoomMessageEvent>(*it); msg != nullptr) {
+            // Check the messages we received in the batch, to see if we have orphaned replacements that to edit it
+            if (const auto targetEventId = orphanedReplacementEvents.take(msg->id()); !targetEventId.isEmpty()) {
+                auto replacementIt = q->findInTimeline(targetEventId);
+                if (replacementIt != historyEdge()) {
+                    if (const auto *replacementMsg = eventCast<const RoomMessageEvent>(replacementIt->event()); replacementMsg != nullptr) {
+                        qCDebug(EVENTS) << "Found parent" << msg->id() << "for orphan replacement event" << replacementMsg->id();
+                        *it = makeReplaced(**it, *replacementMsg);
+                        continue;
+                    }
+                }
+            }
+
+            // Process the other replacements, which we hopefully have the target for
+            if (const auto replacedEvent = msg->replacedEvent(); !replacedEvent.isEmpty()) {
+                // Try to find the target in the timeline:
+                if (processReplacement(*msg))
+                    continue;
+                // Otherwise, check this batch for the event:
+                if (auto targetIt = find(events.begin(), events.end(), msg->replacedEvent(), &RoomEvent::id);
+                    targetIt != events.end())
+                    *targetIt = makeReplaced(**targetIt, *msg);
+                else {
+                    // If not found right now, store it later to possibly find it later.
+                    qCDebug(EVENTS) << "Replacing event" << msg->id() << "ignored: target event"
+                                    << msg->replacedEvent() << "is not found, will check for the parent in later batches";
+                    orphanedReplacementEvents[msg->replacedEvent()] = msg->id();
+                }
+            }
+        }
+    }
 }
 
 Room::Changes Room::processEphemeralEvent(EventPtr&& event)


### PR DESCRIPTION
This has been a commonly seen bug in NeoChat (and other libQuotient-based clients) because we rightfully assume that the server will aggregate these events for us. It appears this theory doesn't actually hold in reality, and you will frequently see the original message despite it being edited when restarting the client and so on.

To fix this we need to tackle two problems: the first being that we didn't handle redactions/replacements at all when loading historical messages, and that was easy to fix. The second, harder issue is the order of these events coming in.

For example, lets imagine a room with an old message (not included in the first batch) and that was edited recently, so the replacement event predates its target. This creates an orphan that has to be handled when processing the next batch, otherwise the message will never be replaced properly.

I tested this with an initial batch that includes the message and its replacement, which displays properly even after restarting NeoChat. I also tried redacting an older message, and editing an older message - both also work great now.

Fixes #713