### PR TITLE
More scattered tweaks, fixes and cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ defaults:
 
 concurrency: quotient-ci
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   CI:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,23 +18,17 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        os: [ ubuntu-24.04 ]
+        os: [ ubuntu-24.04, macos-14, windows-latest ]
         qt-version: [ '6.8' ]
-        override-compiler: [ '', GCC ] # Defaults: MSVC on Windows, Clang elsewhere
+        override-compiler: [ '' ] # Defaults: MSVC on Windows, Clang elsewhere
         include: # Attach API updating and static analysis to specific jobs
         - os: ubuntu-24.04
           qt-version: '6.8'
           override-compiler: GCC
           update-api: update-api
           static-analysis: sonar # NB: to use sonar with Clang, replace gcov usage with lcov
-        - os: ubuntu-24.04
-          qt-version: '6.8'
-          override-compiler: ''
-          static-analysis: codeql
         - os: macos-14
-          qt-version: '6.8'
-        - os: windows-latest
-          qt-version: '6.8'
+          qt-version: '6.10'
 
     env:
       GCC_VERSION: -14
@@ -163,16 +157,6 @@ jobs:
              >>$GITHUB_ENV
         echo "QUOTEST_ORIGIN=$QUOTEST_ORIGIN with regenerated API files" >>$GITHUB_ENV
 
-    - name: Initialize CodeQL tools
-      if: matrix.static-analysis == 'codeql'
-      uses: github/codeql-action/init@v3
-      with:
-        languages: cpp
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
-
     - name: Build and install ECM
       run: |
         cd ..
@@ -216,10 +200,6 @@ jobs:
             LD_LIBRARY_PATH=$LIB_PATH \
             quotest "$TEST_USER" "$TEST_PWD" quotest-gha '#quotest:matrix.org' "$QUOTEST_ORIGIN"
       timeout-minutes: 4 # quotest is supposed to finish within 3 minutes, actually
-
-    - name: Perform CodeQL analysis
-      if: matrix.static-analysis == 'codeql'
-      uses: github/codeql-action/analyze@v3
 
     - name: Prepare coverage files for Sonar analysis
       if: matrix.static-analysis == 'sonar'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,9 +217,9 @@ jobs:
 
     - name: Run sonar-scanner
       if: matrix.static-analysis == 'sonar'
+      continue-on-error: true
       uses: SonarSource/sonarqube-scan-action@v6
       env:
-        # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       with:
         args: >

--- a/Quotient/events/roomevent.h
+++ b/Quotient/events/roomevent.h
@@ -159,7 +159,7 @@ public:
 
     //! \brief Make a replaced event
     //!
-    //! \returns a clone of `*this` with content taken from \p replacement as described in
+    //! \returns a clone of `*this` with content taken from \p replacementEvent as described in
     //!          https://spec.matrix.org/latest/client-server-api/#applying-mnew_content
     //! \note Disposal of the original event after that is on the caller.
     event_ptr_tt<RoomEvent> makeReplaced(const RoomEvent &replacementEvent) const;

--- a/Quotient/keyverificationsession.cpp
+++ b/Quotient/keyverificationsession.cpp
@@ -224,12 +224,15 @@ using EmojiStore = QVector<EmojiStoreEntry>;
 EmojiStore loadEmojiStore()
 {
     Q_INIT_RESOURCE(libquotientemojis);
-    QFile dataFile(":/sas-emoji.json"_L1);
-    dataFile.open(QFile::ReadOnly);
-    auto data = dataFile.readAll();
-    Q_CLEANUP_RESOURCE(libquotientemojis);
-    return fromJson<EmojiStore>(
-        QJsonDocument::fromJson(data).array());
+    if (QFile dataFile(":/sas-emoji.json"_L1); dataFile.open(QFile::ReadOnly)) {
+        auto data = dataFile.readAll();
+        Q_CLEANUP_RESOURCE(libquotientemojis);
+        return fromJson<EmojiStore>(QJsonDocument::fromJson(data).array());
+    } else {
+        qCritical(MAIN)
+            << "Could not open the file with SAS emoji definitions; key verification will not work";
+        return {};
+    }
 }
 
 EmojiEntry emojiForCode(int code, const QString& language)

--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -2784,19 +2784,6 @@ void Room::Private::addRelation(const ReactionEvent& reactionEvt)
         emit q->updatedEvent(content.eventId);
 }
 
