### PR TITLE
Mark removeFromDirectChats as Q_INVOKABLE

### DIFF
--- a/Quotient/connection.h
+++ b/Quotient/connection.h
@@ -238,7 +238,7 @@ public:
     //! immediately, without waiting to complete synchronisation with
     //! the server.
     //! \sa directChatsListChanged
-    void removeFromDirectChats(const QString& roomId, const QString& userId = {});
+    Q_INVOKABLE void removeFromDirectChats(const QString& roomId, const QString& userId = {});
 
     //! Check whether the room id corresponds to a direct chat
     bool isDirectChat(const QString& roomId) const;


### PR DESCRIPTION
I needed to use this in NeoChat developer tools for a direct chat toggle, but it wasn't accessible under QML. (I didn't need its sibling addToDirectChats as I had other C++ logic to plug in.)