### PR TITLE
Add a way to set an additional suffix for keychain entries

### DIFF
--- a/Quotient/connection.cpp
+++ b/Quotient/connection.cpp
@@ -248,15 +248,17 @@ bool Connection::capabilitiesReady() const
 
 QStringList Connection::supportedMatrixSpecVersions() const { return d->data->homeserverData().supportedSpecVersions; }
 
-namespace {
-QFuture<QKeychain::Job*> runKeychainJob(QKeychain::Job* j, const QString& keychainId)
+QFuture<QKeychain::Job*> Connection::Private::runKeychainJob(QKeychain::Job* j, const QString& keychainId) const
 {
     j->setAutoDelete(true);
-    j->setKey(keychainId);
+    if (!keychainSuffix.isEmpty()) {
+        j->setKey(keychainId + "-"_L1 + keychainSuffix);
+    } else {
+        j->setKey(keychainId);
+    }
     auto ft = QtFuture::connect(j, &QKeychain::Job::finished);
     j->start();
     return ft;
-}
 }
 
 void Connection::Private::saveAccessTokenToKeychain() const
@@ -1013,6 +1015,11 @@ QFuture<Room *> Connection::waitForNewRoom(const QString &roomId)
         return false;
     });
     return ft;
+}
+
+void Connection::setKeychainSuffix(const QString &suffix)
+{
+    d->keychainSuffix = suffix;
 }
 
 JobHandle<LeaveRoomJob> Connection::leaveRoom(Room* room)

--- a/Quotient/connection.h
+++ b/Quotient/connection.h
@@ -635,6 +635,16 @@ public:
 
     Q_INVOKABLE QFuture<Room *> waitForNewRoom(const QString &roomId);
 
+    //! \brief Sets an additional suffix for keychain entries.
+    //!
+    //! This is useful for platforms that may share the same keychain but not config folders.
+    //! For example, Flatpaks and system packages where the keychain entries from libQuotient can
+    //! conflict.
+    //!
+    //! This identifier is appended to entries in the keychain, for example "@userid:domain" becomes "@userid:domain-suffix".
+    //! The dash is added automatically.
+    void setKeychainSuffix(const QString &suffix);
+
 public Q_SLOTS:
     //! \brief Log in using a username and password pair
     //!

--- a/Quotient/connection_p.h
+++ b/Quotient/connection_p.h
@@ -23,6 +23,10 @@
 #include <QtCore/QCoreApplication>
 #include <QtCore/QQueue>
 
+namespace QKeychain {
+class Job;
+}
+
 namespace Quotient {
 
 class Q_DECL_HIDDEN Quotient::Connection::Private {
@@ -93,6 +97,8 @@ public:
     bool isHandlingOutgoing = false;
 
     unsigned int lastScheduledRequest = 0;
+
+    QString keychainSuffix;
 
     //! \brief Check the homeserver and resolve it if needed, before connecting
     //!
@@ -188,5 +194,7 @@ public:
     void setupCryptoMachine(const QByteArray& picklingKey);
     void runShareKey(Room* room, std::function<void()>);
     void startKeyShare();
+
+    QFuture<QKeychain::Job*> runKeychainJob(QKeychain::Job* j, const QString& keychainId) const;
 };
 } // namespace Quotient


### PR DESCRIPTION
In NeoChat we discovered that the access tokens and other data stored in the keychain weren't segmented. Due to reasons, the keychain for native packages and Flatpaks can be the same which presents a problem because config files (which store which accounts are loaded) aren't shared.

What happens is that if you log in with the Flatpak version, it overwrites and makes the native package unusable.