### PR TITLE
Fix null event ending up in Thread::addEvent

### DIFF
--- a/Quotient/room.cpp
+++ b/Quotient/room.cpp
@@ -1865,8 +1865,10 @@ void Room::Private::updateThread(const RoomEvent* event)
         thread.threadRootId = rme->threadRootEventId();
         // If we can't find the root we assume it's a historical event and will be loaded later.
         if (auto rootIt = q->findInTimeline(thread.threadRootId); rootIt != historyEdge()) {
-            thread.addEvent(rootIt->viewAs<RoomMessageEvent>(), true,
-                            (*rootIt)->senderId() == connection->userId());
+            if (auto* messageEvent = rootIt->viewAs<RoomMessageEvent>()) {
+                thread.addEvent(messageEvent, true,
+                                (*rootIt)->senderId() == connection->userId());
+            }
         }
     }
 


### PR DESCRIPTION
This can happen if we chance come upon an event that can't be viewed as a RoomMessageEvent. Other call-sites of viewAs also check if null, but this one didn't.

Fixes a crash seen in NeoChat 26.04 when running against libQuotient 0.9.x.

```
0x00007ffff3e65e02 in QJsonObject::value(QLatin1String) const () from /usr/lib/x86_64-linux-gnu/libQt6Core.so.6
(gdb) bt
#0  0x00007ffff3e65e02 in QJsonObject::value(QLatin1String) const () at /usr/lib/x86_64-linux-gnu/libQt6Core.so.6
#1  0x0000555555bcb148 in QJsonObject::operator[] (this=<optimized out>, key=...)
    at /usr/include/QtCore/qjsonobject.h:75
#2  Quotient::Event::contentJson (this=this@entry=0xed395177f5e6d000)
    at /run/build/libquotient/Quotient/events/event.cpp:53
#3  0x0000555555bd4339 in Quotient::Event::contentPart<std::optional<Quotient::EventRelation>, QLatin1String const&> (this=0xed395177f5e6d000, key=...) at /run/build/libquotient/Quotient/events/event.h:308
#4  Quotient::RoomMessageEvent::relatesTo (this=this@entry=0x0)
    at /run/build/libquotient/Quotient/events/roommessageevent.cpp:254
#5  0x0000555555bd54eb in Quotient::RoomMessageEvent::threadRootEventId (this=this@entry=0x0)
    at /run/build/libquotient/Quotient/events/roommessageevent.cpp:314
#6  0x0000555555c5a20a in Quotient::Thread::addEvent
    (this=this@entry=0x555569452808, event=0x0, isLatest=isLatest@entry=true, isLocalUser=true)
    at /run/build/libquotient/Quotient/thread.cpp:14
#7  0x0000555555b64aae in Quotient::Room::Private::updateThread
    (this=this@entry=0x5555686efd00, event=0x555567541460) at /run/build/libquotient/Quotient/room.cpp:1868
#8  0x0000555555b703ef in Quotient::Room::Private::moveEventsToTimeline
    (this=this@entry=0x5555686efd00, events=..., placement=placement@entry=Newer)
    at /usr/include/c++/15.2.0/bits/unique_ptr.h:193
#9  0x0000555555b72d22 in Quotient::Room::Private::addNewMessageEvents (this=this@entry=0x5555686efd00, events=...)
    at /run/build/libquotient/Quotient/room.cpp:2895
#10 0x0000555555b73e75 in Quotient::Room::Private::addNewMessageEvents (this=0x5555686efd00, events=...)
    at /run/build/libquotient/Quotient/room.cpp:2868
#11 Quotient::Room::updateData (this=0x5555686efc00, data=..., fromCache=false)
    at /run/build/libquotient/Quotient/room.cpp:1985
#12 0x00007ffff3e0afbc in QObject::event(QEvent*) () at /usr/lib/x86_64-linux-gnu/libQt6Core.so.6
#13 0x00007ffff59a6fdf in QApplicationPrivate::notify_helper(QObject*, QEvent*) ()
    at /usr/lib/x86_64-linux-gnu/libQt6Widgets.so.6
#14 0x00007ffff3dadde8 in QCoreApplication::notifyInternal2(QObject*, QEvent*) ()
    at /usr/lib/x86_64-linux-gnu/libQt6Core.so.6
#15 0x00007ffff3db19d9 in QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) ()
    at /usr/lib/x86_64-linux-gnu/libQt6Core.so.6
#16 0x00007ffff40e70ef in ??? () at /usr/lib/x86_64-linux-gnu/libQt6Core.so.6
#17 0x00007ffff3b0e18e in g_main_dispatch () at /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0
#18 0x00007ffff3b0f1bf in g_main_context_iterate_unlocked.isra () at /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0
#19 0x00007ffff3b0f323 in g_main_context_iteration () at /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0
#20 0x00007ffff40e692d in QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) ()
    at /usr/lib/x86_64-linux-gnu/libQt6Core.so.6
--Type <RET> for more, q to quit, c to continue without paging--c
#21 0x00007ffff3dbade3 in QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) ()
    at /usr/lib/x86_64-linux-gnu/libQt6Core.so.6
#22 0x00007ffff3db66a9 in QCoreApplication::exec() () at /usr/lib/x86_64-linux-gnu/libQt6Core.so.6
#23 0x00005555556da077 in main (argc=<optimized out>, argv=<optimized out>)
    at /run/build/neochat/src/app/main.cpp:300
```