### PR TITLE
Make JoinRule enum scoped

### DIFF
--- a/Quotient/quotient_common.h
+++ b/Quotient/quotient_common.h
@@ -46,6 +46,7 @@
 namespace Quotient {
 Q_NAMESPACE_EXPORT(QUOTIENT_API)
 QML_ELEMENT
+Q_CLASSINFO("RegisterEnumClassesUnscoped", "false") // Prevent unscoped enums from overwriting each other
 
 //! \brief Enabling structure for conversion between a given enum and JSON
 //!
@@ -201,7 +202,7 @@ constexpr inline auto MegolmV1AesSha2AlgoKey = "m.megolm.v1.aes-sha2"_L1;
 QUO_META_ENUM(EncryptionType, EncryptionType::Undefined, MegolmV1AesSha2AlgoKey)
 
 //! Enum representing the available room join rules
-enum JoinRule : uint32_t {
+enum class JoinRule : uint32_t {
     Public,
     Knock,
     Invite,

--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -1616,7 +1616,7 @@ RoomStateView Room::currentState() const
 
 JoinRule Room::joinRule() const
 {
-    return currentState().queryOr(&JoinRulesEvent::joinRule, Public);
+    return currentState().queryOr(&JoinRulesEvent::joinRule, JoinRule::Public);
 }
 
 QList<QString> Room::allowIds() const
@@ -1634,12 +1634,13 @@ void Room::setJoinRule(JoinRule newRule, const QList<QString>& allowedRooms)
         return;
     }
 
-    JoinRule actualRule = (newRule == Restricted || newRule == KnockRestricted) && allowedRooms.isEmpty() ? Invite : newRule;
+    using enum JoinRule;
+    if ((newRule == Restricted || newRule == KnockRestricted) && allowedRooms.isEmpty())
+        newRule = Invite;
     QList<EventContent::AllowCondition> newAllow;
-    for (const auto& room :allowedRooms) {
+    for (const auto& room :allowedRooms)
         newAllow.append({room, "m.room_membership"_L1});
-    }
-    setState<JoinRulesEvent>(actualRule, newAllow);
+    setState<JoinRulesEvent>(newRule, newAllow);
     // Not emitting joinRuleChanged() here, since that would override the change
     // in the UI with the *current* value, which is not the *new* value.
 }


### PR DESCRIPTION
This fixes a nasty issue in the QML module, because this wasn't scoped it was only accessible at the name level (e.g. Quotient.Invite) There were various other issues because of the similar names between Membership and other enums, so I stuck RegisterEnumClassesUnscoped on the namespace too.

This does consitute an API change, but clients should be able to make this backwards-compatible with older libquotient versions.