### PR TITLE
Add markAsDirectChat, a simplified version of addToDirectChats

### DIFF
--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -3520,6 +3520,22 @@ void Room::activateEncryption()
     setState<EncryptionEvent>(EncryptionType::MegolmV1AesSha2);
 }
 
+void Room::markAsDirectChat()
+{
+    const auto ids = memberIds();
+    if (ids.size() != 2) {
+        qCWarning(MAIN) << "Calling Room::markAsDirectChat on room" << id()
+                << "with more than two members is unsupported.";
+        return;
+    }
+
+    // Find the non-you member in this room.
+    if (QUO_CHECK(ids.front() != ids.back()))
+        connection()->addToDirectChats(this, ids[ids.front() == connection()->userId() ? 1 : 0]);
+    else
+        qCritical(MAIN) << "Internal data corruption, the room includes two members with id" << ids.front();
+}
+
 void Room::addMegolmSessionFromBackup(const QByteArray& sessionId, const QByteArray& sessionKey, uint32_t index, const QByteArray& senderKey, const QByteArray& senderEdKey)
 {
     const auto sessionIt = d->groupSessions.find(sessionId);

--- a/Quotient/room.h
+++ b/Quotient/room.h
@@ -890,6 +890,17 @@ public Q_SLOTS:
      */
     void activateEncryption();
 
+    //! \brief Mark this room as a direct chat, guessing which user should be the DM recipient
+    //!
+    //! This function marks this room as a direct chat. There is no option to provide a user id here.
+    //! Emits the signal synchronously, without waiting to complete
+    //! synchronisation with the server.
+    //!
+    //! This function does nothing if you are the sole user, or there are more than two users in the room
+    //!
+    //! \sa directChatsListChanged
+    void markAsDirectChat();
+
 Q_SIGNALS:
     /// Initial set of state events has been loaded
     /**


### PR DESCRIPTION
I wanted to add a "simple" toggle to NeoChat developer tools, which would allow you to convert a DM-like room to a DM. Since we use QML it would preferable to have a nicer way to call addToDirectChats without knowing the other member's ID.

Currently this function is limited to rooms with only two members, and there is an early return that warns about this.