### PR TITLE
Don't try to migrate quotient's legacy crypto database when we already have a rust-sdk crypto db

### DIFF
--- a/Quotient/connection.cpp
+++ b/Quotient/connection.cpp
@@ -370,6 +370,11 @@ void Connection::Private::setupCryptoMachine(const QByteArray& picklingKey)
     mxIdForDb.replace(u':', u'_');
     const QString databaseFolder{ QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) % u'/' % mxIdForDb };
     const QString legacyDatabaseFile{ databaseFolder + "/quotient_%1.db3"_L1.arg(q->deviceId()) };
+    const auto hasVodozemacDatabase = QDir().exists(databaseFolder + u'/' + q->deviceId());
+    if (hasVodozemacDatabase && QFile::exists(legacyDatabaseFile)) {
+        qCDebug(E2EE) << "Removing legacy database as new database already exists";
+        QFile(legacyDatabaseFile).remove();
+    }
 
     QString accountPickle;
     const auto hasDb = QFileInfo(legacyDatabaseFile).exists();


### PR DESCRIPTION
This can happen e.g. when the user temporarily starts a version of a client that still uses legacy crypto, since libquotient will just create a new database. The rust part will then crash as it can't deal with loading the old data in the existing database