### PR TITLE
Change membersLeft from a QList to a QSet

### DIFF
--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -129,7 +129,7 @@ public:
     // For storing a list of current member names for the purpose of disambiguation.
     QMultiHash<QString, QString> memberNameMap;
     QStringList membersInvited;
-    QStringList membersLeft;
+    QSet<QString> membersLeft;
     QStringList membersTyping;
 
     QHash<QString, QSet<QString>> eventIdReadUsers;
@@ -3024,7 +3024,7 @@ void Room::Private::preprocessStateEvent(const RoomEvent& newEvent,
             case Membership::Leave:
                 if (rme.membership() == Membership::Invite
                     || rme.membership() == Membership::Join) {
-                    membersLeft.removeOne(rme.userId());
+                    membersLeft.remove(rme.userId());
                     Q_ASSERT(!membersLeft.contains(rme.userId()));
                 }
                 break;
@@ -3140,8 +3140,7 @@ Room::Change Room::Private::processStateEvent(const RoomEvent& curEvent,
             case Membership::Knock:
             case Membership::Ban:
             case Membership::Leave:
-                if (!membersLeft.contains(evt.userId()))
-                    membersLeft.append(evt.userId());
+                membersLeft.insert(evt.userId());
                 break;
             case Membership::Undefined:
                 qCWarning(MEMBERS) << "Ignored undefined membership type";
@@ -3406,7 +3405,7 @@ QString Room::Private::calculateDisplayname() const
         shortlist = buildShortlist(membersInvited);
 
     if (shortlist.front().isEmpty())
-        shortlist = buildShortlist(membersLeft);
+        shortlist = buildShortlist(membersLeft.values());
 
     QStringList names;
     for (const auto& u : shortlist) {


### PR DESCRIPTION
I noticed in a profiling flamegraph that this was an outsized part during preprocessStateEvent, because we kept calling removeOne which performs an expensive search. In a quick test on my account, the list was in the magnitudes of hundreds of items big. And then there could be multiple rooms like that...

Anyway this is an easy win for QSet, which has a faster lookup compared to QList.