-namespace {
-/// Whether the event is a redaction or a replacement
-inline bool isEditing(const RoomEventPtr& ep)
-{
-    return QUO_CHECK(ep != nullptr)
-           && ep->switchOnType([](const RedactionEvent&) { return true; },
-                               [](const RoomMessageEvent& rme) {
-                                   return !rme.replacedEvent().isEmpty();
-                               },
-                               false);
-}
-}
-
 Room::Timeline::size_type Room::Private::mergePendingEvent(PendingEvents::iterator localEchoIt,
                                                            RoomEvents::iterator remoteEchoIt)
 {

--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -3232,7 +3232,7 @@ void Room::Private::processRedactionsAndEdits(RoomEvents &events)
                 if (auto targetIt = find(events, replacedEventId, &RoomEvent::id);
                     targetIt != events.end())
                     *targetIt = (*targetIt)->makeReplaced(*evt);
-                else if (evt->isStateEvent()){
+                else {
                     qCDebug(EVENTS)
                         << "Replacing event" << evt->id() << "postponed: target event"
                         << evt->replacedEvent()

--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -2254,44 +2254,42 @@ QString Room::Private::doPostFile(event_ptr_tt<RoomMessageEvent> fileEvent, cons
     // Remote URL will only be known after upload; fill in the local path
     // to enable the preview while the event is pending.
     q->uploadFile(txnId, localUrl);
-    // Below, the upload job is used as a context object to clean up connections
-    const auto& transferJob = fileTransfers.value(txnId).job;
-    connect(q, &Room::fileTransferCompleted, transferJob,
-        [this, txnId](const QString& tId, const QUrl&,
-                      const FileSourceInfo& fileMetadata) {
+    if (const auto& transferJob = fileTransfers.value(txnId).job) {
+        // Below, the upload job is used as a context object to clean up connections
+        connect(q, &Room::fileTransferCompleted, transferJob,
+                [this, txnId](const QString& tId, const QUrl&, const FileSourceInfo& fileMetadata) {
+                    if (tId != txnId)
+                        return;
+
+                    const auto it = q->findPendingEvent(txnId);
+                    if (it != unsyncedEvents.end()) {
+                        it->setFileUploaded(fileMetadata);
+                        emit q->pendingEventChanged(int(it - unsyncedEvents.begin()));
+                        doSendEvent(it);
+                    } else {
+                        // Normally in this situation we should instruct
+                        // the media server to delete the file; alas, there's no
+                        // API specced for that.
+                        qCWarning(MAIN) << "File uploaded to" << getUrlFromSourceInfo(fileMetadata)
+                                        << "but the event referring to it was "
+                                           "cancelled";
+                    }
+                });
+        connect(q, &Room::fileTransferFailed, transferJob, [this, txnId](const QString& tId) {
             if (tId != txnId)
                 return;
 
             const auto it = q->findPendingEvent(txnId);
-            if (it != unsyncedEvents.end()) {
-                it->setFileUploaded(fileMetadata);
-                emit q->pendingEventChanged(int(it - unsyncedEvents.begin()));
-                doSendEvent(it);
-            } else {
-                // Normally in this situation we should instruct
-                // the media server to delete the file; alas, there's no
-                // API specced for that.
-                qCWarning(MAIN)
-                    << "File uploaded to" << getUrlFromSourceInfo(fileMetadata)
-                    << "but the event referring to it was "
-                       "cancelled";
-            }
+            if (it == unsyncedEvents.end())
+                return;
+
+            const auto idx = int(it - unsyncedEvents.begin());
+            emit q->pendingEventAboutToDiscard(idx);
+            // See #286 on why `it` may not be valid here.
+            unsyncedEvents.erase(unsyncedEvents.begin() + idx);
+            emit q->pendingEventDiscarded();
         });
-    connect(q, &Room::fileTransferFailed, transferJob,
-            [this, txnId](const QString& tId) {
-                if (tId != txnId)
-                    return;
-
-                const auto it = q->findPendingEvent(txnId);
-                if (it == unsyncedEvents.end())
-                    return;
-
-                const auto idx = int(it - unsyncedEvents.begin());
-                emit q->pendingEventAboutToDiscard(idx);
-                // See #286 on why `it` may not be valid here.
-                unsyncedEvents.erase(unsyncedEvents.begin() + idx);
-                emit q->pendingEventDiscarded();
-            });
+    }
 
     return txnId;
 }
@@ -2504,16 +2502,24 @@ void Room::uploadFile(const QString& id, const QUrl& localFilename,
     // This is required because toLocalFile doesn't work on android and toString doesn't work on the desktop
     auto fileName = localFilename.isLocalFile() ? localFilename.toLocalFile() : localFilename.toString();
     FileSourceInfo fileMetadata;
+    // NB: tempFile needs to live at least until Connection::uploadFile() opens it
     QTemporaryFile tempFile;
     if (usesEncryption()) {
-        tempFile.open();
-        QFile file(fileName);
-        file.open(QFile::ReadOnly);
-        QByteArray data;
-        std::tie(fileMetadata, data) = encryptFile(file.readAll());
-        tempFile.write(data);
-        tempFile.close();
-        fileName = QFileInfo(tempFile).absoluteFilePath();
+        if (tempFile.open()) {
+            if (QFile file(fileName); file.open(QFile::ReadOnly)) {
+                QByteArray data;
+                std::tie(fileMetadata, data) = encryptFile(file.readAll());
+                tempFile.write(data);
+                fileName = QFileInfo(tempFile).absoluteFilePath();
+            } else
+                d->failedTransfer(id, u"Could not open a temporary file for encryption"_s);
+
+            tempFile.close();
+        } else
+            d->failedTransfer(id, u"Could not open the file for uploading"_s);
+
+        if (d->fileTransfers.value(id).status == FileTransferInfo::Failed)
+            return;
     }
     auto job = connection()->uploadFile(fileName, overrideContentType);
     if (isJobPending(job)) {

--- a/Quotient/thread.cpp
+++ b/Quotient/thread.cpp
@@ -27,7 +27,8 @@ ThreadInfos::UpdateResult ThreadInfos::updateFrom(const TimelineItem &eventItem)
     }
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
-    auto [threadIt, isNew] = tryEmplace(threadRootId, event.id());
+    // Could be tryEmplace() but current Xcode cannot initialise aggregates in it :(
+    auto [threadIt, isNew] = tryInsert(threadRootId, {event.id()});
 #else
     auto threadIt = base_type::find(threadRootId); // base_type:: to use non-const find()
     const auto isNew = threadIt == end();

--- a/autotests/testcrosssigning.cpp
+++ b/autotests/testcrosssigning.cpp
@@ -20,7 +20,7 @@ private Q_SLOTS:
         path = path.left(path.lastIndexOf(QDir::separator()));
         path += "/cross_signing_data.json"_L1;
         QFile file(path);
-        file.open(QIODevice::ReadOnly);
+        QVERIFY(file.open(QIODevice::ReadOnly));
         auto data = file.readAll();
         QVERIFY(!data.isEmpty());
         auto jobMock = Mocked<QueryKeysJob>(QHash<QString, QStringList>{});

--- a/autotests/testkeyimport.cpp
+++ b/autotests/testkeyimport.cpp
@@ -25,7 +25,7 @@ void TestKeyImport::testImport()
     path = path.left(path.lastIndexOf(QDir::separator()));
     path += "/key-export.data"_L1;
     QFile file(path);
-    file.open(QIODevice::ReadOnly);
+    QVERIFY(file.open(QIODevice::ReadOnly));
     auto data = file.readAll();
     QVERIFY(!data.isEmpty());
     const auto result = keyImport.decrypt(QString::fromUtf8(data), u"123passphrase"_s);

--- a/autotests/testutils.h
+++ b/autotests/testutils.h
@@ -17,11 +17,10 @@ template<EventClass EventT>
 inline event_ptr_tt<EventT> loadEventFromFile(const QString &eventFileName)
 {
     if (!eventFileName.isEmpty()) {
-        QFile testEventFile;
-        testEventFile.setFileName(QLatin1StringView(DATA_DIR) + u'/' + eventFileName);
-        return testEventFile.open(QIODevice::ReadOnly)
-                   ? loadEvent<EventT>(QJsonDocument::fromJson(testEventFile.readAll()).object())
-                   : nullptr;
+        if (QFile testEventFile(QStringLiteral(DATA_DIR "/") + eventFileName);
+            testEventFile.open(QIODevice::ReadOnly)) {
+            return loadEvent<EventT>(QJsonDocument::fromJson(testEventFile.readAll()).object());
+        }
     }
     return nullptr;
 }


### PR DESCRIPTION
The only functional fix is in 0e761a4875cc4f866f6255176a02a24b2484f195 - please double-check the code around it, as we don't have tests for this case (yet; maybe I will get AI come up with something ingenious). The rest is plugging warnings from the build, or (in case of 5bc478ff53ead8ae4e25d73a4e9cbbbebd4ed9d9) from CI - GHA deprecated another CodeQL API version, and I found out that they now have the no-build CodeQL configuration that can be run in an entirely separate workflow.