### PR TITLE
Fix crash when crypto machine fails to init

### DIFF
--- a/Quotient/crypto-sdk/src/cryptomachine.rs
+++ b/Quotient/crypto-sdk/src/cryptomachine.rs
@@ -69,11 +69,9 @@ pub(crate) struct CryptoMachine {
 impl Drop for CryptoMachine {
     fn drop(&mut self) {
         self.runtime.block_on(async {
-            let machine = self
-                .machine
-                .take()
-                .expect("CryptoMachine should not be destroyed more than once");
-            drop(ManuallyDrop::into_inner(machine));
+            if let Some(machine) = self.machine.take() {
+                drop(ManuallyDrop::into_inner(machine));
+            }
         })
     }
 }


### PR DESCRIPTION
If the crypto machine doesn't init, we want to exit cleanly. When shutting down, the CryptoMachine tries destroying its OlmMachine even when it's not there. That explodes.