### PR TITLE
Use is_cross_signing_trusted instead of is_verified

### DIFF
--- a/Quotient/crypto-sdk/src/cryptomachine.rs
+++ b/Quotient/crypto-sdk/src/cryptomachine.rs
@@ -2063,7 +2063,7 @@ impl CryptoMachine {
                 .get_device(&user_id, &device_id, None)
                 .await?
                 .ok_or("Unknown device")?
-                .is_verified())
+                .is_cross_signing_trusted())
         });
         result.unwrap_or_else(|error| {
             error!("Failed to process is_verified_device: {:?}", error);


### PR DESCRIPTION
This matches the behavior of our previous crypto backend more closely, as our own session is locally trusted and thus marks an otherwise ordinary unverified session incorrectly.