### PR TITLE
Fix sending /.well-known/support requests

### DIFF
--- a/Quotient/csapi/support.cpp
+++ b/Quotient/csapi/support.cpp
@@ -12,4 +12,6 @@ QUrl GetWellknownSupportJob::makeRequestUrl(const HomeserverData& hsData)
 GetWellknownSupportJob::GetWellknownSupportJob()
     : BaseJob(HttpVerb::Get, u"GetWellknownSupportJob"_s,
               makePath("/.well-known", "/matrix/support"), false)
-{}
+{
+    setSendToServerName(true);
+}

--- a/Quotient/jobs/basejob.cpp
+++ b/Quotient/jobs/basejob.cpp
@@ -110,6 +110,7 @@ public:
     QUrlQuery requestQuery;
     RequestData requestData;
     bool needsToken;
+    bool sendToServerName = false;
 
     bool inBackground = false;
 
@@ -278,7 +279,12 @@ QUrl BaseJob::makeRequestUrl(const HomeserverData& hsData, const QByteArray& enc
 
 QNetworkRequest BaseJob::Private::prepareRequest() const
 {
-    QNetworkRequest req{ makeRequestUrl(connection->homeserverData(), apiEndpoint, requestQuery) };
+    auto homeserverData = connection->homeserverData();
+    if (sendToServerName) {
+        homeserverData.baseUrl = QUrl(u"https://" + connection->userId().split(u":"_s)[1]);
+    }
+
+    QNetworkRequest req{ makeRequestUrl(homeserverData, apiEndpoint, requestQuery) };
     if (!requestHeaders.contains("Content-Type"))
         req.setHeader(QNetworkRequest::ContentTypeHeader, "application/json"_L1);
     if (needsToken)
@@ -832,4 +838,9 @@ QFuture<void> BaseJob::future()
 
     d->futureGenerated = true;
     return d->promise.future();
+}
+
+void BaseJob::setSendToServerName(bool send)
+{
+    d->sendToServerName = send;
 }

--- a/Quotient/jobs/basejob.cpp
+++ b/Quotient/jobs/basejob.cpp
@@ -281,7 +281,7 @@ QNetworkRequest BaseJob::Private::prepareRequest() const
 {
     auto homeserverData = connection->homeserverData();
     if (sendToServerName) {
-        homeserverData.baseUrl = QUrl(u"https://" + connection->userId().split(u":"_s)[1]);
+        homeserverData.baseUrl = QUrl(u"https://"_s + connection->userId().split(u":"_s)[1]);
     }
 
     QNetworkRequest req{ makeRequestUrl(homeserverData, apiEndpoint, requestQuery) };

--- a/Quotient/jobs/basejob.h
+++ b/Quotient/jobs/basejob.h
@@ -342,6 +342,7 @@ protected:
     QStringList expectedKeys() const;
     void addExpectedKey(QString key);
     void setExpectedKeys(const QStringList& keys);
+    void setSendToServerName(bool send);
 
     const QNetworkReply* reply() const;
     QNetworkReply* reply();


### PR DESCRIPTION
These requests should go to the server name (e.g., kde.org), not its base url (e.g., kde.modular.im).

I mostly hate this patch, it's quite hacky and overwrites the generated files. But I'm not sure what a nicer fix would be...