### PR TITLE
Install libQuotient without stripping its RUNPATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,7 @@ set(${PROJECT_NAME}_INSTALL_INCLUDEDIR
 # Instruct CMake to run moc automatically when needed.
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 find_package(${Qt} ${QtMinVersion} REQUIRED Core Network Gui Test Sql Qml)
 get_filename_component(Qt_Prefix "${${Qt}_DIR}/../../../.." ABSOLUTE)


### PR DESCRIPTION
This fixes a problem: KDE with custom Qt of a higher version than system Qt. The libQuotient build system finds and builds against that Qt version, but the RUNPATH is stripped when installing the library, so the dynamic linker will try to link it against distro Qt, which is incompatible -> the application using libQuotient fails to start.